### PR TITLE
chore(deps): bump api-contracts to 0.25.0

### DIFF
--- a/.changeset/api-contracts-0-25-0.md
+++ b/.changeset/api-contracts-0-25-0.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+Update `@qawolf/api-contracts` to 0.25.0. Environment responses now identify
+the default environment, and `qawolf run get` includes attempt artifacts and
+failure diagnoses when available.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.24.0",
+        "@qawolf/api-contracts": "0.25.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -448,7 +448,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.24.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-vluI07C6zet4hwTVgfpn7iJHP/W1LOW7yd3niAmo0kExCEAe+IE90VCNkN8IBBF6MTe49VIqc/XBktaEVtzclQ=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.25.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-uSx9ZiyUMwYyi2J/aUm/pX/DOAmuI8iD5UOwCxNWj1WRTfMvlqMgSg4yvhEW7DpyTItNC7RsDzWfEo4YWmEjsQ=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.24.0",
+    "@qawolf/api-contracts": "0.25.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -95,7 +95,7 @@ current branch.
 | `qawolf environment get` | read | Read a single environment's name, kind, health status, run concurrency limit, and termination state. |
 | `qawolf environment getVariable` | read | Read the values of named environment variables in one call. Values are secrets. Names that do not exist go to missingNames and do not fail the call. |
 | `qawolf environment listVariableNames` | read | Use this to answer which QA Wolf environment variables are available to test code. Returns names only; values never leave the server. |
-| `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_ENVIRONMENT_EMAIL. The value is never returned. |
+| `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_EMAIL. The value is never returned. |
 | `qawolf environment update` | write | Update an environment owned by the caller's team and return it in the environment.get shape. Omitted fields remain unchanged. |
 | `qawolf flow addTag` | write | Assign an existing tag to the selected flows. Create tags with tag.create. |
 | `qawolf flow update` | write | Move a flow between draft and active readiness. The other statuses shown in the app are derived and cannot be set. |

--- a/src/domains/environments/resolveEnvironment.kinds.test.ts
+++ b/src/domains/environments/resolveEnvironment.kinds.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from "bun:test";
 
 import { resolveEnvironment } from "./resolveEnvironment.js";
-import { env, makeDeps } from "./resolveEnvironment.testUtils.js";
+import { env, makeDeps, page } from "./resolveEnvironment.testUtils.js";
 
 describe("resolveEnvironment kind pre-selector", () => {
   it("skips the kind pre-selector when only previews exist", async () => {
     const { deps, select } = makeDeps({
       pages: [
-        {
-          environments: [
-            env("env-1", "PR 1", "preview"),
-            env("env-2", "PR 2", "preview"),
-          ],
-        },
+        page("env-1", [
+          env("env-1", "PR 1", "preview", true),
+          env("env-2", "PR 2", "preview"),
+        ]),
       ],
       selectAnswers: ["env-1"],
     });
@@ -29,14 +27,12 @@ describe("resolveEnvironment kind pre-selector", () => {
   it("pre-selects a kind when both kinds exist, then lists only that kind", async () => {
     const { deps, select } = makeDeps({
       pages: [
-        {
-          environments: [
-            env("env-1", "PR 1", "preview"),
-            env("env-2", "PR 2", "preview"),
-            env("env-3", "Staging", "static"),
-            env("env-4", "Prod", "static"),
-          ],
-        },
+        page("env-1", [
+          env("env-1", "PR 1", "preview", true),
+          env("env-2", "PR 2", "preview"),
+          env("env-3", "Staging", "static"),
+          env("env-4", "Prod", "static"),
+        ]),
       ],
       selectAnswers: ["preview", "env-2"],
     });
@@ -64,13 +60,11 @@ describe("resolveEnvironment kind pre-selector", () => {
   it("auto-picks when the chosen kind has exactly one environment", async () => {
     const { deps, select, info } = makeDeps({
       pages: [
-        {
-          environments: [
-            env("env-1", "PR 1", "preview"),
-            env("env-2", "PR 2", "preview"),
-            env("env-3", "Staging", "static"),
-          ],
-        },
+        page("env-1", [
+          env("env-1", "PR 1", "preview", true),
+          env("env-2", "PR 2", "preview"),
+          env("env-3", "Staging", "static"),
+        ]),
       ],
       selectAnswers: ["static"],
     });
@@ -88,12 +82,10 @@ describe("resolveEnvironment kind pre-selector", () => {
   it("returns cancelled when the kind prompt is dismissed", async () => {
     const { deps } = makeDeps({
       pages: [
-        {
-          environments: [
-            env("env-1", "PR 1", "preview"),
-            env("env-2", "Staging", "static"),
-          ],
-        },
+        page("env-1", [
+          env("env-1", "PR 1", "preview", true),
+          env("env-2", "Staging", "static"),
+        ]),
       ],
       selectCancelled: true,
     });

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { resolveEnvironment } from "./resolveEnvironment.js";
-import { env, makeDeps } from "./resolveEnvironment.testUtils.js";
+import { env, makeDeps, page } from "./resolveEnvironment.testUtils.js";
 
 describe("resolveEnvironment", () => {
   it("resolves the trimmed --env flag through environment.get", async () => {
@@ -87,7 +87,7 @@ describe("resolveEnvironment", () => {
   });
 
   it("errors when the team has no environments", async () => {
-    const { deps } = makeDeps({ pages: [{ environments: [] }] });
+    const { deps } = makeDeps({ pages: [page("env-default", [])] });
 
     const outcome = await resolveEnvironment(deps, {
       explicit: undefined,
@@ -103,7 +103,7 @@ describe("resolveEnvironment", () => {
 
   it("auto-picks a sole environment and says so", async () => {
     const { deps, select, info } = makeDeps({
-      pages: [{ environments: [env("env-1", "Staging")] }],
+      pages: [page("env-1", [env("env-1", "Staging", "static", true)])],
     });
 
     const outcome = await resolveEnvironment(deps, {
@@ -121,7 +121,10 @@ describe("resolveEnvironment", () => {
   it("prompts with name labels and kind/status hints when several exist", async () => {
     const { deps, select, info } = makeDeps({
       pages: [
-        { environments: [env("env-1", "Staging"), env("env-2", "Prod")] },
+        page("env-1", [
+          env("env-1", "Staging", "static", true),
+          env("env-2", "Prod"),
+        ]),
       ],
       selectAnswers: ["env-2"],
     });
@@ -145,8 +148,8 @@ describe("resolveEnvironment", () => {
   it("pages through nextCursor before prompting", async () => {
     const { deps, findEnvironments, select } = makeDeps({
       pages: [
-        { environments: [env("env-1", "A")], nextCursor: "c2" },
-        { environments: [env("env-2", "B")] },
+        page("env-1", [env("env-1", "A", "static", true)], "c2"),
+        page("env-1", [env("env-2", "B")]),
       ],
       selectAnswers: ["env-1"],
     });
@@ -163,7 +166,9 @@ describe("resolveEnvironment", () => {
 
   it("returns cancelled when the prompt is dismissed", async () => {
     const { deps } = makeDeps({
-      pages: [{ environments: [env("env-1", "A"), env("env-2", "B")] }],
+      pages: [
+        page("env-1", [env("env-1", "A", "static", true), env("env-2", "B")]),
+      ],
       selectCancelled: true,
     });
 

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -11,17 +11,7 @@ const getContract = publicContractsV1.environment.get;
 type FindOutput = z.output<typeof findContract.output>;
 type GetOutput = z.output<typeof getContract.output>;
 
-export type Page = {
-  environments: {
-    id: string;
-    name: string;
-    kind: "static" | "preview";
-    runConcurrencyLimit: string;
-    status: "blocked" | "needs-investigation" | "ready" | "running";
-    url: string;
-  }[];
-  nextCursor?: string;
-};
+export type Page = FindOutput;
 
 export function makeDeps(args: {
   mode?: "human" | "json" | "agent";
@@ -50,7 +40,14 @@ export function makeDeps(args: {
           : { ok: false, error: args.findError, errorBody: args.findErrorBody };
       }
       if (args.endlessCursor) {
-        return { ok: true, value: { environments: [], nextCursor: "again" } };
+        return {
+          ok: true,
+          value: {
+            defaultEnvironmentId: "env-default",
+            environments: [],
+            nextCursor: "again",
+          },
+        };
       }
       const page = pages[call];
       call += 1;
@@ -107,13 +104,23 @@ export function env(
   id: string,
   name: string,
   kind: "static" | "preview" = "static",
+  isDefault = false,
 ): Page["environments"][number] {
   return {
     id,
+    isDefault,
     name,
     kind,
     runConcurrencyLimit: "5",
     status: "ready",
     url: "https://x",
   };
+}
+
+export function page(
+  defaultEnvironmentId: string,
+  environments: Page["environments"],
+  nextCursor?: string,
+): Page {
+  return { defaultEnvironmentId, environments, nextCursor };
 }


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts` 0.25.0 is now published, while the CLI remains pinned to 0.24.0 and cannot validate the latest environment and run response shapes. This updates the dependency and lockfile, regenerates the CLI skill, aligns environment resolver fixtures with the new default-environment metadata, and adds a minor changeset for the new output fields.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
