### PR TITLE
docs(skill): name the issue types in the skill description

### DIFF
--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qawolf-cli
-description: Manage QA Wolf through the qawolf CLI. Use when asked which QA Wolf environment variables are available or to list, set, or delete them; manage environments, flows, runs, tags, or issues; authenticate; install; run or list flows; or drive a live cloud browser (launch a runner, screenshot it, click and type on it, read its recorder) from a shell.
+description: Manage QA Wolf through the qawolf CLI. Use when asked to create, update, or list coverage requests, bug reports, or maintenance reports; start a run of flows or tags on the QA Wolf platform or read a run's results; list, set, or delete environment variables; manage environments, flows, or tags; request automation of draft flows; run or list flows locally; authenticate; install the local runtime; or drive a live cloud browser (launch a runner, screenshot it, click and type on it, read its recorder) from a shell.
 license: Apache-2.0
 compatibility: Requires the qawolf CLI on PATH. Install it from @qawolf/cli or use a standalone binary from GitHub Releases.
 ---

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -1,6 +1,6 @@
 ---
 name: qawolf-cli
-description: Manage QA Wolf through the qawolf CLI. Use when asked which QA Wolf environment variables are available or to list, set, or delete them; manage environments, flows, runs, tags, or issues; authenticate; install; run or list flows; or drive a live cloud browser (launch a runner, screenshot it, click and type on it, read its recorder) from a shell.
+description: Manage QA Wolf through the qawolf CLI. Use when asked to create, update, or list coverage requests, bug reports, or maintenance reports; start a run of flows or tags on the QA Wolf platform or read a run's results; list, set, or delete environment variables; manage environments, flows, or tags; request automation of draft flows; run or list flows locally; authenticate; install the local runtime; or drive a live cloud browser (launch a runner, screenshot it, click and type on it, read its recorder) from a shell.
 license: Apache-2.0
 compatibility: Requires the qawolf CLI on PATH. Install it from @qawolf/cli or use a standalone binary from GitHub Releases.
 ---


### PR DESCRIPTION
# Overview of Changes

The skill description said "issues", but users say "coverage request", "bug report", and "maintenance report", and agents match the skill index against the user's words. In a production Slack conversation (2026-08-14), the agent did not connect "create a coverage request for yourself" to this skill, chose the app browser instead, and gave up because the conversation pod has no browser. This change names the three issue types directly and extends the description to the full command surface: platform runs and their results, environment variables, environments, flows, tags, automation requests, local flow runs, auth, and the local runtime install.

The change is one line in `src/commands/qawolfCliSkill.template.md`, plus the regenerated `skills/qawolf-cli/SKILL.md`.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test   # 1647 pass
bun run build
```

A tester-gym scenario on the platform repo (`creates-a-coverage-request-from-slack-with-the-cli`, branch `run-skill`) reproduces the incident against the shell-only conversation network and validates this routing end to end.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)