### PR TITLE
fix(runner): wait 60s for runner calls instead of the 15s default

### DIFF
--- a/.changeset/runner-calls-sixty-seconds.md
+++ b/.changeset/runner-calls-sixty-seconds.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf runner` commands now wait up to 60 seconds for the platform to answer, up from 15. Runner calls are answered by a live runner doing the work — starting a browser, evaluating a snippet, capturing a screen — and the first action on a fresh runner regularly needs longer than 15 seconds, which made the CLI report a timeout for work that was still finishing.

--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handleRunnerExec } from "./evaluateSnippet.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const evaluated = { outcome: "evaluated" as const, result: "success" as const };
 
@@ -21,6 +22,7 @@ describe("handleRunnerExec", () => {
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.evaluateSnippet,
       { code: "export default {};", id: "ci" },
+      runnerCallOptions,
     );
   });
 

--- a/src/domains/interactiveRunner/evaluateSnippet.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.ts
@@ -15,6 +15,7 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const stdinArgument = "-";
 
@@ -107,6 +108,7 @@ export async function handleRunnerExec(
       ...(scope.filePath === undefined ? {} : { filePath: scope.filePath }),
       ...(scope.files === undefined ? {} : { files: scope.files }),
     },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return { ...failureFields(result), exitCode: exitCodes.network };

--- a/src/domains/interactiveRunner/keepalive.test.ts
+++ b/src/domains/interactiveRunner/keepalive.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "bun:test";
 import { handleRunnerKeepalive } from "./keepalive.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 import { makeJournal } from "./journal.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 describe("handleRunnerKeepalive", () => {
   // There is no keepalive endpoint and this does not want one: every request the
@@ -24,6 +25,7 @@ describe("handleRunnerKeepalive", () => {
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.readJournal,
       { id: "ci", stream: "run-status", tail: 1 },
+      runnerCallOptions,
     );
     expect(outputs()[0]?.humanMessage).toContain("is alive");
     expect(outputs()[0]?.data).toEqual({ id: "ci", outcome: "alive" });

--- a/src/domains/interactiveRunner/launch.test.ts
+++ b/src/domains/interactiveRunner/launch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handleRunnerLaunch } from "./launch.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const launched = {
   gpuAccelerated: false,
@@ -23,9 +24,8 @@ describe("handleRunnerLaunch", () => {
 
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.launch,
-      {
-        id: "cli-minted",
-      },
+      { id: "cli-minted" },
+      runnerCallOptions,
     );
     expect(await deps.store.readDefaultRunnerId()).toBe("cli-minted");
   });
@@ -45,10 +45,8 @@ describe("handleRunnerLaunch", () => {
 
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.launch,
-      {
-        id: "ci",
-        runnerName: "node20WithAndroid",
-      },
+      { id: "ci", runnerName: "node20WithAndroid" },
+      runnerCallOptions,
     );
   });
 

--- a/src/domains/interactiveRunner/launch.ts
+++ b/src/domains/interactiveRunner/launch.ts
@@ -15,6 +15,7 @@ import {
 } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 import { parseRunnerId, parseRunnerName } from "./runnerIds.js";
 
 type LaunchedRunner = {
@@ -43,6 +44,7 @@ async function launchRunner(
       id: options.id,
       ...(options.runnerName ? { runnerName: options.runnerName } : {}),
     },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return {

--- a/src/domains/interactiveRunner/performAction.test.ts
+++ b/src/domains/interactiveRunner/performAction.test.ts
@@ -8,6 +8,7 @@ import type { BrowserActionFlags } from "~/core/interactiveRunner/browserAction.
 
 import { handleRunnerAct } from "./performAction.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const noFlags: BrowserActionFlags = {
   button: undefined,
@@ -99,6 +100,7 @@ describe("handleRunnerAct", () => {
       expect(callPublicApi).toHaveBeenCalledWith(
         publicContractsV1.runner.performAction,
         { action: shape.action, id: "ci" },
+        runnerCallOptions,
       );
     });
   }

--- a/src/domains/interactiveRunner/performAction.ts
+++ b/src/domains/interactiveRunner/performAction.ts
@@ -14,6 +14,7 @@ import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
 
 /** `-` reads a whole action as JSON, which is the forward-a-tool-call path. */
@@ -78,6 +79,7 @@ export async function handleRunnerAct(
   const result = await ctx.platformClient.callPublicApi(
     publicContractsV1.runner.performAction,
     { action: built.action, id: resolved.runnerId },
+    runnerCallOptions,
   );
   if (!result.ok) {
     // A lost answer at the transport is the same hazard as the unreachable

--- a/src/domains/interactiveRunner/readJournal.ts
+++ b/src/domains/interactiveRunner/readJournal.ts
@@ -5,6 +5,8 @@ import type { AuthCommandContext } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
 type JournalWindow = {
   entries: JournalEntry<unknown>[];
   hasUnsearchedHistory: boolean;
@@ -65,6 +67,7 @@ export async function readJournal(
         : { sinceSequence: request.sinceSequence }),
       ...(request.tail === undefined ? {} : { tail: request.tail }),
     },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return {

--- a/src/domains/interactiveRunner/resolveRunner.test.ts
+++ b/src/domains/interactiveRunner/resolveRunner.test.ts
@@ -5,6 +5,7 @@ import { interactiveRunnerMessages } from "~/core/messages/index.js";
 
 import { resolveRunner } from "./resolveRunner.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const launched = {
   gpuAccelerated: false,
@@ -68,9 +69,8 @@ describe("resolveRunner", () => {
 
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.launch,
-      {
-        id: "cli-minted",
-      },
+      { id: "cli-minted" },
+      runnerCallOptions,
     );
     expect(await deps.store.readDefaultRunnerId()).toBe("cli-minted");
   });

--- a/src/domains/interactiveRunner/runFlow.test.ts
+++ b/src/domains/interactiveRunner/runFlow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handleRunnerRun } from "./runFlow.js";
 import { makeAuthCtx, makeTestDeps, testCwd } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const submitted = { outcome: "submitted" as const, runId: "run-a" };
 
@@ -38,12 +39,10 @@ describe("handleRunnerRun", () => {
       publicContractsV1.runner.runFlow,
       {
         entryPointPath: "flow.ts",
-        files: {
-          "flow.ts": "export default {};",
-          "package.json": "{}",
-        },
+        files: { "flow.ts": "export default {};", "package.json": "{}" },
         id: "ci",
       },
+      runnerCallOptions,
     );
   });
 

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -18,6 +18,7 @@ import { collectRunFiles } from "./collectFiles.js";
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { followRun } from "./followRun.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 export async function handleRunnerRun(
   ctx: AuthCommandContext,
@@ -64,6 +65,7 @@ export async function handleRunnerRun(
   const result = await ctx.platformClient.callPublicApi(
     publicContractsV1.runner.runFlow,
     { entryPointPath, files, id: resolved.runnerId },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return { ...failureFields(result), exitCode: exitCodes.network };

--- a/src/domains/interactiveRunner/runnerCallOptions.ts
+++ b/src/domains/interactiveRunner/runnerCallOptions.ts
@@ -1,0 +1,10 @@
+import type { RequestOptions } from "~/shell/platform/createTrpcClient.js";
+
+/**
+ * Runner endpoints are answered by a live runner doing the work — starting a
+ * browser, evaluating a snippet, capturing a screen — not by the platform's
+ * database, so the client's default timeout is too short for them. Sixty
+ * seconds covers the slowest observed case, a first action that has to start
+ * the browser before it can be performed.
+ */
+export const runnerCallOptions: RequestOptions = { timeoutMs: 60_000 };

--- a/src/domains/interactiveRunner/stop.test.ts
+++ b/src/domains/interactiveRunner/stop.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handleRunnerStop } from "./stop.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 describe("handleRunnerStop", () => {
   it("stops the runner the flag names", async () => {
@@ -16,9 +17,11 @@ describe("handleRunnerStop", () => {
       await handleRunnerStop(ctx, { runner: "ci" }, makeTestDeps()),
     ).toBeUndefined();
 
-    expect(callPublicApi).toHaveBeenCalledWith(publicContractsV1.runner.stop, {
-      id: "ci",
-    });
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.stop,
+      { id: "ci" },
+      runnerCallOptions,
+    );
     expect(outputs()[0]?.humanMessage).toContain("Stopped runner ci");
   });
 

--- a/src/domains/interactiveRunner/stop.ts
+++ b/src/domains/interactiveRunner/stop.ts
@@ -10,6 +10,7 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 export async function handleRunnerStop(
   ctx: AuthCommandContext,
@@ -32,6 +33,7 @@ export async function handleRunnerStop(
     {
       id: resolved.runnerId,
     },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return { ...failureFields(result), exitCode: exitCodes.network };

--- a/src/domains/interactiveRunner/takeScreenshot.test.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handleRunnerScreenshot } from "./takeScreenshot.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 // Real JPEG magic bytes, so a test can tell a decoded image from its base64.
 const jpegBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
@@ -29,6 +30,7 @@ describe("handleRunnerScreenshot", () => {
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.takeScreenshot,
       { id: "ci" },
+      runnerCallOptions,
     );
     expect(deps.written).toEqual([{ bytes: jpegBytes, path: "shot.jpg" }]);
   });

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -10,6 +10,7 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
 
 /**
  * Takes one screenshot and writes it to a file.
@@ -47,6 +48,7 @@ export async function handleRunnerScreenshot(
   const result = await ctx.platformClient.callPublicApi(
     publicContractsV1.runner.takeScreenshot,
     { id: resolved.runnerId },
+    runnerCallOptions,
   );
   if (!result.ok) {
     return { ...failureFields(result), exitCode: exitCodes.network };


### PR DESCRIPTION
# Overview of Changes

`qawolf runner` commands gave the platform 15 seconds to answer, which fits calls answered from the database but not calls answered by a live runner doing the work. The first action on a fresh runner now starts a browser (qawolf/platform#31196), which regularly takes longer than 15 seconds, so the CLI reported a timeout for work that was still finishing. Runner calls now wait up to 60 seconds.

# Testing

Against a preview environment, `runner act navigate` as the first action on a fresh runner no longer dies at the client's 15s timeout — the call now stays open long enough for the runner itself to answer.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
