### PR TITLE
chore(cli): add Cloud Agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "@qawolf/cli",
+  "install": "command -v bun >/dev/null 2>&1 || curl -fsSL https://bun.sh/install | bash -s \"bun-v1.3.13\"; export BUN_INSTALL=\"$HOME/.bun\"; export PATH=\"$BUN_INSTALL/bin:$PATH\"; bun install --frozen-lockfile"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Relates to Cloud Agent environment setup -->

# Overview of Changes

Adds a `.cursor/environment.json` so QA Wolf Cloud Agents get a working, reproducible dev environment out of the box. The repo needs Bun (pinned via `packageManager`), which is not present in the default image, so the `install` phase installs the pinned Bun (`bun-v1.3.13`) when it is missing and then runs `bun install --frozen-lockfile`. The command is idempotent and needs no `start`/`terminals` because the CLI has no long-running services.

# Testing

Validated end to end on a fresh VM: Bun install, dependency install (twice, for idempotence), the full quality suite, a build, and a real product action (running the web example flow, which launches Chromium and passes).

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
bun run dev -- doctor
bun run dev -- flows run examples/example.flow.ts --junit /tmp/junit.xml
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ece44eda-eb10-4ad3-99f7-bbfd5a65b216?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ece44eda-eb10-4ad3-99f7-bbfd5a65b216&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

