### PR TITLE
fix(runner): surface the server's reason when a launch is refused

### DIFF
--- a/src/domains/interactiveRunner/launch.test.ts
+++ b/src/domains/interactiveRunner/launch.test.ts
@@ -119,6 +119,7 @@ describe("handleRunnerLaunch", () => {
     expect(result?.exitCode).toBe(4);
     expect(result?.error).toContain("timed out");
     expect(result?.error).toContain("qawolf runner launch --id ci");
+    expect(result?.errorBody).toBeUndefined();
     expect(await deps.store.readDefaultRunnerId()).toBe("ci");
   });
 
@@ -142,6 +143,28 @@ describe("handleRunnerLaunch", () => {
     expect(result?.error).toContain("already running node20Basic");
     expect(result?.error).not.toContain("relaunch");
     expect(await deps.store.readDefaultRunnerId()).toBeUndefined();
+  });
+
+  // The server's own reason is the only thing that names which image the id is
+  // already running, so a refused launch has to pass it on rather than leave
+  // the caller with a bare status code.
+  it("passes on the reason the server gave for refusing the launch", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      error: "QA Wolf API runner.launch request failed (HTTP 409).",
+      errorBody:
+        "runner ci is already running node20Basic; stop it before launching node20WithAndroid",
+      ok: false,
+    });
+
+    const result = await handleRunnerLaunch(
+      ctx,
+      { id: "ci", name: "node20WithAndroid" },
+      makeTestDeps(),
+    );
+
+    expect(result?.errorBody).toContain("already running node20Basic");
+    expect(result?.exitCode).toBe(4);
   });
 
   // The default the directory had before may name a runner that is still

--- a/src/domains/interactiveRunner/launch.ts
+++ b/src/domains/interactiveRunner/launch.ts
@@ -9,6 +9,10 @@ import type {
   CommandResult,
 } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
+import {
+  failureFields,
+  type PlatformFailure,
+} from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { parseRunnerId, parseRunnerName } from "./runnerIds.js";
@@ -20,9 +24,9 @@ type LaunchedRunner = {
   runnerName: RunnerNameForPublicApi;
 };
 
-type LaunchResult =
-  | { ok: true; value: LaunchedRunner }
-  | { ok: false; error: string; exitCode: number; mayHaveArrived: boolean };
+type LaunchFailure = PlatformFailure & { ok: false; exitCode: number };
+
+type LaunchResult = { ok: true; value: LaunchedRunner } | LaunchFailure;
 
 /**
  * Launches a runner under `id`, or attaches to the one already running there.
@@ -42,7 +46,7 @@ async function launchRunner(
   );
   if (!result.ok) {
     return {
-      error: result.error,
+      ...failureFields(result),
       exitCode: exitCodes.network,
       mayHaveArrived: result.mayHaveArrived ?? false,
       ok: false,
@@ -100,12 +104,10 @@ export async function launchAndRemember(
     ).catch(() => undefined);
   }
   return {
+    ...launched,
     error: launched.mayHaveArrived
       ? interactiveRunnerMessages.launchLost(options.id, launched.error)
       : interactiveRunnerMessages.launchFailed(options.id, launched.error),
-    exitCode: launched.exitCode,
-    mayHaveArrived: launched.mayHaveArrived,
-    ok: false,
   };
 }
 
@@ -133,7 +135,7 @@ export async function handleRunnerLaunch(
     deps,
   );
   if (!launched.ok) {
-    return { error: launched.error, exitCode: launched.exitCode };
+    return { ...failureFields(launched), exitCode: launched.exitCode };
   }
 
   ctx.ui.output(


### PR DESCRIPTION
Relates to [NOVA-1539](https://linear.app/qawolf/issue/NOVA-1539)

# Overview of Changes

When the server refused a `runner launch` — for example the id was already running a different image — the CLI showed only the bare HTTP status and dropped the server's explanation. The launch failure path now passes the server's reason through, the same way every other runner write already does. The lost-answer/timeout path is unchanged; it has no server response to show.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)