### PR TITLE
fix(runner): pass the server's refusal reason through auto-launch

### DIFF
--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -194,6 +194,26 @@ describe("handleRunnerExec", () => {
     expect(result?.exitCode).toBe(1);
   });
 
+  // The same promise for the launch this command makes on the caller's behalf:
+  // the server's reason must survive the trip through resolveRunner.
+  it("passes on the reason the server gave for refusing the auto-launch", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      error: "QA Wolf API runner.launch request failed (HTTP 409).",
+      errorBody: "Runner quota reached: 5 of 5 runners are already running.",
+      ok: false,
+    });
+
+    const result = await handleRunnerExec(
+      ctx,
+      { contextFile: undefined, runner: undefined, source: "flow.ts" },
+      makeTestDeps(),
+    );
+
+    expect(result?.errorBody).toContain("quota reached");
+    expect(result?.exitCode).toBe(4);
+  });
+
   // For this verb, unreachable also covers a runner with no live page, which will
   // never clear, so the message has to name that rather than just say "retry".
   it("names the no-live-page case an unreachable answer hides", async () => {

--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -194,8 +194,8 @@ describe("handleRunnerExec", () => {
     expect(result?.exitCode).toBe(1);
   });
 
-  // The same promise for the launch this command makes on the caller's behalf:
-  // the server's reason must survive the trip through resolveRunner.
+  // The handler rebuilds resolveRunner's failure as its own result, and the
+  // server's reason has to survive that rebuild too.
   it("passes on the reason the server gave for refusing the auto-launch", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({

--- a/src/domains/interactiveRunner/evaluateSnippet.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.ts
@@ -95,7 +95,7 @@ export async function handleRunnerExec(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
   announceRunner(ctx, resolved);
 

--- a/src/domains/interactiveRunner/events.ts
+++ b/src/domains/interactiveRunner/events.ts
@@ -8,6 +8,7 @@ import type {
   CommandResult,
 } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import {
@@ -61,7 +62,7 @@ export async function handleRunnerEvents(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
 
   // A stream name is a path segment on the runner rather than a closed set, so an

--- a/src/domains/interactiveRunner/keepalive.ts
+++ b/src/domains/interactiveRunner/keepalive.ts
@@ -3,6 +3,7 @@ import type {
   AuthCommandContext,
   CommandResult,
 } from "~/shell/commandContext.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { readJournal, unreachableFailure } from "./readJournal.js";
@@ -37,7 +38,7 @@ export async function handleRunnerKeepalive(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
 
   const window = await readJournal(ctx, resolved.runnerId, {

--- a/src/domains/interactiveRunner/performAction.ts
+++ b/src/domains/interactiveRunner/performAction.ts
@@ -71,7 +71,7 @@ export async function handleRunnerAct(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
   announceRunner(ctx, resolved);
 

--- a/src/domains/interactiveRunner/resolveRunner.test.ts
+++ b/src/domains/interactiveRunner/resolveRunner.test.ts
@@ -162,6 +162,30 @@ describe("resolveRunner", () => {
     expect(await deps.store.readDefaultRunnerId()).toBeUndefined();
   });
 
+  // The server's own reason is the only thing that names which image the id is
+  // already running, so a refused auto-launch has to pass it on rather than
+  // leave the caller with a bare status code.
+  it("passes on the reason the server gave for refusing the launch", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      error: "QA Wolf API runner.launch request failed (HTTP 409).",
+      errorBody:
+        "runner cli-minted is already running node20Basic; stop it before launching node20WithAndroid",
+      ok: false,
+    });
+
+    const resolved = await resolveRunner(
+      ctx,
+      { autoLaunch: true, runner: undefined },
+      makeTestDeps(),
+    );
+
+    expect(
+      resolved.type === "failed" ? resolved.errorBody : undefined,
+    ).toContain("already running node20Basic");
+    expect(resolved).toMatchObject({ exitCode: 4, type: "failed" });
+  });
+
   it("names the runner it was launching when the launch fails", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({ ok: false, error: "apex unreachable" });

--- a/src/domains/interactiveRunner/resolveRunner.ts
+++ b/src/domains/interactiveRunner/resolveRunner.ts
@@ -1,6 +1,7 @@
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import type { AuthCommandContext } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { launchAndRemember } from "./launch.js";
@@ -17,7 +18,7 @@ import { parseRunnerId } from "./runnerIds.js";
 export type ResolvedRunner =
   | { type: "resolved"; runnerId: string }
   | { type: "launched"; runnerId: string }
-  | { type: "failed"; error: string; exitCode: number };
+  | { type: "failed"; error: string; errorBody?: string; exitCode: number };
 
 const runnerIdEnvironmentVariable = "QAWOLF_RUNNER_ID";
 
@@ -76,7 +77,7 @@ export async function resolveRunner(
   );
   if (!launched.ok) {
     return {
-      error: launched.error,
+      ...failureFields(launched),
       exitCode: launched.exitCode,
       type: "failed",
     };

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -57,7 +57,7 @@ export async function handleRunnerRun(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
   announceRunner(ctx, resolved);
 

--- a/src/domains/interactiveRunner/stop.ts
+++ b/src/domains/interactiveRunner/stop.ts
@@ -24,7 +24,7 @@ export async function handleRunnerStop(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
 
   const result = await ctx.platformClient.callPublicApi(

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -41,7 +41,7 @@ export async function handleRunnerScreenshot(
     deps,
   );
   if (resolved.type === "failed") {
-    return { error: resolved.error, exitCode: resolved.exitCode };
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
   }
 
   const result = await ctx.platformClient.callPublicApi(


### PR DESCRIPTION
Relates to [NOVA-1541](https://linear.app/qawolf/issue/NOVA-1541)

# Overview of Changes

When a command auto-launches a runner and the server refuses the launch, the CLI showed only the bare HTTP status — the server's reason (which image the id is already running, a quota reached) was dropped. Now every auto-launching command passes the server's reason on, the same way `qawolf runner launch` does since #1476.

A refusal still exits with the network exit code; that pre-existing issue is filed as [NOVA-1542](https://linear.app/qawolf/issue/NOVA-1542).

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
