### PR TITLE
fix(flows): ignore node_modules when discovering flow files

### DIFF
--- a/.changeset/ignore-node-modules.md
+++ b/.changeset/ignore-node-modules.md
@@ -1,0 +1,11 @@
+---
+"@qawolf/cli": patch
+---
+
+The CLI no longer finds flow files in `node_modules`.
+
+The default pattern is `**/*.flow.{ts,js}`. Some packages use `.flow.js` for a different purpose, because it is also the file name convention of the Facebook Flow type checker. The CLI read these files and showed them as flows. `qawolf flows list` showed a flow for each one. The name came from the file name, because the file has no `flow()` call.
+
+The CLI now ignores `node_modules` when it looks for flow files. The search is also much faster, because a dependency tree contains most of the files in a project.
+
+This does not change how a flow finds a package. A flow that imports a package continues to work.

--- a/src/domains/flows/expand.test.ts
+++ b/src/domains/flows/expand.test.ts
@@ -260,4 +260,37 @@ describe("expandPatterns", () => {
       await rm(tmp, { recursive: true, force: true });
     }
   });
+
+  // `.flow.js` is also the Facebook Flow convention for type-annotated source,
+  // so published packages ship files that match the default pattern.
+  it("should not discover flow files inside node_modules", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "expand-nodemodules-"));
+    const dep = join(tmp, "node_modules", "ssf");
+    await mkdir(dep, { recursive: true });
+    await writeFile(join(dep, "ssf.flow.js"), "// vendored");
+    await writeFile(join(tmp, "mine.flow.ts"), "// mine");
+    try {
+      const result = await expandPatterns([], tmp, undefined, defaultFs);
+      expect(result).toEqual([join(tmp, "mine.flow.ts")]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("should not discover flow files in a nested node_modules of a .qawolf env", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "expand-envnm-"));
+    const env = join(tmp, ".qawolf", "staging");
+    await mkdir(join(env, "node_modules", "cfb"), { recursive: true });
+    await writeFile(
+      join(env, "node_modules", "cfb", "xlscfb.flow.js"),
+      "// vendored",
+    );
+    await writeFile(join(env, "mine.flow.ts"), "// mine");
+    try {
+      const result = await expandPatterns([], tmp, undefined, defaultFs);
+      expect(result).toEqual([join(env, "mine.flow.ts")]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/domains/flows/expand.ts
+++ b/src/domains/flows/expand.ts
@@ -43,6 +43,12 @@ export async function expandPatterns(
     const matches = await glob(effectivePatterns, {
       cwd: root,
       absolute: true,
+      // Some packages use `.flow.js` for a different purpose. It is also the
+      // file name convention of the Facebook Flow type checker. For example,
+      // `xlsx` installs two such files. A dependency tree does not contain
+      // the flows of the project. It contains most of the files in a project.
+      // Thus this also makes the search much faster.
+      ignore: ["**/node_modules/**"],
     });
     for (const match of matches) {
       // tinyglobby emits forward slashes even on win32; the rest of the CLI


### PR DESCRIPTION
> [!NOTE]
> This description was drafted by AI and edited as needed.
>
> Fixes [WIZ-11598](https://linear.app/qawolf/issue/WIZ-11598).

### Overview of Changes

`expandPatterns` passes no `ignore` to tinyglobby, so the default pattern `**/*.flow.{ts,js}` descends into `node_modules`. `.flow.js` is also the Facebook Flow convention for type-annotated source, so published packages ship files that match — `xlsx` installs two, through `cfb` and `ssf`. The names are invented by `list.ts:52` — `meta.name ?? flowBasename(file)` — which falls back to the filename because neither file contains a `flow()` call to read a name from:

```json
{"file":"node_modules/cfb/xlscfb.flow.js","name":"xlscfb","tags":[]}
{"file":"node_modules/ssf/ssf.flow.js","name":"ssf","tags":[]}
```

`flows run` discards them, because no `flow()` call means no target, and `run.ts:31` skips a flow without one. That skip is silent, which is why this has gone unreported.

- **`src/domains/flows/expand.ts`** — adds `ignore: ["**/node_modules/**"]` to the glob. The same option, for the same reason, is already at `src/shell/interactiveRunner/collectRunFiles.ts:43`.
- **`src/domains/flows/expand.test.ts`** — two cases: a top-level `node_modules`, and one nested in a `.qawolf/<env>` dir.
- **`.changeset/ignore-node-modules.md`** — patch.

`expandPatterns` has a single `glob()` call and is the shared entry point for `flows run`, `flows list`, `install browsers`, `install android`, `install all` and `doctor`, so one option covers all six.

### Testing

- 1649 in the full suite; lint, format, typecheck and knip clean.
- Checked against a real project: the two vendored files no longer appear, and every genuine flow is still discovered.
- The glob walk dropped from ~22 ms to ~1 ms (median of five runs), since it no longer descends the dependency tree.
- A flow importing `xlsx` runs and passes, as above.

The second test is the one that matters: `resolveGlobRoots` globs each `.qawolf/<env>` dir as its own root, so a fix that only worked from `cwd` would pass the first test and still leak.

### Checklist

- [x] Tests added, written before the fix
- [x] Changeset added
- [x] `lint`, `format`, `typecheck`, `knip` pass
- [x] Confirmed flows that import packages still work
- [x] No client-identifying details in source, tests, changeset or description
