### PR TITLE
fix(runner): stop taking a screenshot from starting a runner that cannot take one

### DIFF
--- a/.changeset/clever-runners-refuse.md
+++ b/.changeset/clever-runners-refuse.md
@@ -4,6 +4,6 @@
 
 `qawolf runner screenshot` asks for a runner that already has a screen instead of starting one, and `qawolf runner exec` names the missing page rather than the runner's image.
 
-A runner's virtual desktop starts with its first run, so a runner launched to serve a screenshot would have no screen and could only answer `screen-not-ready`. `screenshot` refuses instead, and names both things it needs: a runner, and a run on it. That also keeps the group readable, because no `read` command starts a runner.
+A runner's virtual desktop starts with its first run, so a runner launched to serve a screenshot would have no screen and could only answer `screen-needs-a-run`. `screenshot` refuses instead, and names both things it needs: a runner, and a run on it. That also keeps the group readable, because no `read` command starts a runner.
 
 A `node20WithPlaywright` runner with no live page does run a browser and simply has nothing open on it yet, so `qawolf runner exec` points at the page rather than at the runner's image. Checking the image stays as the secondary possibility, since it is the case that never clears.

--- a/.changeset/clever-runners-refuse.md
+++ b/.changeset/clever-runners-refuse.md
@@ -2,8 +2,8 @@
 "@qawolf/cli": patch
 ---
 
-`qawolf runner screenshot` no longer launches a runner when none is available, and `qawolf runner exec` no longer blames the wrong thing when there is no page yet.
+`qawolf runner screenshot` asks for a runner that already has a screen instead of starting one, and `qawolf runner exec` names the missing page rather than the runner's image.
 
-A runner's virtual desktop starts with its first run, so a runner launched to serve a screenshot had no screen and the command reliably answered `screen-not-ready`: a billed pod in exchange for an error. It now says what to do instead, which is to launch a runner and open a page on it. This also makes one rule true across the group: no `read` command starts a runner, so only `run`, `act` and `exec` ever do.
+A runner's virtual desktop starts with its first run, so a runner launched to serve a screenshot would have no screen and could only answer `screen-not-ready`. `screenshot` refuses instead, and names both things it needs: a runner, and a run on it. That also keeps the group readable, because no `read` command starts a runner.
 
-`qawolf runner exec` against a runner with no live page used to suggest checking whether the runner runs a browser at all. On a freshly launched `node20WithPlaywright` runner that is the wrong thing to check, since it does run one and simply has no page open yet; the message now says to run a flow on it or navigate it first, and keeps the never-clears case as the secondary possibility.
+A `node20WithPlaywright` runner with no live page does run a browser and simply has nothing open on it yet, so `qawolf runner exec` points at the page rather than at the runner's image. Checking the image stays as the secondary possibility, since it is the case that never clears.

--- a/.changeset/clever-runners-refuse.md
+++ b/.changeset/clever-runners-refuse.md
@@ -1,0 +1,9 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf runner screenshot` no longer launches a runner when none is available, and `qawolf runner exec` no longer blames the wrong thing when there is no page yet.
+
+A runner's virtual desktop starts with its first run, so a runner launched to serve a screenshot had no screen and the command reliably answered `screen-not-ready`: a billed pod in exchange for an error. It now says what to do instead, which is to launch a runner and open a page on it. This also makes one rule true across the group: no `read` command starts a runner, so only `run`, `act` and `exec` ever do.
+
+`qawolf runner exec` against a runner with no live page used to suggest checking whether the runner runs a browser at all. On a freshly launched `node20WithPlaywright` runner that is the wrong thing to check, since it does run one and simply has no page open yet; the message now says to run a flow on it or navigate it first, and keeps the never-clears case as the secondary possibility.

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -1,6 +1,9 @@
 import { formatSeconds } from "~/core/formatSeconds.js";
 import { pluralize } from "~/core/pluralize.js";
 
+const noRunnerId =
+  "No runner id. Pass --runner, set QAWOLF_RUNNER_ID, or run qawolf runner launch first.";
+
 export const interactiveRunnerMessages = {
   actionFailed: (errorMessage: string) =>
     `The action reached the runner and did not take effect: ${errorMessage}`,
@@ -47,10 +50,8 @@ export const interactiveRunnerMessages = {
     `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and stop the runner with qawolf runner stop --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
-  noRunnerIdForScreenshot:
-    "No runner id. Pass --runner, set QAWOLF_RUNNER_ID, or launch one with qawolf runner launch. A screenshot needs a page as well as a runner: a freshly launched runner has no screen until something opens one, so navigate it or run a flow on it first.",
-  noRunnerId:
-    "No runner id. Pass --runner, set QAWOLF_RUNNER_ID, or run qawolf runner launch first.",
+  noRunnerIdForScreenshot: `${noRunnerId} A screenshot also needs a screen, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
+  noRunnerId,
   notRunning: (id: string) => `Runner ${id} was not running.`,
   runFailed: (errorMessage: string | undefined) =>
     errorMessage === undefined
@@ -65,7 +66,7 @@ export const interactiveRunnerMessages = {
   runnerHasNoScreen:
     "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a node20WithPlaywright runner instead.",
   runnerHasNoScreenToEvaluate:
-    "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until something opens one, so run a flow on it or navigate it first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
+    "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until a run opens one, so run a flow on it with qawolf runner run first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
   runnerUnreachable:
     "The runner could not be reached. It may still be starting, or it may have terminated after inactivity. Retry, or launch it again.",
   screenNeedsARun:

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -47,6 +47,8 @@ export const interactiveRunnerMessages = {
     `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and stop the runner with qawolf runner stop --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
+  noRunnerIdForScreenshot:
+    "No runner id. Pass --runner, set QAWOLF_RUNNER_ID, or launch one with qawolf runner launch. A screenshot needs a page as well as a runner: a freshly launched runner has no screen until something opens one, so navigate it or run a flow on it first.",
   noRunnerId:
     "No runner id. Pass --runner, set QAWOLF_RUNNER_ID, or run qawolf runner launch first.",
   notRunning: (id: string) => `Runner ${id} was not running.`,
@@ -63,7 +65,7 @@ export const interactiveRunnerMessages = {
   runnerHasNoScreen:
     "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a node20WithPlaywright runner instead.",
   runnerHasNoScreenToEvaluate:
-    "The runner could not evaluate the snippet. As well as a runner that is still starting or busy, this covers one with no live page to evaluate against, which will never clear: check that the runner you launched runs a browser. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
+    "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until something opens one, so run a flow on it or navigate it first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
   runnerUnreachable:
     "The runner could not be reached. It may still be starting, or it may have terminated after inactivity. Retry, or launch it again.",
   screenNeedsARun:

--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -210,6 +210,9 @@ describe("handleRunnerExec", () => {
     );
 
     expect(result?.error).toContain("no live page");
+    // A fresh node20WithPlaywright runner does run a browser, so telling the
+    // caller to check the image would send them after the wrong thing.
+    expect(result?.error).toContain("run a flow on it or navigate it first");
     expect(result?.error).toContain("not proof the snippet did not run");
     expect(result?.exitCode).toBe(4);
   });

--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -212,7 +212,7 @@ describe("handleRunnerExec", () => {
     expect(result?.error).toContain("no live page");
     // A fresh node20WithPlaywright runner does run a browser, so telling the
     // caller to check the image would send them after the wrong thing.
-    expect(result?.error).toContain("run a flow on it or navigate it first");
+    expect(result?.error).toContain("run a flow on it with qawolf runner run");
     expect(result?.error).toContain("not proof the snippet did not run");
     expect(result?.exitCode).toBe(4);
   });

--- a/src/domains/interactiveRunner/resolveRunner.test.ts
+++ b/src/domains/interactiveRunner/resolveRunner.test.ts
@@ -86,6 +86,26 @@ describe("resolveRunner", () => {
     expect(callPublicApi).not.toHaveBeenCalled();
   });
 
+  it("uses a command's own wording when it supplies one", async () => {
+    const { ctx } = makeAuthCtx();
+
+    const resolved = await resolveRunner(
+      ctx,
+      {
+        autoLaunch: false,
+        noRunnerIdMessage: "Launch one and open a page first.",
+        runner: undefined,
+      },
+      makeTestDeps(),
+    );
+
+    expect(resolved).toEqual({
+      error: "Launch one and open a page first.",
+      exitCode: 2,
+      type: "failed",
+    });
+  });
+
   it("refuses an id the published schema does not admit", async () => {
     const { ctx } = makeAuthCtx();
 

--- a/src/domains/interactiveRunner/resolveRunner.test.ts
+++ b/src/domains/interactiveRunner/resolveRunner.test.ts
@@ -1,6 +1,8 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import { describe, expect, it } from "bun:test";
 
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+
 import { resolveRunner } from "./resolveRunner.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 
@@ -82,7 +84,11 @@ describe("resolveRunner", () => {
       makeTestDeps(),
     );
 
-    expect(resolved.type).toBe("failed");
+    expect(resolved).toEqual({
+      error: interactiveRunnerMessages.noRunnerId,
+      exitCode: 2,
+      type: "failed",
+    });
     expect(callPublicApi).not.toHaveBeenCalled();
   });
 

--- a/src/domains/interactiveRunner/resolveRunner.ts
+++ b/src/domains/interactiveRunner/resolveRunner.ts
@@ -37,7 +37,16 @@ async function chooseRunnerId(
 
 export async function resolveRunner(
   ctx: AuthCommandContext,
-  options: { autoLaunch: boolean; runner: string | undefined },
+  options: {
+    autoLaunch: boolean;
+    /**
+     * What to say when nothing names a runner and none will be launched.
+     * Optional because most commands want the plain answer; a command whose next
+     * step is more than "launch one" supplies its own.
+     */
+    noRunnerIdMessage?: string;
+    runner: string | undefined;
+  },
   deps: InteractiveRunnerDeps,
 ): Promise<ResolvedRunner> {
   const chosen = await chooseRunnerId(options.runner, deps);
@@ -54,7 +63,7 @@ export async function resolveRunner(
 
   if (!options.autoLaunch) {
     return {
-      error: interactiveRunnerMessages.noRunnerId,
+      error: options.noRunnerIdMessage ?? interactiveRunnerMessages.noRunnerId,
       exitCode: exitCodes.invalidArgs,
       type: "failed",
     };

--- a/src/domains/interactiveRunner/takeScreenshot.test.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.test.ts
@@ -111,9 +111,7 @@ describe("handleRunnerScreenshot", () => {
     expect(result?.exitCode).toBe(2);
   });
 
-  // A runner started for this command would have no screen yet, so auto-launching
-  // one would bill a pod in order to answer screen-not-ready every time.
-  it("never launches a runner, and names both things the caller needs", async () => {
+  it("never launches a runner, and names the screen as well as the runner", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     const deps = makeTestDeps();
 
@@ -125,7 +123,9 @@ describe("handleRunnerScreenshot", () => {
 
     expect(result?.exitCode).toBe(2);
     expect(result?.error).toContain("qawolf runner launch");
-    expect(result?.error).toContain("navigate it or run a flow on it first");
+    // A run is the only thing that starts the virtual desktop, so it is the only
+    // next step worth naming: navigating needs a page a fresh runner has not got.
+    expect(result?.error).toContain("run a flow on it with qawolf runner run");
     expect(callPublicApi).not.toHaveBeenCalled();
     expect(deps.written).toEqual([]);
   });

--- a/src/domains/interactiveRunner/takeScreenshot.test.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.test.ts
@@ -111,6 +111,43 @@ describe("handleRunnerScreenshot", () => {
     expect(result?.exitCode).toBe(2);
   });
 
+  // A runner started for this command would have no screen yet, so auto-launching
+  // one would bill a pod in order to answer screen-not-ready every time.
+  it("never launches a runner, and names both things the caller needs", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    const deps = makeTestDeps();
+
+    const result = await handleRunnerScreenshot(
+      ctx,
+      { out: "shot.jpg", runner: undefined },
+      deps,
+    );
+
+    expect(result?.exitCode).toBe(2);
+    expect(result?.error).toContain("qawolf runner launch");
+    expect(result?.error).toContain("navigate it or run a flow on it first");
+    expect(callPublicApi).not.toHaveBeenCalled();
+    expect(deps.written).toEqual([]);
+  });
+
+  it("takes the stored default when no flag names a runner", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { imageJpegBase64, outcome: "captured" },
+    });
+    const deps = makeTestDeps();
+    await deps.store.writeDefaultRunnerId("from-store");
+
+    await handleRunnerScreenshot(
+      ctx,
+      { out: "shot.jpg", runner: undefined },
+      deps,
+    );
+
+    expect(callPublicApi.mock.calls[0]?.[1]).toEqual({ id: "from-store" });
+  });
+
   it("reports an unreachable runner, writing nothing", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -30,7 +30,7 @@ export async function handleRunnerScreenshot(
   deps: InteractiveRunnerDeps,
 ): Promise<CommandResult> {
   // Never launches: the virtual desktop starts with the runner's first run, so a
-  // runner started for this command could only answer `screen-not-ready`.
+  // runner started for this command could only answer `screen-needs-a-run`.
   const resolved = await resolveRunner(
     ctx,
     {

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -29,11 +29,8 @@ export async function handleRunnerScreenshot(
   options: { out: string; runner: string | undefined },
   deps: InteractiveRunnerDeps,
 ): Promise<CommandResult> {
-  // Never launches. A runner started for this command has no screen yet, because
-  // the virtual desktop starts with the runner's first run, so auto-launching
-  // would bill a pod in order to answer `screen-not-ready` every time. Saying
-  // what to do instead costs nothing, and it keeps one rule true across the
-  // group: no read command starts a runner.
+  // Never launches: the virtual desktop starts with the runner's first run, so a
+  // runner started for this command could only answer `screen-not-ready`.
   const resolved = await resolveRunner(
     ctx,
     {

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -9,7 +9,7 @@ import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
-import { announceRunner, resolveRunner } from "./resolveRunner.js";
+import { resolveRunner } from "./resolveRunner.js";
 
 /**
  * Takes one screenshot and writes it to a file.
@@ -29,15 +29,23 @@ export async function handleRunnerScreenshot(
   options: { out: string; runner: string | undefined },
   deps: InteractiveRunnerDeps,
 ): Promise<CommandResult> {
+  // Never launches. A runner started for this command has no screen yet, because
+  // the virtual desktop starts with the runner's first run, so auto-launching
+  // would bill a pod in order to answer `screen-not-ready` every time. Saying
+  // what to do instead costs nothing, and it keeps one rule true across the
+  // group: no read command starts a runner.
   const resolved = await resolveRunner(
     ctx,
-    { autoLaunch: true, runner: options.runner },
+    {
+      autoLaunch: false,
+      noRunnerIdMessage: interactiveRunnerMessages.noRunnerIdForScreenshot,
+      runner: options.runner,
+    },
     deps,
   );
   if (resolved.type === "failed") {
     return { error: resolved.error, exitCode: resolved.exitCode };
   }
-  announceRunner(ctx, resolved);
 
   const result = await ctx.platformClient.callPublicApi(
     publicContractsV1.runner.takeScreenshot,


### PR DESCRIPTION
Relates to NOVA-1365
Stacked on #1445 — review that first.

# Overview of Changes

`qawolf runner screenshot` would launch a runner when none was available, and then reliably fail: a runner's virtual desktop only starts with its first run, so the runner it just billed had no screen to photograph. The caller paid for a pod and got `screen-not-ready`.

It now refuses instead, and says what to do — launch a runner and open a page on it. That makes one rule true across the whole group: no read command ever starts a runner, so only `run`, `act` and `exec` do.

`qawolf runner exec` also stops blaming the wrong thing. Against a freshly launched runner with no page open it used to suggest checking whether the runner runs a browser at all, which on a `node20WithPlaywright` runner is the wrong thing to check. It now says to run a flow or navigate first, keeping the never-clears case as the secondary possibility.

# Blocked on an unpublished contracts version

**This will not pass CI yet, and that is expected.** The commands call `runner.*` contracts that no published `@qawolf/api-contracts` version carries — they exist only in unmerged platform PRs. The pin stays at main’s `0.20.0` rather than moving to a version that does not exist; once the platform publishes the first version carrying the `runner.*` contracts, a one-line bump turns CI green.

Until then `bun run generate` fails on a missing export, which takes `typecheck`, `lint`, `test` and `build` down with it. `format:check` and `knip` pass. Every gate passes locally against a contracts build staged with `bun run stage:api-contracts`.

# Testing

```bash
bun run stage:api-contracts ../platform   # a checkout carrying the runner contracts
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
