### PR TITLE
build(cli): publish releases to GitHub Packages as well as npm

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -65,8 +65,9 @@ jobs:
           }
 
           userconfig=$(mktemp)
+          view_log=$(mktemp)
           chmod 600 "$userconfig"
-          trap 'rm -f "$userconfig"' EXIT
+          trap 'rm -f "$userconfig" "$view_log"' EXIT
           printf '//npm.pkg.github.com/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$userconfig"
           export NPM_CONFIG_USERCONFIG="$userconfig"
 
@@ -75,12 +76,20 @@ jobs:
           # bare --registry publishes to npmjs without complaining.
           scoped_registry=(--@qawolf:registry="$registry")
 
-          # An unpublished version gives empty output and exit 0; only an unknown
-          # package gives E404. Testing the exit code would skip every publish.
-          published=$(npm view "@qawolf/cli@${version}" version "${scoped_registry[@]}" 2>/dev/null || true)
-          if [ -n "$published" ]; then
-            echo "@qawolf/cli@${version} is already on GitHub Packages."
-            exit 0
+          # An absent package or version answers with E404, so that is the only
+          # failure meaning "not published yet". Anything else — E401 from a bad
+          # token, a network error — must stop the job rather than fall through
+          # to a publish that hides why the query failed. Keep the streams
+          # separate: npm writes warnings to stderr, and merging them into
+          # $published would read as "already published" and skip the publish.
+          if published=$(npm view "@qawolf/cli@${version}" version "${scoped_registry[@]}" 2>"$view_log"); then
+            if [ -n "$published" ]; then
+              echo "@qawolf/cli@${version} is already on GitHub Packages."
+              exit 0
+            fi
+          elif ! grep -q "E404" "$view_log"; then
+            cat "$view_log" >&2
+            exit 1
           fi
 
           # No --access (GitHub Packages rejects the flag; visibility comes from

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,0 +1,88 @@
+name: Publish to GitHub Packages
+
+# Why we publish the same version twice: docs/releasing.md § GitHub Packages.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+# Serialize runs per tag: workflow_call and workflow_dispatch can otherwise race
+# on publishing the same version.
+concurrency:
+  group: publish-github-packages-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]] || {
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          }
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: package.json
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - name: Publish to GitHub Packages
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          registry=https://npm.pkg.github.com
+
+          version=$(bun -e "console.log(require('./package.json').version)")
+          [ "v${version}" = "$RELEASE_TAG" ] || {
+            echo "Tag $RELEASE_TAG does not match package version $version" >&2
+            exit 1
+          }
+
+          userconfig=$(mktemp)
+          chmod 600 "$userconfig"
+          trap 'rm -f "$userconfig"' EXIT
+          printf '//npm.pkg.github.com/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$userconfig"
+          export NPM_CONFIG_USERCONFIG="$userconfig"
+
+          # Must be the scoped flag. The repo .npmrc pins @qawolf to npmjs, and
+          # npm reads `@scope:registry` ahead of the plain `registry` key, so a
+          # bare --registry publishes to npmjs without complaining.
+          scoped_registry=(--@qawolf:registry="$registry")
+
+          # An unpublished version gives empty output and exit 0; only an unknown
+          # package gives E404. Testing the exit code would skip every publish.
+          published=$(npm view "@qawolf/cli@${version}" version "${scoped_registry[@]}" 2>/dev/null || true)
+          if [ -n "$published" ]; then
+            echo "@qawolf/cli@${version} is already on GitHub Packages."
+            exit 0
+          fi
+
+          # No --access (GitHub Packages rejects the flag; visibility comes from
+          # the repo) and no provenance (attestation is npmjs-only).
+          npm publish "${scoped_registry[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,19 @@ jobs:
     with:
       tag: ${{ needs.release.outputs.tag }}
 
+  # A sibling of binaries rather than a step in release: a registry failure must
+  # not skip the binary build, and changeset publish only knows one registry.
+  github-packages:
+    name: GitHub Packages
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-github-packages.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+
   notify-binaries:
     name: Notify Slack of binaries
     needs: [release, binaries]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,11 +2,15 @@
 
 `@qawolf/cli` uses [Changesets](https://github.com/changesets/changesets) to manage versions and publish to npm.
 
+We publish each version to two registries. Our clients install from npmjs. Our internal builds get the package from [GitHub Packages](#github-packages).
+
 ## Prerequisites
 
 Before the first publish:
 
 - `NPM_TOKEN` must be set as a GitHub Actions secret (Settings → Secrets → Actions → New repository secret).
+
+The publish to GitHub Packages needs no secret. It uses the built-in `GITHUB_TOKEN` of the workflow. That token can write the packages of this repository.
 
 ## How to add a changeset
 
@@ -33,6 +37,22 @@ PRs that do not affect the published package (CI config, internal tooling, docs)
 
    `changeset publish` publishes to npm and creates a git tag for the new version. The changesets action pushes that tag and creates a GitHub Release from it, which triggers the binary build pipeline. npm [provenance](https://docs.npmjs.com/generating-provenance-statements) is enabled via the `NPM_CONFIG_PROVENANCE: true` env var on the publish step.
 
+5. Two jobs then run in parallel from the new tag. The first job builds the binaries. The second job publishes to [GitHub Packages](#github-packages).
+
+## GitHub Packages
+
+An npm registry map applies to a full scope. It cannot apply to one package. Our internal builds map the full `@qawolf` scope to GitHub Packages. Thus we cannot send `@qawolf/cli` to npmjs and keep the other `@qawolf` packages on GitHub Packages. A version that is absent from GitHub Packages gives an `E404` error.
+
+[`publish-github-packages.yml`](../.github/workflows/publish-github-packages.yml) corrects this. It gets the source at the release tag, builds the package again, and publishes it to `https://npm.pkg.github.com`. Three conditions are important if you change this workflow:
+
+- Use the `--@qawolf:registry=` flag. The `.npmrc` file of this repo sets the `@qawolf` scope to npmjs. A project file has more control than a user file or an environment variable. npm also reads a scope key before the plain `registry` key. Therefore a `--registry` flag alone publishes to npmjs and gives no error.
+- Do not use the `--access` flag. GitHub Packages refuses that flag. A package of the organization gets its visibility from the repository.
+- Do not use provenance. Only npmjs makes an attestation, and a request for provenance here stops the publish. Therefore `NPM_CONFIG_PROVENANCE` stays on the changesets step in `release.yml`.
+
+The job stops with no error if the version is already present. Therefore you can run the job again safely.
+
+To publish a version that is older than this workflow, run the workflow alone. Go to Actions → Publish to GitHub Packages → Run workflow. Give the release tag, for example `v1.11.0`.
+
 ## After publish
 
 Verify the release:
@@ -42,6 +62,14 @@ npm view @qawolf/cli version   # should match the version in package.json
 qawolf --version               # should match package.json version
 ```
 
+To verify the copy on GitHub Packages, use a token that has the `read:packages` scope. That registry needs authentication for each read, also for a public package.
+
+```bash
+npm view @qawolf/cli version --@qawolf:registry=https://npm.pkg.github.com
+```
+
 ## Re-running a failed publish
 
 If the publish step fails (e.g. network issue after the version PR was merged), re-run the Release workflow from the GitHub Actions UI (Actions → Release → Re-run jobs). If the version was already partially published, npm will return an error indicating the version exists — in that case, cut a patch release with a new changeset rather than attempting to re-publish the same version.
+
+If only the GitHub Packages job failed, run that job again. The job makes no change to npmjs, and a second run is safe.


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

An npm registry map applies to a full scope, not to one package. We publish `@qawolf/cli` only to npm. A consumer that maps the `@qawolf` scope to GitHub Packages therefore gets an `E404` error.

This change publishes each release to the two registries.

- **`.github/workflows/publish-github-packages.yml`**: a new reusable workflow. It builds the source at the release tag and publishes it to `https://npm.pkg.github.com`. The `--@qawolf:registry=` flag is necessary. npm reads a scope key before the plain `registry` key, so a `--registry` flag alone publishes to npm and gives no error. A version check makes the workflow safe to run again, and the `workflow_dispatch` trigger adds a version that is older than this change.
- **`.github/workflows/release.yml`**: a new `github-packages` job calls that workflow. It runs in parallel with `binaries`, so a registry failure does not stop the binary build or the Slack message.
- **`docs/releasing.md`**: records the two registries, the constraints of GitHub Packages, and the procedure to add an older version.

# Testing

```bash
bun run lint
bun run format:check
bun run typecheck
bun run knip
bun run test
bun run build
```

- The publish step ran as a dry run against the live registry with a real token. npm reported `Publishing to https://npm.pkg.github.com`. This shows that the scope flag replaces the value in the `.npmrc` file of this repo.
- The version check gave the correct result for four conditions: a version that is present, a version that is absent, a package that is absent, and a bad token. npm answers an absent package or version with `E404`, and the step continues only for that error. It stops for each other error, for example the `E401` from a bad token.
- The version query keeps stdout and stderr separate. npm writes warnings to stderr, and a merge of the two streams would read as "already published" and skip the publish.
- The tag check stopped the step when the tag does not match the package version.
- Only the publish step has the token. The token goes to a temporary file with mode 600, and a trap removes that file when the step stops.
- A real publish is not possible before this PR merges. The token permission and the upload stay unverified. GitHub Packages also answers an unauthenticated read of an absent package with `E404`, so the first publish cannot tell a bad token from an absent package. The publish itself then stops with the authentication error.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [ ] Tests added/updated (not applicable — CI configuration only)
- [x] No breaking changes
