### PR TITLE
feat(cli): add issue addFlows command via contracts 0.26.0

### DIFF
--- a/.changeset/issue-add-flows-command.md
+++ b/.changeset/issue-add-flows-command.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+The new command `qawolf issue addFlows` adds flows to a coverage request. Flows that the coverage request already covers stay covered.
+
+You cannot add flows to a bug report or a maintenance report. These reports link to flows through the runs that reproduce them.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.25.0",
+        "@qawolf/api-contracts": "0.26.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -448,7 +448,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.25.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-uSx9ZiyUMwYyi2J/aUm/pX/DOAmuI8iD5UOwCxNWj1WRTfMvlqMgSg4yvhEW7DpyTItNC7RsDzWfEo4YWmEjsQ=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.26.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-GchQXFIjEfoo0QpWKx/iy0Co7i75GU/3Obb+30xTTzizPQB3ynJGsxX9gomL05BLIQzWwPahtspaIuueLiQJ0g=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.25.0",
+    "@qawolf/api-contracts": "0.26.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -133,6 +133,7 @@ current branch.
 | `qawolf install android` | local | Install Android system images, AVDs, and the Appium driver used by the project's Android flows |
 | `qawolf install browsers` | local | Install Playwright browsers used by the project's web flows |
 | `qawolf install clear` | local | Remove the managed runtime cache (all installed runtime versions) |
+| `qawolf issue addFlows` | write | Add flows to a coverage request owned by the caller's team. Flows already covered stay covered. Bug and maintenance reports link to flows through the runs that reproduce them, so their flows cannot be set directly. |
 | `qawolf issue create` | write | Create a bug or coverage request issue for the caller's team. Maintenance issues cannot be created through the public API. |
 | `qawolf issue find` | read | List the team's bug reports, maintenance reports, or coverage requests, newest first. |
 | `qawolf issue get` | read | Get an issue by id. |


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

Bumps `@qawolf/api-contracts` from 0.25.0 to 0.26.0.
- **`package.json` / `bun.lock`**: `@qawolf/api-contracts` 0.25.0 → 0.26.0. Exact pin, matching the rest of the dependency block.
- **`skills/qawolf-cli/SKILL.md`**: regenerated by `bun run generate`, which is already wired into the `typecheck` and `test` scripts. Adds the `qawolf issue addFlows` row to the command table.
- **`.changeset/issue-add-flows-command.md`**: new, `minor` — a new user-facing command rather than a fix.

The generated command:

```
qawolf issue addFlows --issue-id <value> --flow-ids <values...>
```

Worth knowing: the contract's input schema does not discriminate on issue type. `issueId` accepts any issue id. The "coverage requests only" rule is enforced by the platform, so passing a bug report or maintenance report id passes client side validation and is rejected server side. Bug and maintenance reports link to flows through the runs that reproduce them, so their flows are not directly settable currently. 

# Testing

```bash
bun run typecheck
bun run test
bun run lint
bun run format:check
bun run knip
```

- 1686 tests pass across 231 files, 0 fail. No test changes were needed — the generated command is covered by the existing `src/commands/publicApi/index.test.ts` registration tests.
- `qawolf issue addFlows --help` renders the description and both flags correctly, confirming the generator derived `--flow-ids <values...>` and `--issue-id <value>` from the Zod input schema.
- Endpoint surface diffed between 0.25.0 and 0.26.0 to confirm `issue.addFlows` is the only delta.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
