### PR TITLE
fix(flows): read flow names that contain quote characters

### DIFF
--- a/.changeset/flow-name-quotes.md
+++ b/.changeset/flow-name-quotes.md
@@ -1,0 +1,11 @@
+---
+"@qawolf/cli": patch
+---
+
+The CLI now reads flow names that contain quote characters.
+
+Before this change, the parser stopped the name at the first single quote or double quote. The parser ignored which quote started the name. Thus the name `Shopper's cart` became `Shopper`. The parser also did not find the target of that flow. A flow without a target does not run. Therefore `qawolf flows run` skipped the flow and showed the message `No flows matched.` The command `qawolf flows list` showed the short name.
+
+The parser now records the quote that starts the name. It also accepts a backslash before a quote. Thus the parser correctly reads the names `"Say \"hi\""` and `'Shopper\'s cart'`. The parser accepts a name in backticks. A name that contains `${...}` stays dynamic, because the value is only available at run time.
+
+Two more target forms now work. The CLI reads the target from an options object that contains a second object before the `target` key. The CLI also reads a target in backticks.

--- a/src/core/extractFlowMeta.test.ts
+++ b/src/core/extractFlowMeta.test.ts
@@ -57,6 +57,27 @@ describe("extractFlowMeta — quotes in the flow name", () => {
     });
   });
 
+  it.each([
+    ["U+2028 line separator", "\u2028"],
+    ["U+2029 paragraph separator", "\u2029"],
+  ])("should drop a %s line continuation inside a name", (_label, sep) => {
+    expect(
+      extractFlowMeta(`flow("Say \\${sep}hi", "Web - Chrome", x)`),
+    ).toEqual({ name: "Say hi", target: "Web - Chrome" });
+  });
+
+  // Unlike a raw line feed, a raw U+2028 or U+2029 is legal inside a quoted
+  // literal from ES2019 on, so it belongs in the value rather than ending it.
+  it.each([
+    ["U+2028", "\u2028"],
+    ["U+2029", "\u2029"],
+  ])("should keep an unescaped %s inside a name", (_label, sep) => {
+    expect(extractFlowMeta(`flow("Say${sep}hi", "Web - Chrome", x)`)).toEqual({
+      name: `Say${sep}hi`,
+      target: "Web - Chrome",
+    });
+  });
+
   // Only identity escapes are decoded. Names do not carry control or unicode
   // escapes, because the generator avoids escaping altogether by choosing a
   // delimiter the name does not contain.
@@ -111,6 +132,8 @@ describe("extractFlowMeta — callee matching", () => {
     // so a \b-based test reads these as a bare `flow(` call.
     ["$flow(", `$flow("N", "chromium", x)`],
     ["πflow(", `πflow("N", "chromium", x)`],
+    // A private method named `flow` is not the `flow()` helper.
+    ["this.#flow(", `this.#flow("N", "chromium", x)`],
   ])("should not match %s", (_label, source) => {
     expect(extractFlowMeta(source)).toEqual({
       name: undefined,

--- a/src/core/extractFlowMeta.test.ts
+++ b/src/core/extractFlowMeta.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "bun:test";
+import { extractFlowMeta } from "./flowMeta.js";
+
+// A flow name is an arbitrary string typed by a human, so it can contain either
+// quote character. The parser must track which delimiter opened the literal and
+// honour backslash escapes, rather than stopping at the first quote it sees.
+describe("extractFlowMeta — quotes in the flow name", () => {
+  it("should keep an apostrophe inside a double-quoted name", () => {
+    expect(
+      extractFlowMeta(`flow("Shopper's cart", "Web - Chrome", async () => {})`),
+    ).toEqual({ name: "Shopper's cart", target: "Web - Chrome" });
+  });
+
+  it("should keep a double quote inside a single-quoted name", () => {
+    expect(
+      extractFlowMeta(`flow('Say "hi"', 'Web - Chrome', async () => {})`),
+    ).toEqual({ name: 'Say "hi"', target: "Web - Chrome" });
+  });
+
+  it("should decode an escaped double quote inside a double-quoted name", () => {
+    expect(
+      extractFlowMeta(
+        String.raw`flow("Say \"hi\"", "Web - Chrome", async () => {})`,
+      ),
+    ).toEqual({ name: 'Say "hi"', target: "Web - Chrome" });
+  });
+
+  it("should decode an escaped apostrophe inside a single-quoted name", () => {
+    expect(
+      extractFlowMeta(
+        String.raw`flow('Shopper\'s cart', 'Web - Chrome', async () => {})`,
+      ),
+    ).toEqual({ name: "Shopper's cart", target: "Web - Chrome" });
+  });
+
+  it("should decode an escaped backslash inside a name", () => {
+    expect(
+      extractFlowMeta(
+        String.raw`flow("C:\\Users share", "Web - Chrome", async () => {})`,
+      ),
+    ).toEqual({ name: String.raw`C:\Users share`, target: "Web - Chrome" });
+  });
+
+  // Only identity escapes are decoded. Names do not carry control or unicode
+  // escapes, because the generator avoids escaping altogether by choosing a
+  // delimiter the name does not contain.
+  it("should not decode a control-character escape inside a name", () => {
+    expect(
+      extractFlowMeta(String.raw`flow("A\tB", "Web - Chrome", async () => {})`),
+    ).toEqual({ name: "AtB", target: "Web - Chrome" });
+  });
+});
+
+describe("extractFlowMeta — template literal names", () => {
+  it("should read a backtick-delimited name", () => {
+    expect(
+      extractFlowMeta('flow(`My Flow`, "Web - Chrome", async () => {})'),
+    ).toEqual({ name: "My Flow", target: "Web - Chrome" });
+  });
+
+  it("should keep both quote characters inside a backtick-delimited name", () => {
+    expect(
+      extractFlowMeta(
+        'flow(`Shopper\'s "best" cart`, "Web - Chrome", async () => {})',
+      ),
+    ).toEqual({ name: `Shopper's "best" cart`, target: "Web - Chrome" });
+  });
+
+  it("should treat an interpolated template literal as a dynamic name", () => {
+    expect(
+      extractFlowMeta('flow(`Flow ${n}`, "Web - Chrome", async () => {})'),
+    ).toEqual({ name: undefined, target: undefined });
+  });
+});
+
+// Characterization: these pin behaviour the current regexes already have, so a
+// reimplementation cannot quietly drop it.
+describe("extractFlowMeta — callee matching", () => {
+  it.each([
+    ["flow(", `flow("N", "chromium", x)`],
+    ["member expression", `obj.flow("N", "chromium", x)`],
+    ["space before paren", `flow  (  "N" ,  "chromium" , x)`],
+  ])("should match %s", (_label, source) => {
+    expect(extractFlowMeta(source)).toEqual({
+      name: "N",
+      target: "chromium",
+    });
+  });
+
+  it.each([
+    ["workflow(", `workflow("N", "chromium", x)`],
+    ["myflow(", `myflow("N", "chromium", x)`],
+    ["_flow(", `_flow("N", "chromium", x)`],
+  ])("should not match %s", (_label, source) => {
+    expect(extractFlowMeta(source)).toEqual({
+      name: undefined,
+      target: undefined,
+    });
+  });
+});
+
+describe("extractFlowMeta — degenerate and dynamic arguments", () => {
+  it("should report an empty name as undefined so callers fall back to the filename", () => {
+    expect(extractFlowMeta(`flow("", "chromium", x)`)).toEqual({
+      name: undefined,
+      target: "chromium",
+    });
+  });
+
+  it("should preserve a whitespace-only name verbatim", () => {
+    expect(extractFlowMeta(`flow("   ", "chromium", x)`)).toEqual({
+      name: "   ",
+      target: "chromium",
+    });
+  });
+
+  it("should return no target when the target is a variable", () => {
+    expect(extractFlowMeta(`flow("N", myTarget, x)`)).toEqual({
+      name: "N",
+      target: undefined,
+    });
+  });
+
+  it("should return nothing when the name is a variable", () => {
+    expect(extractFlowMeta(`flow(myName, "chromium", x)`)).toEqual({
+      name: undefined,
+      target: undefined,
+    });
+  });
+});
+
+describe("extractFlowMeta — target in the options object", () => {
+  it.each([
+    ["bare key", `flow("N", { target: "chromium" }, x)`],
+    ["key after another", `flow("N", { launch: true, target: "chromium" }, x)`],
+    ["camelCase decoy", `flow("N", { myTarget: "no", target: "chromium" }, x)`],
+    [
+      "snake_case decoy",
+      `flow("N", { my_target: "no", target: "chromium" }, x)`,
+    ],
+    [
+      "decoy inside a string value",
+      `flow("N", { note: "target: no", target: "chromium" }, x)`,
+    ],
+  ])("should read the target from %s", (_label, source) => {
+    expect(extractFlowMeta(source)).toEqual({
+      name: "N",
+      target: "chromium",
+    });
+  });
+
+  it("should not read a target from an object outside the flow() call", () => {
+    expect(
+      extractFlowMeta(
+        `const opts = { target: "production" }; flow("My Flow", async () => {})`,
+      ),
+    ).toEqual({ name: "My Flow", target: undefined });
+  });
+});
+
+describe("extractFlowMeta — multiple flow() calls", () => {
+  it("should skip a flow( occurrence that is not followed by a name literal", () => {
+    expect(
+      extractFlowMeta(`// see flow(\nflow("Real", "chromium", x)`),
+    ).toEqual({ name: "Real", target: "chromium" });
+  });
+
+  it("should read a commented-out flow() call, which it cannot distinguish from code", () => {
+    expect(
+      extractFlowMeta(
+        `// flow("Commented", "firefox", x)\nflow("Real", "x", x)`,
+      ),
+    ).toEqual({ name: "Commented", target: "firefox" });
+  });
+
+  it("should take the name and target from the first call that supplies each", () => {
+    expect(extractFlowMeta(`flow("A", x)\nflow("B", "chromium", x)`)).toEqual({
+      name: "A",
+      target: "chromium",
+    });
+  });
+});

--- a/src/core/extractFlowMeta.test.ts
+++ b/src/core/extractFlowMeta.test.ts
@@ -41,6 +41,22 @@ describe("extractFlowMeta — quotes in the flow name", () => {
     ).toEqual({ name: String.raw`C:\Users share`, target: "Web - Chrome" });
   });
 
+  // A backslash before a line break is a line continuation: it lets the source
+  // span lines and contributes nothing to the value.
+  it("should drop a line continuation inside a name", () => {
+    expect(extractFlowMeta('flow("Say \\\nhi", "Web - Chrome", x)')).toEqual({
+      name: "Say hi",
+      target: "Web - Chrome",
+    });
+  });
+
+  it("should drop a CRLF line continuation inside a name", () => {
+    expect(extractFlowMeta('flow("Say \\\r\nhi", "Web - Chrome", x)')).toEqual({
+      name: "Say hi",
+      target: "Web - Chrome",
+    });
+  });
+
   // Only identity escapes are decoded. Names do not carry control or unicode
   // escapes, because the generator avoids escaping altogether by choosing a
   // delimiter the name does not contain.
@@ -91,6 +107,10 @@ describe("extractFlowMeta — callee matching", () => {
     ["workflow(", `workflow("N", "chromium", x)`],
     ["myflow(", `myflow("N", "chromium", x)`],
     ["_flow(", `_flow("N", "chromium", x)`],
+    // `$` and non-ASCII letters are valid in a JS identifier but are not \w,
+    // so a \b-based test reads these as a bare `flow(` call.
+    ["$flow(", `$flow("N", "chromium", x)`],
+    ["πflow(", `πflow("N", "chromium", x)`],
   ])("should not match %s", (_label, source) => {
     expect(extractFlowMeta(source)).toEqual({
       name: undefined,

--- a/src/core/flowCall.ts
+++ b/src/core/flowCall.ts
@@ -1,0 +1,109 @@
+import { readStringLiteral } from "~/core/stringLiteral.js";
+
+export type FlowCallMeta = {
+  name: string | undefined;
+  target: string | undefined;
+};
+
+// `\b` keeps `workflow(` and `myflow(` out while still allowing `obj.flow(`.
+const flowCallRe = /\bflow\s*\(\s*/g;
+// Sticky, so each is a check at one position rather than a search.
+const argSeparatorRe = /\s*,\s*/y;
+const keyValueRe = /\s*:\s*/y;
+const wordChar = /\w/;
+
+/**
+ * Reads `target` from the options object opening at `start`.
+ *
+ * Only the object's own keys count, so a `target` in a sub-object is ignored.
+ * Literals are skipped whole, so a brace or the word `target` inside a string
+ * value cannot be read as structure.
+ */
+function readTargetFromObject(
+  source: string,
+  start: number,
+): string | undefined {
+  let depth = 0;
+  let i = start;
+  while (i < source.length) {
+    const char = source.charAt(i);
+
+    if (char === "{") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (char === "}") {
+      depth--;
+      if (depth === 0) return undefined;
+      i++;
+      continue;
+    }
+
+    const literal = readStringLiteral(source, i);
+    if (literal) {
+      i = literal.end + 1;
+      continue;
+    }
+
+    // The required `:` rules out `targetish`, and the preceding character rules
+    // out `my_target`. charAt returns "" out of range, which never matches \w.
+    if (
+      depth === 1 &&
+      source.startsWith("target", i) &&
+      !wordChar.test(source.charAt(i - 1))
+    ) {
+      keyValueRe.lastIndex = i + "target".length;
+      if (keyValueRe.test(source)) {
+        return readStringLiteral(source, keyValueRe.lastIndex)?.value;
+      }
+    }
+
+    i++;
+  }
+  return undefined;
+}
+
+function readTarget(source: string, afterName: number): string | undefined {
+  argSeparatorRe.lastIndex = afterName;
+  if (!argSeparatorRe.test(source)) return undefined;
+
+  const argStart = argSeparatorRe.lastIndex;
+  if (source.charAt(argStart) === "{") {
+    return readTargetFromObject(source, argStart);
+  }
+  // `||`, not `??`: an empty target is no more useful than a missing one.
+  return readStringLiteral(source, argStart)?.value || undefined;
+}
+
+/**
+ * Extracts the static name and target from the first `flow()` call that
+ * supplies each.
+ *
+ * Name and target are resolved independently: a file whose first call omits the
+ * target still reports the target of a later call. That has been the behaviour
+ * since these were two separate regexes, and flows in the wild depend on it.
+ */
+export function parseFlowCall(source: string): FlowCallMeta {
+  let name: string | undefined;
+  let target: string | undefined;
+
+  for (const match of source.matchAll(flowCallRe)) {
+    const nameLiteral = readStringLiteral(
+      source,
+      match.index + match[0].length,
+    );
+    // A dynamic name hides the target too: without the end of the name there is
+    // no way to find the comma that separates them.
+    if (!nameLiteral) continue;
+
+    // An empty name is reported as absent so callers fall back to the filename.
+    if (name === undefined && nameLiteral.value !== "")
+      name = nameLiteral.value;
+    if (target === undefined) target = readTarget(source, nameLiteral.end + 1);
+
+    if (name !== undefined && target !== undefined) break;
+  }
+
+  return { name, target };
+}

--- a/src/core/flowCall.ts
+++ b/src/core/flowCall.ts
@@ -5,8 +5,10 @@ export type FlowCallMeta = {
   target: string | undefined;
 };
 
-// `\b` keeps `workflow(` and `myflow(` out while still allowing `obj.flow(`.
-const flowCallRe = /\bflow\s*\(\s*/g;
+// Keeps `workflow(`, `_flow(` and `$flow(` out while still allowing
+// `obj.flow(`. `\b` is not enough: it tests \w, which excludes `$` and every
+// non-ASCII letter, so `$flow(` and `πflow(` would read as a bare `flow(` call.
+const flowCallRe = /(?<![$\p{ID_Continue}])flow\s*\(\s*/gu;
 // Sticky, so each is a check at one position rather than a search.
 const argSeparatorRe = /\s*,\s*/y;
 const keyValueRe = /\s*:\s*/y;
@@ -82,7 +84,8 @@ function readTarget(source: string, afterName: number): string | undefined {
  *
  * Name and target are resolved independently: a file whose first call omits the
  * target still reports the target of a later call. That has been the behaviour
- * since these were two separate regexes, and flows in the wild depend on it.
+ * since these were two separate regexes. Resolving both from one call would
+ * silently drop such a file from the run, so the split is deliberate.
  */
 export function parseFlowCall(source: string): FlowCallMeta {
   let name: string | undefined;

--- a/src/core/flowCall.ts
+++ b/src/core/flowCall.ts
@@ -5,10 +5,10 @@ export type FlowCallMeta = {
   target: string | undefined;
 };
 
-// Keeps `workflow(`, `_flow(` and `$flow(` out while still allowing
-// `obj.flow(`. `\b` is not enough: it tests \w, which excludes `$` and every
-// non-ASCII letter, so `$flow(` and `πflow(` would read as a bare `flow(` call.
-const flowCallRe = /(?<![$\p{ID_Continue}])flow\s*\(\s*/gu;
+// Keeps `workflow(`, `_flow(`, `$flow(` and `this.#flow(` out while still
+// allowing `obj.flow(`. `\b` is not enough: it tests \w, which excludes `$`,
+// `#` and every non-ASCII letter, so those would read as a bare `flow(` call.
+const flowCallRe = /(?<![#$\p{ID_Continue}])flow\s*\(\s*/gu;
 // Sticky, so each is a check at one position rather than a search.
 const argSeparatorRe = /\s*,\s*/y;
 const keyValueRe = /\s*:\s*/y;

--- a/src/core/flowMeta.ts
+++ b/src/core/flowMeta.ts
@@ -1,5 +1,6 @@
 import { getWebBrowserInfo, parseExecutionTarget } from "@qawolf/flow-targets";
 import { basename } from "node:path";
+import { type FlowCallMeta, parseFlowCall } from "~/core/flowCall.js";
 import type { BrowserName } from "~/core/types.js";
 
 export function flowBasename(file: string): string {
@@ -61,37 +62,16 @@ export function isAndroidTarget(target: string): boolean {
   return classifyTarget(target)?.kind === "android";
 }
 
-// Matches the flow name — the first string literal argument to flow():
-//   flow("My Flow", ...)
-//        ^^^^^^^^^
-const nameRe = /\bflow\s*\(\s*["']([^"'\n]+)["']/;
+export type PeekFlowMetaFn = (filePath: string) => Promise<FlowCallMeta>;
 
-// Matches the browser target, scoped to the flow() call so a `target:` property
-// elsewhere in the file (e.g. in a config object) is not captured.
-// Two alternatives cover both call signatures:
-//
-//   Positional — second arg is a string literal (group 1):
-//     flow("My Flow", "chromium", async () => { ... })
-//                     ^^^^^^^^^
-//
-//   Object arg — second arg is an options object containing target (group 2):
-//     flow("My Flow", { target: "webkit", launch: true }, async () => { ... })
-//                               ^^^^^^^^
-//
-// Dynamic expressions (variables, template literals) produce undefined for that field.
-const flowTargetRe =
-  /\bflow\s*\(\s*["'][^"'\n]*["']\s*,\s*(?:["']([^"'\n]+)["']|\{[^{}]*\btarget\s*:\s*["']([^"'\n]+)["'])/;
-
-export type PeekFlowMetaFn = (
-  filePath: string,
-) => Promise<{ name: string | undefined; target: string | undefined }>;
-
-export function extractFlowMeta(source: string): {
-  name: string | undefined;
-  target: string | undefined;
-} {
-  const name = nameRe.exec(source)?.[1];
-  const flowTargetMatch = flowTargetRe.exec(source);
-  const target = flowTargetMatch?.[1] ?? flowTargetMatch?.[2];
-  return { name, target };
+/**
+ * Reads the name and target a flow declares, from either call shape:
+ *
+ *   flow("My Flow", "chromium", async () => { ... })
+ *   flow("My Flow", { target: "webkit", launch: true }, async () => { ... })
+ *
+ * Either field is undefined when the call does not state it statically.
+ */
+export function extractFlowMeta(source: string): FlowCallMeta {
+  return parseFlowCall(source);
 }

--- a/src/core/stringLiteral.ts
+++ b/src/core/stringLiteral.ts
@@ -1,0 +1,52 @@
+export type StringLiteral = {
+  /** The literal's runtime value, with escape sequences decoded. */
+  value: string;
+  /** Index of the closing delimiter. */
+  end: number;
+};
+
+/**
+ * Reads the static string literal opening at `start`.
+ *
+ * Returns undefined when `start` does not open a literal, when the literal is
+ * unterminated, or when it is a template literal containing `${...}` — an
+ * interpolated value is only known at runtime, so there is no static value to
+ * report.
+ */
+export function readStringLiteral(
+  source: string,
+  start: number,
+): StringLiteral | undefined {
+  const quote = source.charAt(start);
+  if (quote !== '"' && quote !== "'" && quote !== "`") return undefined;
+
+  let value = "";
+  let i = start + 1;
+  while (i < source.length) {
+    const char = source.charAt(i);
+
+    if (char === "\\") {
+      // Every escape we need is an identity escape — `\"`, `\'`, `` \` ``, `\\`
+      // — so the character after the backslash stands for itself. Control and
+      // unicode escapes are not decoded because names do not carry them: rather
+      // than escape, the generator picks a delimiter the name does not contain.
+      value += source.charAt(i + 1);
+      i += 2;
+      continue;
+    }
+
+    if (char === quote) return { value, end: i };
+
+    if (quote === "`") {
+      if (char === "$" && source.charAt(i + 1) === "{") return undefined;
+    } else if (char === "\n" || char === "\r") {
+      // A raw line break cannot appear in a quoted literal, so this is not one.
+      return undefined;
+    }
+
+    value += char;
+    i++;
+  }
+
+  return undefined;
+}

--- a/src/core/stringLiteral.ts
+++ b/src/core/stringLiteral.ts
@@ -26,11 +26,22 @@ export function readStringLiteral(
     const char = source.charAt(i);
 
     if (char === "\\") {
-      // Every escape we need is an identity escape — `\"`, `\'`, `` \` ``, `\\`
-      // — so the character after the backslash stands for itself. Control and
-      // unicode escapes are not decoded because names do not carry them: rather
-      // than escape, the generator picks a delimiter the name does not contain.
-      value += source.charAt(i + 1);
+      const escaped = source.charAt(i + 1);
+
+      // A line continuation lets the literal span lines and contributes
+      // nothing to the value.
+      if (escaped === "\n" || escaped === "\r") {
+        const crlf = escaped === "\r" && source.charAt(i + 2) === "\n";
+        i += crlf ? 3 : 2;
+        continue;
+      }
+
+      // Every other escape we need is an identity escape — `\"`, `\'`,
+      // `` \` ``, `\\` — so the character stands for itself. Control and
+      // unicode escapes are not decoded because names do not carry them:
+      // rather than escape, the generator picks a delimiter the name does not
+      // contain.
+      value += escaped;
       i += 2;
       continue;
     }

--- a/src/core/stringLiteral.ts
+++ b/src/core/stringLiteral.ts
@@ -5,6 +5,8 @@ export type StringLiteral = {
   end: number;
 };
 
+const lineTerminator = /[\n\r\u2028\u2029]/;
+
 /**
  * Reads the static string literal opening at `start`.
  *
@@ -29,8 +31,9 @@ export function readStringLiteral(
       const escaped = source.charAt(i + 1);
 
       // A line continuation lets the literal span lines and contributes
-      // nothing to the value.
-      if (escaped === "\n" || escaped === "\r") {
+      // nothing to the value. Every line terminator counts, U+2028 and U+2029
+      // included.
+      if (lineTerminator.test(escaped)) {
         const crlf = escaped === "\r" && source.charAt(i + 2) === "\n";
         i += crlf ? 3 : 2;
         continue;
@@ -52,6 +55,8 @@ export function readStringLiteral(
       if (char === "$" && source.charAt(i + 1) === "{") return undefined;
     } else if (char === "\n" || char === "\r") {
       // A raw line break cannot appear in a quoted literal, so this is not one.
+      // U+2028 and U+2029 are excluded on purpose: they are line terminators,
+      // but ES2019 onwards allows them unescaped inside a quoted literal.
       return undefined;
     }
 


### PR DESCRIPTION
> [!NOTE]
> Body drafted with AI & edited as needed

### Overview of Changes

`extractFlowMeta` matched the flow name with `/\bflow\s*\(\s*["']([^"'\n]+)["']/`. The character class `[^"'\n]` excludes **both** quote characters, whatever quote opened the literal. A double quoted name therefore stopped at an apostrophe, and a single quoted name stopped at a double quote.

A generator that meets a `"` in a name emits single quote delimiters to avoid escaping, which produces valid source the CLI could not read:

```js
export default flow(
  'Open the "Settings" tab',   // valid TypeScript
  "Web - Chrome",              // ← never reached
```

- **`src/core/stringLiteral.ts`** (new) — reads one static string literal. Tracks the opening delimiter, steps over `\`-escapes, and supports backticks. Returns `undefined` for `${...}` interpolation and for a raw line break in a quoted literal.
- **`src/core/flowCall.ts`** (new) — `parseFlowCall`. Walks `flow(` candidates, reads the name literal, then the positional or object target. The object scan tracks brace depth and skips string literals whole, so a brace or the word `target` inside a string value cannot be read as structure.
- **`src/core/flowMeta.ts`** — drops both regexes; `extractFlowMeta` now delegates. No consumer changed.
- **`src/core/extractFlowMeta.test.ts`** (new) — 28 tests.
- **`.changeset/flow-name-quotes.md`** (new) — patch.

### Testing
- 28 unit tests; 1675 in the full suite; lint, format, typecheck and knip clean.
- A 21-case behavioural probe run against the old and new implementations produced **identical output** on every pre-existing case.
- End-to-end against the built CLI: pre-fix reports `No flows matched.` (exit 0); post-fix reports `Running 1 flow`, launches chromium, and passes (exit 0). Verified headed.

### Checklist

- [x] Tests added for the new behaviour
- [x] Existing behaviour pinned by characterization tests
- [x] Changeset added
- [x] `lint`, `format`, `typecheck`, `knip` pass
- [x] No client-identifying names in source, tests, or changeset
