### PR TITLE
refactor(runner): move the runner group to success/failure outcomes, rename stop -> terminate, update to use runner family

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.26.0",
+        "@qawolf/api-contracts": "0.27.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.26.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-GchQXFIjEfoo0QpWKx/iy0Co7i75GU/3Obb+30xTTzizPQB3ynJGsxX9gomL05BLIQzWwPahtspaIuueLiQJ0g=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.27.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-LeAhmB1CGbj1UUdC/wkIhzktPTxOE5w+vcHhjEsYIWFXDpw+jM+l2BQmfxYloLEZTlvv1FPCDTU5fCMLx52epw=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.26.0",
+    "@qawolf/api-contracts": "0.27.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -148,7 +148,7 @@ current branch.
 | `qawolf runner launch` | write | Launch an interactive runner and make it this directory's default |
 | `qawolf runner run` | write | Run a flow on an interactive runner, shipping the current directory's files with it |
 | `qawolf runner screenshot` | read | Save a JPEG of an interactive runner's screen to a file |
-| `qawolf runner stop` | write | Stop an interactive runner |
+| `qawolf runner terminate` | write | End an interactive runner, and the pod it runs on with it |
 | `qawolf tag create` | write | Create a tag on the caller's team. Tags select flows in run.create. |
 | `qawolf tag list` | read | List the team's tags, alphabetical by name. Tag names select flows in run.create. |
 

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -53,7 +53,7 @@ An interactive runner is a live pod holding a browser, and it is billed while it
 runs. `qawolf runner launch` starts one; `qawolf runner run` starts one too when
 no runner is already available, and says so when it does. Reading a runner
 counts as activity, so `qawolf runner events --follow` left open keeps it alive
-and billing. `qawolf runner stop` is what ends it, so stop a runner you launched
+and billing. `qawolf runner terminate` is what ends it, so terminate a runner you launched
 rather than leaving it to time out.
 
 `qawolf runner launch` remembers its runner as this directory's default, so the
@@ -164,7 +164,8 @@ call the QA Wolf API and require auth.
 The `runner` commands drive a live cloud browser: `launch` one, `screenshot` to
 see it, `act` to click and type, `run` a flow on it, `exec` a snippet against its
 page, `events` to read its journal (including the `recorder` stream, which turns
-your actions into Playwright locators), `keepalive` to hold it open, and `stop`
+your actions into Playwright locators), `keepalive` to hold it open, and
+`terminate`
 when done. Everything is a plain request to one host, so a shell with an API key
 and its own vision model can close the see-and-act loop with no other tooling.
 

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -9,7 +9,7 @@ plain request to one host, so there is no connection to hold open.
 Runner ids are yours to choose and are scoped to your team, so `agent-1` is a
 fine id. Launching an id that is already running attaches to that runner instead
 of starting and billing a second one, and the answer says which happened: read
-`outcome` for `launched` or `already-running`. Reusing one id is therefore the
+`alreadyRunning`. Reusing one id is therefore the
 cheap and safe pattern, and the same id with a different `--name` is refused
 rather than silently ignored.
 
@@ -38,8 +38,8 @@ nothing is signed in, and no page is open. Acting as though your earlier setup
 survived is the single most likely way to drive the wrong page.
 
 No `read` command ever launches a runner. `screenshot`, `events` and `keepalive`
-tell you there is no runner rather than quietly billing one, and so does `stop`,
-since starting a pod in order to stop it would be absurd.
+tell you there is no runner rather than quietly billing one, and so does
+`terminate`, since starting a pod in order to end it would be absurd.
 
 ## The order that matters
 
@@ -71,7 +71,7 @@ Retry on the exit code, not on the message text:
   persists past a few tries, relaunch the id.
 - `2` will not clear on its own. Either nothing has run on this runner yet, so
   run a flow, or the runner has no browser at all, so launch with
-  `--name node20WithPlaywright` instead. The message says which.
+  `--name playwright` instead. The message says which.
 
 The one exception is `exec`, which reports both as `4`; read its message to tell
 them apart.
@@ -157,7 +157,7 @@ so the snippet can use your own page objects and helpers.
 request. The runner holds no copy of your project, so what runs is exactly what
 is on disk at that moment, uncommitted edits included. A `package.json` has to
 be there, since the run reads its npm dependencies from it, and the files may
-carry at most 4 MiB in total: run from a directory holding the flow and what it
+carry at most 30 MiB in total: run from a directory holding the flow and what it
 imports rather than from the root of a large monorepo. A missing file, a missing
 `package.json` and files over the cap are all refused before any runner is
 resolved or launched, so a typo costs nothing.
@@ -264,7 +264,7 @@ pod that is gone. It resets the clock and tells you the runner is still there.
 
 It is listed as a `read`, but it is the one read with a cost: keeping the clock
 reset keeps a billed pod alive. Call it while you are genuinely still working, not
-on a timer you forget, and call `qawolf runner stop` when you are done rather
+on a timer you forget, and call `qawolf runner terminate` when you are done rather
 than leaving a pod to time out. A loop that keeps a runner alive and never stops
 it bills until someone notices.
 
@@ -277,7 +277,7 @@ the screen, so it is not optional even though the goal here is to drive by hand.
 export QAWOLF_API_KEY=...          # the only credential
 export QAWOLF_RUNNER_ID=agent-1    # so no command below needs --runner
 
-qawolf runner launch --id agent-1 --json          # --id, not the variable; read .outcome
+qawolf runner launch --id agent-1 --json          # --id, not the variable; read .alreadyRunning
 qawolf runner run flows/smoke.flow.ts --follow    # starts the screen; exit 1 if it failed
 
 qawolf runner act navigate --url https://example.com/login
@@ -286,5 +286,5 @@ qawolf runner act click --button left --x 480 --y 260
 qawolf runner act type --text "someone@example.com"
 
 qawolf runner events recorder --tail 5 | jq -r '[.locator] + (.alternates // []) | @tsv'
-qawolf runner stop
+qawolf runner terminate
 ```

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -272,7 +272,8 @@ Options:
 Commands:
   launch [options]           Launch an interactive runner and make it this
                              directory's default
-  stop [options]             Stop an interactive runner
+  terminate [options]        End an interactive runner, and the pod it runs on
+                             with it
   keepalive [options]        Reset a runner's inactivity clock, for a caller
                              that pauses between actions
   run [options] <file>       Run a flow on an interactive runner, shipping the
@@ -298,21 +299,21 @@ exports[`--help output qawolf runner launch 1`] = `
 Launch an interactive runner and make it this directory's default
 
 Options:
-  --id <id>       Id to launch under. Relaunching an id attaches to that runner
-  --name <image>  Runner image to run, e.g. node20WithPlaywright
-  -h, --help      display help for command
+  --id <id>        Id to launch under. Relaunching an id attaches to that runner
+  --name <family>  Runner family to run, e.g. playwright
+  -h, --help       display help for command
 
 Examples:
   $ qawolf runner launch
-  $ qawolf runner launch --name node20WithAndroid
+  $ qawolf runner launch --name android
   $ qawolf runner launch --id ci
 "
 `;
 
-exports[`--help output qawolf runner stop 1`] = `
-"Usage: qawolf runner stop [options]
+exports[`--help output qawolf runner terminate 1`] = `
+"Usage: qawolf runner terminate [options]
 
-Stop an interactive runner
+End an interactive runner, and the pod it runs on with it
 
 Options:
   --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -86,8 +86,8 @@ describe("--help output", () => {
     expect(helpFor("runner", "launch")).toMatchSnapshot();
   });
 
-  it("qawolf runner stop", () => {
-    expect(helpFor("runner", "stop")).toMatchSnapshot();
+  it("qawolf runner terminate", () => {
+    expect(helpFor("runner", "terminate")).toMatchSnapshot();
   });
 
   it("qawolf runner run", () => {
@@ -129,7 +129,7 @@ describe("--help output", () => {
       ["flows", "pull"],
       ["runner"],
       ["runner", "launch"],
-      ["runner", "stop"],
+      ["runner", "terminate"],
       ["runner", "run"],
       ["runner", "events"],
       ["runner", "keepalive"],

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -53,7 +53,7 @@ An interactive runner is a live pod holding a browser, and it is billed while it
 runs. `qawolf runner launch` starts one; `qawolf runner run` starts one too when
 no runner is already available, and says so when it does. Reading a runner
 counts as activity, so `qawolf runner events --follow` left open keeps it alive
-and billing. `qawolf runner stop` is what ends it, so stop a runner you launched
+and billing. `qawolf runner terminate` is what ends it, so terminate a runner you launched
 rather than leaving it to time out.
 
 `qawolf runner launch` remembers its runner as this directory's default, so the
@@ -119,7 +119,8 @@ call the QA Wolf API and require auth.
 The `runner` commands drive a live cloud browser: `launch` one, `screenshot` to
 see it, `act` to click and type, `run` a flow on it, `exec` a snippet against its
 page, `events` to read its journal (including the `recorder` stream, which turns
-your actions into Playwright locators), `keepalive` to hold it open, and `stop`
+your actions into Playwright locators), `keepalive` to hold it open, and
+`terminate`
 when done. Everything is a plain request to one host, so a shell with an API key
 and its own vision model can close the see-and-act loop with no other tooling.
 

--- a/src/commands/runner/lifecycle.register.ts
+++ b/src/commands/runner/lifecycle.register.ts
@@ -4,7 +4,7 @@ import { declareCommandKind } from "~/commands/commandKind.js";
 import { withAuthContext } from "~/commands/context.js";
 import { handleRunnerKeepalive } from "~/domains/interactiveRunner/keepalive.js";
 import { handleRunnerLaunch } from "~/domains/interactiveRunner/launch.js";
-import { handleRunnerStop } from "~/domains/interactiveRunner/stop.js";
+import { handleRunnerTerminate } from "~/domains/interactiveRunner/terminate.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
 import { runnerDeps, runnerFlagDescription } from "./context.js";
@@ -12,7 +12,7 @@ import { runnerDeps, runnerFlagDescription } from "./context.js";
 const launchExamples = `
 Examples:
   $ qawolf runner launch
-  $ qawolf runner launch --name node20WithAndroid
+  $ qawolf runner launch --name android
   $ qawolf runner launch --id ci`;
 
 const keepaliveExamples = `
@@ -32,7 +32,7 @@ export function registerRunnerLifecycleCommands(
       "--id <id>",
       "Id to launch under. Relaunching an id attaches to that runner",
     )
-    .option("--name <image>", "Runner image to run, e.g. node20WithPlaywright")
+    .option("--name <family>", "Runner family to run, e.g. playwright")
     .addHelpText("after", launchExamples)
     .action((opts: { id?: string; name?: string }, command: Command) =>
       withAuthContext(signals, (ctx) =>
@@ -44,12 +44,12 @@ export function registerRunnerLifecycleCommands(
       )(opts, command),
     );
 
-  declareCommandKind(runner.command("stop"), "write")
-    .description("Stop an interactive runner")
+  declareCommandKind(runner.command("terminate"), "write")
+    .description("End an interactive runner, and the pod it runs on with it")
     .option("--runner <id>", runnerFlagDescription)
     .action((opts: { runner?: string }, command: Command) =>
       withAuthContext(signals, (ctx) =>
-        handleRunnerStop(ctx, { runner: opts.runner }, runnerDeps(ctx)),
+        handleRunnerTerminate(ctx, { runner: opts.runner }, runnerDeps(ctx)),
       )(opts, command),
     );
 

--- a/src/core/interactiveRunner/runFiles.test.ts
+++ b/src/core/interactiveRunner/runFiles.test.ts
@@ -26,8 +26,12 @@ describe("checkRunFiles", () => {
   // still encode to more than a runner accepts. Refused here so the caller is told
   // which cap it broke rather than handed an opaque transport failure.
   it("refuses files that encode to more than a runner accepts", () => {
+    // A fifth of the content cap, so the six-fold inflation lands past the
+    // encoded cap whatever the two caps are set to.
     const escapeHeavy = {
-      "data.json": String.fromCharCode(1).repeat(2 * 1024 * 1024),
+      "data.json": String.fromCharCode(1).repeat(
+        Math.ceil(maxRunFilesByteLength / 5),
+      ),
     };
     const files = { ...packageJson, ...flow, ...escapeHeavy };
 

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -18,7 +18,7 @@ export const interactiveRunnerMessages = {
   defaultNotRemembered: (id: string) =>
     `Runner ${id} could not be written to .qawolf as this directory's default, so later commands will not find it on their own. Pass --runner ${id}, or set QAWOLF_RUNNER_ID=${id}.`,
   defaultNotForgotten: (id: string) =>
-    `Runner ${id} was stopped, but it could not be removed from .qawolf as this directory's default, so later commands will still be sent to it. Pass --runner, or launch a new runner.`,
+    `Runner ${id} was terminated, but it could not be removed from .qawolf as this directory's default, so later commands will still be sent to it. Pass --runner, or launch a new runner.`,
   fileNotCollected: (path: string) =>
     `"${path}" is not one of the files that travel to a runner. It must be inside the current directory and end in .ts, .tsx, .js, .mjs, .cjs or .json.`,
   fileUnreadable: (path: string, reason: string) =>
@@ -40,16 +40,16 @@ export const interactiveRunnerMessages = {
   launchFailed: (id: string, error: string) =>
     `Launching runner ${id} failed. ${error}`,
   launchLost: (id: string, error: string) =>
-    `Launching runner ${id} failed. ${error}. The request may still have reached QA Wolf and started a runner, so relaunch the same id with qawolf runner launch --id ${id} to attach to it rather than start a second one, or stop it with qawolf runner stop --runner ${id}.`,
+    `Launching runner ${id} failed. ${error}. The request may still have reached QA Wolf and started a runner, so relaunch the same id with qawolf runner launch --id ${id} to attach to it rather than start a second one, or terminate it with qawolf runner terminate --runner ${id}.`,
   launched: (id: string) => `Launched runner ${id}.`,
   launchedForCommand: (id: string) =>
-    `No runner was given, so launched ${id} for this command. Its browser is fresh: nothing has been run on it and nothing is signed in. It bills until it is stopped or idles out, so stop it with qawolf runner stop --runner ${id} when you are done.`,
+    `No runner was given, so launched ${id} for this command. Its browser is fresh: nothing has been run on it and nothing is signed in. It bills until it is terminated or idles out, so terminate it with qawolf runner terminate --runner ${id} when you are done.`,
   followEventsTimedOut: (stream: string, seconds: number) =>
     `Stopped following ${stream} after ${formatSeconds(seconds * 1000)}: reading keeps the runner alive and billing, so a follow does not run unbounded. Pass --timeout to wait longer, or follow again to continue.`,
   followEndCutShort:
     "The run settled, but the last window of its followed streams could not be read, so the output above may be missing its final lines.",
   followTimedOut: (runId: string, runnerId: string, seconds: number) =>
-    `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and stop the runner with qawolf runner stop --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
+    `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and terminate the runner with qawolf runner terminate --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
   needsFullSync: (missingPaths: readonly string[]) =>
     `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -50,11 +50,13 @@ export const interactiveRunnerMessages = {
     "The run settled, but the last window of its followed streams could not be read, so the output above may be missing its final lines.",
   followTimedOut: (runId: string, runnerId: string, seconds: number) =>
     `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and stop the runner with qawolf runner stop --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
+  needsFullSync: (missingPaths: readonly string[]) =>
+    `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
   noRunnerIdForScreenshot: `${noRunnerId} A screenshot also needs a screen, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
   noRunnerId,
-  notRunning: (id: string) => `Runner ${id} was not running.`,
+  wasNotRunning: (id: string) => `Runner ${id} was not running.`,
   runFailed: (errorMessage: string | undefined) =>
     errorMessage === undefined
       ? "The run failed and reported no reason."
@@ -63,11 +65,15 @@ export const interactiveRunnerMessages = {
   runPassed: "The run passed.",
   runSettledUnknown: (status: string) =>
     `The run settled as "${status}", which this version of the CLI does not recognize. Upgrade to read it.`,
+  actionAnsweredUnknown: (failureReason: string) =>
+    `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
+  screenshotAnsweredUnknown: (failureReason: string) =>
+    `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
   runSubmitAnsweredUnknown: (outcome: string) =>
     `The runner answered the submission with "${outcome}", which this version of the CLI does not recognize. Upgrade to read it.`,
   runSubmitted: (runId: string) => `Submitted run ${runId}.`,
   runnerHasNoScreen:
-    "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a node20WithPlaywright runner instead.",
+    "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a playwright runner instead.",
   runnerHasNoScreenToEvaluate:
     "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until a run opens one, so run a flow on it with qawolf runner run first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
   runnerUnreachable:
@@ -98,7 +104,7 @@ export const interactiveRunnerMessages = {
     'Nothing arrived on stdin. Pipe the action in, or name the action type instead of "-".',
   stdinEmptySnippet:
     'Nothing arrived on stdin. Pipe the snippet in, or name a file instead of "-".',
-  stopped: (id: string) => `Stopped runner ${id}.`,
+  terminated: (id: string) => `Terminated runner ${id}.`,
   requestTooLarge: (byteLength: number, maxByteLength: number) =>
     `The run request encodes to ${String(byteLength)} bytes, over the ${String(maxByteLength)} a runner accepts. Escaping inflates file content, so a set of files inside the content cap can still encode to more than this. Run from a directory holding only the flow and what it imports.`,
   unknownStream: (stream: string, known: readonly string[]) =>

--- a/src/domains/interactiveRunner/evaluateSnippet.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.test.ts
@@ -222,7 +222,7 @@ describe("handleRunnerExec", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-unreachable" },
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
     });
 
     const result = await handleRunnerExec(
@@ -232,7 +232,7 @@ describe("handleRunnerExec", () => {
     );
 
     expect(result?.error).toContain("no live page");
-    // A fresh node20WithPlaywright runner does run a browser, so telling the
+    // A fresh playwright runner does run a browser, so telling the
     // caller to check the image would send them after the wrong thing.
     expect(result?.error).toContain("run a flow on it with qawolf runner run");
     expect(result?.error).toContain("not proof the snippet did not run");

--- a/src/domains/interactiveRunner/evaluateSnippet.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.ts
@@ -114,7 +114,8 @@ export async function handleRunnerExec(
     return { ...failureFields(result), exitCode: exitCodes.network };
   }
 
-  if (result.value.outcome === "runner-unreachable") {
+  if (result.value.outcome === "failure") {
+    result.value.failureReason satisfies "runner-unreachable";
     return {
       error: interactiveRunnerMessages.runnerHasNoScreenToEvaluate,
       exitCode: exitCodes.network,

--- a/src/domains/interactiveRunner/followRun.test.ts
+++ b/src/domains/interactiveRunner/followRun.test.ts
@@ -100,7 +100,7 @@ describe("followRun", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-unreachable" },
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
     });
 
     const result = await follow(ctx);

--- a/src/domains/interactiveRunner/journal.testUtils.ts
+++ b/src/domains/interactiveRunner/journal.testUtils.ts
@@ -48,7 +48,7 @@ export function makeJournal(
     if (scripted === "unreachable") {
       return Promise.resolve({
         ok: true,
-        value: { outcome: "runner-unreachable" },
+        value: { failureReason: "runner-unreachable", outcome: "failure" },
       });
     }
 

--- a/src/domains/interactiveRunner/keepalive.test.ts
+++ b/src/domains/interactiveRunner/keepalive.test.ts
@@ -63,7 +63,7 @@ describe("handleRunnerKeepalive", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-unreachable" },
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
     });
 
     const result = await handleRunnerKeepalive(

--- a/src/domains/interactiveRunner/launch.test.ts
+++ b/src/domains/interactiveRunner/launch.test.ts
@@ -8,8 +8,9 @@ import { runnerCallOptions } from "./runnerCallOptions.js";
 const launched = {
   gpuAccelerated: false,
   id: "cli-minted",
-  outcome: "launched" as const,
-  runnerName: "node20WithPlaywright" as const,
+  alreadyRunning: false as const,
+  outcome: "success" as const,
+  runnerName: "playwright" as const,
 };
 
 describe("handleRunnerLaunch", () => {
@@ -34,18 +35,18 @@ describe("handleRunnerLaunch", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { ...launched, id: "ci", runnerName: "node20WithAndroid" },
+      value: { ...launched, id: "ci", runnerName: "android" },
     });
 
     await handleRunnerLaunch(
       ctx,
-      { id: "ci", name: "node20WithAndroid" },
+      { id: "ci", name: "android" },
       makeTestDeps(),
     );
 
     expect(callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.runner.launch,
-      { id: "ci", runnerName: "node20WithAndroid" },
+      { id: "ci", runnerName: "android" },
       runnerCallOptions,
     );
   });
@@ -56,7 +57,12 @@ describe("handleRunnerLaunch", () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { ...launched, id: "ci", outcome: "already-running" },
+      value: {
+        ...launched,
+        id: "ci",
+        alreadyRunning: true,
+        outcome: "success",
+      },
     });
 
     await handleRunnerLaunch(
@@ -127,7 +133,7 @@ describe("handleRunnerLaunch", () => {
   it("forgets the id and gives no relaunch advice when the launch was refused", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
-      error: "runner ci is already running node20Basic",
+      error: "runner ci is already running basic",
       ok: false,
     });
     const deps = makeTestDeps();
@@ -138,7 +144,7 @@ describe("handleRunnerLaunch", () => {
       deps,
     );
 
-    expect(result?.error).toContain("already running node20Basic");
+    expect(result?.error).toContain("already running basic");
     expect(result?.error).not.toContain("relaunch");
     expect(await deps.store.readDefaultRunnerId()).toBeUndefined();
   });
@@ -151,17 +157,17 @@ describe("handleRunnerLaunch", () => {
     callPublicApi.mockResolvedValue({
       error: "QA Wolf API runner.launch request failed (HTTP 409).",
       errorBody:
-        "runner ci is already running node20Basic; stop it before launching node20WithAndroid",
+        "runner ci is already running basic; stop it before launching android",
       ok: false,
     });
 
     const result = await handleRunnerLaunch(
       ctx,
-      { id: "ci", name: "node20WithAndroid" },
+      { id: "ci", name: "android" },
       makeTestDeps(),
     );
 
-    expect(result?.errorBody).toContain("already running node20Basic");
+    expect(result?.errorBody).toContain("already running basic");
     expect(result?.exitCode).toBe(4);
   });
 

--- a/src/domains/interactiveRunner/launch.ts
+++ b/src/domains/interactiveRunner/launch.ts
@@ -2,6 +2,7 @@ import {
   type RunnerNameForPublicApi,
   publicContractsV1,
 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
 
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import type {
@@ -18,12 +19,7 @@ import type { InteractiveRunnerDeps } from "./deps.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 import { parseRunnerId, parseRunnerName } from "./runnerIds.js";
 
-type LaunchedRunner = {
-  gpuAccelerated: boolean;
-  id: string;
-  outcome: "launched" | "already-running";
-  runnerName: RunnerNameForPublicApi;
-};
+type LaunchedRunner = z.output<typeof publicContractsV1.runner.launch.output>;
 
 type LaunchFailure = PlatformFailure & { ok: false; exitCode: number };
 
@@ -31,8 +27,8 @@ type LaunchResult = { ok: true; value: LaunchedRunner } | LaunchFailure;
 
 /**
  * Launches a runner under `id`, or attaches to the one already running there.
- * The distinction is in `outcome`, and every caller passes it on: an agent about
- * to drive a browser needs to know whether it is looking at a fresh one.
+ * `alreadyRunning` tells them apart, and every caller passes it on: an agent
+ * driving a browser needs to know whether it is looking at a fresh one.
  */
 async function launchRunner(
   ctx: AuthCommandContext,
@@ -142,9 +138,9 @@ export async function handleRunnerLaunch(
 
   ctx.ui.output(
     launched.value,
-    launched.value.outcome === "launched"
-      ? interactiveRunnerMessages.launched(launched.value.id)
-      : interactiveRunnerMessages.alreadyRunning(launched.value.id),
+    launched.value.alreadyRunning
+      ? interactiveRunnerMessages.alreadyRunning(launched.value.id)
+      : interactiveRunnerMessages.launched(launched.value.id),
   );
   return undefined;
 }

--- a/src/domains/interactiveRunner/performAction.outcomes.test.ts
+++ b/src/domains/interactiveRunner/performAction.outcomes.test.ts
@@ -28,18 +28,19 @@ async function actWith(value: unknown) {
 
 describe("handleRunnerAct outcomes", () => {
   it("reports the action it performed", async () => {
-    const { outputs, result } = await actWith({ outcome: "performed" });
+    const { outputs, result } = await actWith({ outcome: "success" });
 
     expect(result).toBeUndefined();
     expect(outputs()[0]?.humanMessage).toBe("Performed click.");
-    expect(outputs()[0]?.data).toMatchObject({ outcome: "performed" });
+    expect(outputs()[0]?.data).toMatchObject({ outcome: "success" });
   });
 
   // Attempted and did not take effect: an answer, not a fault on our side.
   it("reports what stopped an action that reached the runner", async () => {
     const { result } = await actWith({
       errorMessage: "the page navigated away",
-      outcome: "action-failed",
+      failureReason: "action-failed",
+      outcome: "failure",
     });
 
     expect(result?.error).toContain("the page navigated away");
@@ -49,7 +50,10 @@ describe("handleRunnerAct outcomes", () => {
   // Not a wait: only a run starts the desktop, so a caller that retries this one
   // retries for ever.
   it("reads a screen that has never started as needing a run, not a retry", async () => {
-    const { result } = await actWith({ outcome: "screen-needs-a-run" });
+    const { result } = await actWith({
+      failureReason: "screen-needs-a-run",
+      outcome: "failure",
+    });
 
     expect(result?.error).toContain("qawolf runner run");
     expect(result?.exitCode).toBe(2);
@@ -57,7 +61,10 @@ describe("handleRunnerAct outcomes", () => {
 
   // Transient, and worth trying again in a second or two.
   it("reads a screen that is not up yet as worth retrying", async () => {
-    const { result } = await actWith({ outcome: "screen-not-ready" });
+    const { result } = await actWith({
+      failureReason: "screen-not-ready",
+      outcome: "failure",
+    });
 
     expect(result?.error).toContain("Retry in a second or two");
     expect(result?.exitCode).toBe(4);
@@ -65,17 +72,23 @@ describe("handleRunnerAct outcomes", () => {
 
   // Permanent, and the caller's to fix by launching a different image.
   it("reads a runner with no screen as never going to work", async () => {
-    const { result } = await actWith({ outcome: "runner-has-no-screen" });
+    const { result } = await actWith({
+      failureReason: "runner-has-no-screen",
+      outcome: "failure",
+    });
 
     expect(result?.error).toContain("Retrying will never help");
-    expect(result?.error).toContain("node20WithPlaywright");
+    expect(result?.error).toContain("playwright");
     expect(result?.exitCode).toBe(2);
   });
 
   // Alone among these verbs, this one may have taken effect before its answer was
   // lost, so the message must not read as an invitation to repeat the click.
   it("does not invite a bare repeat when the answer was lost", async () => {
-    const { result } = await actWith({ outcome: "runner-unreachable" });
+    const { result } = await actWith({
+      failureReason: "runner-unreachable",
+      outcome: "failure",
+    });
 
     expect(result?.error).toContain(
       "does not mean the action was not performed",

--- a/src/domains/interactiveRunner/performAction.test.ts
+++ b/src/domains/interactiveRunner/performAction.test.ts
@@ -83,7 +83,7 @@ describe("handleRunnerAct", () => {
       const { callPublicApi, ctx } = makeAuthCtx();
       callPublicApi.mockResolvedValue({
         ok: true,
-        value: { outcome: "performed" },
+        value: { outcome: "success" },
       });
 
       const result = await handleRunnerAct(
@@ -166,7 +166,7 @@ describe("handleRunnerAct", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "performed" },
+      value: { outcome: "success" },
     });
 
     await handleRunnerAct(

--- a/src/domains/interactiveRunner/performAction.ts
+++ b/src/domains/interactiveRunner/performAction.ts
@@ -97,19 +97,21 @@ export async function handleRunnerAct(
     };
   }
 
-  switch (result.value.outcome) {
-    case "performed":
-      ctx.ui.output(
-        { action: built.action, outcome: "performed" },
-        interactiveRunnerMessages.actionPerformed(built.action.type),
-      );
-      return undefined;
+  if (result.value.outcome === "success") {
+    ctx.ui.output(
+      { action: built.action, outcome: "success" },
+      interactiveRunnerMessages.actionPerformed(built.action.type),
+    );
+    return undefined;
+  }
+
+  const failure = result.value;
+  const { failureReason } = failure;
+  switch (failureReason) {
     // Attempted and did not take effect, which is an answer rather than a fault.
     case "action-failed":
       return {
-        error: interactiveRunnerMessages.actionFailed(
-          result.value.errorMessage,
-        ),
+        error: interactiveRunnerMessages.actionFailed(failure.errorMessage),
         exitCode: exitCodes.testFailure,
       };
     case "screen-needs-a-run":
@@ -134,5 +136,12 @@ export async function handleRunnerAct(
         error: interactiveRunnerMessages.actionMayHaveHappened,
         exitCode: exitCodes.network,
       };
+    default: {
+      failureReason satisfies never;
+      return {
+        error: interactiveRunnerMessages.actionAnsweredUnknown(failureReason),
+        exitCode: exitCodes.network,
+      };
+    }
   }
 }

--- a/src/domains/interactiveRunner/readJournal.ts
+++ b/src/domains/interactiveRunner/readJournal.ts
@@ -76,7 +76,8 @@ export async function readJournal(
       type: "failed",
     };
   }
-  if (result.value.outcome === "runner-unreachable") {
+  if (result.value.outcome === "failure") {
+    result.value.failureReason satisfies "runner-unreachable";
     return { type: "unreachable" };
   }
   return { type: "read", value: result.value };

--- a/src/domains/interactiveRunner/resolveRunner.test.ts
+++ b/src/domains/interactiveRunner/resolveRunner.test.ts
@@ -10,8 +10,9 @@ import { runnerCallOptions } from "./runnerCallOptions.js";
 const launched = {
   gpuAccelerated: false,
   id: "cli-minted",
-  outcome: "launched" as const,
-  runnerName: "node20WithPlaywright" as const,
+  alreadyRunning: false as const,
+  outcome: "success" as const,
+  runnerName: "playwright" as const,
 };
 
 describe("resolveRunner", () => {
@@ -170,7 +171,7 @@ describe("resolveRunner", () => {
     callPublicApi.mockResolvedValue({
       error: "QA Wolf API runner.launch request failed (HTTP 409).",
       errorBody:
-        "runner cli-minted is already running node20Basic; stop it before launching node20WithAndroid",
+        "runner cli-minted is already running basic; stop it before launching android",
       ok: false,
     });
 
@@ -182,7 +183,7 @@ describe("resolveRunner", () => {
 
     expect(
       resolved.type === "failed" ? resolved.errorBody : undefined,
-    ).toContain("already running node20Basic");
+    ).toContain("already running basic");
     expect(resolved).toMatchObject({ exitCode: 4, type: "failed" });
   });
 

--- a/src/domains/interactiveRunner/runFlow.follow.test.ts
+++ b/src/domains/interactiveRunner/runFlow.follow.test.ts
@@ -4,7 +4,7 @@ import { handleRunnerRun } from "./runFlow.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 import { makeJournal } from "./journal.testUtils.js";
 
-const submitted = { outcome: "submitted" as const, runId: "run-a" };
+const submitted = { outcome: "success" as const, runId: "run-a" };
 
 const runFollowing = (
   ctx: ReturnType<typeof makeAuthCtx>["ctx"],
@@ -139,8 +139,9 @@ describe("handleRunnerRun --follow", () => {
         value: {
           gpuAccelerated: false,
           id: "cli-minted",
-          outcome: "launched",
-          runnerName: "node20WithPlaywright",
+          alreadyRunning: false,
+          outcome: "success",
+          runnerName: "playwright",
         },
       })
       .mockImplementation((contract, input) =>
@@ -176,7 +177,13 @@ describe("handleRunnerRun --follow", () => {
         anchorReads++;
         return Promise.resolve(
           anchorReads === 1
-            ? { ok: true, value: { outcome: "runner-unreachable" } }
+            ? {
+                ok: true,
+                value: {
+                  failureReason: "runner-unreachable",
+                  outcome: "failure",
+                },
+              }
             : {
                 ok: true,
                 value: {
@@ -206,7 +213,7 @@ describe("handleRunnerRun --follow", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-unreachable" },
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
     });
 
     const result = await runFollowing(ctx, { recorderEvents: true });

--- a/src/domains/interactiveRunner/runFlow.test.ts
+++ b/src/domains/interactiveRunner/runFlow.test.ts
@@ -5,7 +5,7 @@ import { handleRunnerRun } from "./runFlow.js";
 import { makeAuthCtx, makeTestDeps, testCwd } from "./deps.testUtils.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 
-const submitted = { outcome: "submitted" as const, runId: "run-a" };
+const submitted = { outcome: "success" as const, runId: "run-a" };
 
 async function runWith(
   value: unknown,
@@ -114,20 +114,24 @@ describe("handleRunnerRun", () => {
 
   it("names both images when the runner is the wrong one for the flow", async () => {
     const { result } = await runWith({
-      outcome: "runner-target-mismatch",
-      requiredRunnerName: "node20WithAndroid",
-      runnerName: "node20WithPlaywright",
+      failureReason: "runner-target-mismatch",
+      outcome: "failure",
+      requiredRunnerName: "android",
+      runnerName: "playwright",
     });
 
-    expect(result?.error).toContain("node20WithAndroid");
-    expect(result?.error).toContain("node20WithPlaywright");
+    expect(result?.error).toContain("android");
+    expect(result?.error).toContain("playwright");
     expect(result?.exitCode).toBe(2);
   });
 
   // Resubmitting would bill a second run, so the message says to read the
   // journal rather than to retry.
   it("does not invite a retry when the submission answer was lost", async () => {
-    const { result } = await runWith({ outcome: "runner-unreachable" });
+    const { result } = await runWith({
+      failureReason: "runner-unreachable",
+      outcome: "failure",
+    });
 
     expect(result?.error).toContain("does not mean the run did not start");
     expect(result?.exitCode).toBe(4);
@@ -166,8 +170,9 @@ describe("handleRunnerRun", () => {
         value: {
           gpuAccelerated: false,
           id: "cli-minted",
-          outcome: "launched",
-          runnerName: "node20WithPlaywright",
+          alreadyRunning: false,
+          outcome: "success",
+          runnerName: "playwright",
         },
       })
       .mockResolvedValueOnce({ ok: true, value: submitted });

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -17,6 +17,7 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 import { collectRunFiles } from "./collectFiles.js";
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRecorderAnchor } from "./followPrinters.js";
+import { describeRunSubmitFailure } from "./runSubmitFailure.js";
 import { followRun } from "./followRun.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
@@ -82,67 +83,53 @@ export async function handleRunnerRun(
     return { ...failureFields(result), exitCode: exitCodes.network };
   }
 
-  switch (result.value.outcome) {
-    case "runner-target-mismatch":
-      return {
-        error: interactiveRunnerMessages.targetMismatch(
-          result.value.runnerName,
-          result.value.requiredRunnerName,
-        ),
-        exitCode: exitCodes.invalidArgs,
-      };
-    case "runner-unreachable":
-      // Never a retry suggestion: the run may have started and been too slow to
-      // say so, and running the flow again would bill a second one.
-      return {
-        error: interactiveRunnerMessages.submitMayHaveStarted,
-        exitCode: exitCodes.network,
-      };
-    case "submitted": {
-      const runId = result.value.runId;
-      // The stream flags imply --follow: each only chooses what a follow
-      // prints, so alone it can only mean "follow, with that stream".
-      const follow =
-        options.follow ||
-        options.logs ||
-        options.runEvents ||
-        options.recorderEvents;
-      if (!follow) {
-        ctx.ui.output(
-          { runId, runnerId: resolved.runnerId },
-          interactiveRunnerMessages.runSubmitted(runId),
-        );
-        return undefined;
-      }
-      // A diagnostic while following, not the command's output: what stdout
-      // carries then is the run's journal entries, and a differently shaped
-      // object among them leaves a reader of the stream sniffing keys to tell
-      // which lines are log entries.
-      ctx.ui.info(interactiveRunnerMessages.runSubmitted(runId));
-      return followRun(
-        ctx,
-        {
-          logs: options.logs,
-          recorderSinceSequence,
-          runEvents: options.runEvents,
-          runId,
-          runnerId: resolved.runnerId,
-          timeoutSeconds: timeout.seconds,
-        },
-        deps,
-      );
-    }
+  const { outcome } = result.value;
+  switch (outcome) {
+    case "failure":
+      return describeRunSubmitFailure(result.value);
+    case "success":
+      break;
     // An outcome added to the contract must not fall through to exit 0: today
-    // the response schema refuses one this version does not know, and this
-    // keeps a future contracts bump a compile error rather than a silent pass.
-    default: {
-      result.value satisfies never;
+    // the response schema refuses one this version does not know, and this keeps
+    // a future contracts bump a compile error rather than a silent pass.
+    default:
+      outcome satisfies never;
       return {
-        error: interactiveRunnerMessages.runSubmitAnsweredUnknown(
-          String((result.value as { outcome: string }).outcome),
-        ),
+        error: interactiveRunnerMessages.runSubmitAnsweredUnknown(outcome),
         exitCode: exitCodes.network,
       };
-    }
   }
+
+  const runId = result.value.runId;
+  // The stream flags imply --follow: each only chooses what a follow prints, so
+  // alone it can only mean "follow, with that stream".
+  const follow =
+    options.follow ||
+    options.logs ||
+    options.runEvents ||
+    options.recorderEvents;
+  if (!follow) {
+    ctx.ui.output(
+      { runId, runnerId: resolved.runnerId },
+      interactiveRunnerMessages.runSubmitted(runId),
+    );
+    return undefined;
+  }
+  // A diagnostic while following, not the command's output: what stdout carries
+  // then is the run's journal entries, and a differently shaped object among
+  // them leaves a reader of the stream sniffing keys to tell which lines are log
+  // entries.
+  ctx.ui.info(interactiveRunnerMessages.runSubmitted(runId));
+  return followRun(
+    ctx,
+    {
+      logs: options.logs,
+      recorderSinceSequence,
+      runEvents: options.runEvents,
+      runId,
+      runnerId: resolved.runnerId,
+      timeoutSeconds: timeout.seconds,
+    },
+    deps,
+  );
 }

--- a/src/domains/interactiveRunner/runSubmitFailure.ts
+++ b/src/domains/interactiveRunner/runSubmitFailure.ts
@@ -1,0 +1,53 @@
+import type { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
+
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type { CommandResult } from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+
+type RunSubmitFailure = Extract<
+  z.output<typeof publicContractsV1.runner.runFlow.output>,
+  { outcome: "failure" }
+>;
+
+/** Why a submission was refused, and what the caller should do about it. */
+export function describeRunSubmitFailure(
+  failure: RunSubmitFailure,
+): CommandResult {
+  const { failureReason } = failure;
+  switch (failureReason) {
+    case "runner-target-mismatch":
+      return {
+        error: interactiveRunnerMessages.targetMismatch(
+          failure.runnerName,
+          failure.requiredRunnerName,
+        ),
+        exitCode: exitCodes.invalidArgs,
+      };
+    // Unreachable until a request carries unchangedFiles, and reported rather
+    // than retried. A full request cannot be answered with this, so a caller
+    // seeing it has hit something other than a stale baseline.
+    case "needs-full-sync":
+      return {
+        error: interactiveRunnerMessages.needsFullSync(failure.missingPaths),
+        exitCode: exitCodes.network,
+      };
+    // Never a retry suggestion. The run may have started and been too slow to
+    // say so, and running the flow again would bill a second one.
+    case "runner-unreachable":
+      return {
+        error: interactiveRunnerMessages.submitMayHaveStarted,
+        exitCode: exitCodes.network,
+      };
+    // Reported rather than passed over, for the reason handleRunnerRun gives
+    // about an unknown outcome.
+    default: {
+      failureReason satisfies never;
+      return {
+        error:
+          interactiveRunnerMessages.runSubmitAnsweredUnknown(failureReason),
+        exitCode: exitCodes.network,
+      };
+    }
+  }
+}

--- a/src/domains/interactiveRunner/takeScreenshot.test.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.test.ts
@@ -16,7 +16,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { imageJpegBase64, outcome: "captured" },
+      value: { imageJpegBase64, outcome: "success" },
     });
     const deps = makeTestDeps();
 
@@ -39,7 +39,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { imageJpegBase64, outcome: "captured" },
+      value: { imageJpegBase64, outcome: "success" },
     });
 
     await handleRunnerScreenshot(
@@ -50,7 +50,7 @@ describe("handleRunnerScreenshot", () => {
 
     expect(outputs()[0]?.humanMessage).toContain("screens/step-3.jpg");
     expect(outputs()[0]?.data).toEqual({
-      outcome: "captured",
+      outcome: "success",
       path: "screens/step-3.jpg",
     });
   });
@@ -60,7 +60,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "screen-needs-a-run" },
+      value: { failureReason: "screen-needs-a-run", outcome: "failure" },
     });
     const deps = makeTestDeps();
 
@@ -80,7 +80,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "screen-not-ready" },
+      value: { failureReason: "screen-not-ready", outcome: "failure" },
     });
     const deps = makeTestDeps();
 
@@ -100,7 +100,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-has-no-screen" },
+      value: { failureReason: "runner-has-no-screen", outcome: "failure" },
     });
 
     const result = await handleRunnerScreenshot(
@@ -136,7 +136,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { imageJpegBase64, outcome: "captured" },
+      value: { imageJpegBase64, outcome: "success" },
     });
     const deps = makeTestDeps();
     await deps.store.writeDefaultRunnerId("from-store");
@@ -154,7 +154,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { outcome: "runner-unreachable" },
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
     });
     const deps = makeTestDeps();
 
@@ -174,7 +174,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { imageJpegBase64, outcome: "captured" },
+      value: { imageJpegBase64, outcome: "success" },
     });
 
     const result = await handleRunnerScreenshot(
@@ -199,7 +199,7 @@ describe("handleRunnerScreenshot", () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { imageJpegBase64: "", outcome: "captured" },
+      value: { imageJpegBase64: "", outcome: "success" },
     });
     const deps = makeTestDeps();
 

--- a/src/domains/interactiveRunner/takeScreenshot.ts
+++ b/src/domains/interactiveRunner/takeScreenshot.ts
@@ -54,34 +54,36 @@ export async function handleRunnerScreenshot(
     return { ...failureFields(result), exitCode: exitCodes.network };
   }
 
-  switch (result.value.outcome) {
-    case "captured": {
-      const written = await deps.writeScreenshot({
-        imageJpegBase64: result.value.imageJpegBase64,
-        path: options.out,
-      });
-      // A payload that is not an image is the API's to fix, not the caller's;
-      // a path that cannot be written is the other way round.
-      if (!written.ok) {
-        return written.reason === "not-a-jpeg"
-          ? {
-              error: interactiveRunnerMessages.screenshotNotAnImage,
-              exitCode: exitCodes.network,
-            }
-          : {
-              error: interactiveRunnerMessages.screenshotUnwritable(
-                options.out,
-                written.detail,
-              ),
-              exitCode: exitCodes.invalidArgs,
-            };
-      }
-      ctx.ui.output(
-        { outcome: "captured", path: options.out },
-        interactiveRunnerMessages.screenshotWritten(options.out),
-      );
-      return undefined;
+  if (result.value.outcome === "success") {
+    const written = await deps.writeScreenshot({
+      imageJpegBase64: result.value.imageJpegBase64,
+      path: options.out,
+    });
+    // A payload that is not an image is the API's to fix, not the caller's;
+    // a path that cannot be written is the other way round.
+    if (!written.ok) {
+      return written.reason === "not-a-jpeg"
+        ? {
+            error: interactiveRunnerMessages.screenshotNotAnImage,
+            exitCode: exitCodes.network,
+          }
+        : {
+            error: interactiveRunnerMessages.screenshotUnwritable(
+              options.out,
+              written.detail,
+            ),
+            exitCode: exitCodes.invalidArgs,
+          };
     }
+    ctx.ui.output(
+      { outcome: "success", path: options.out },
+      interactiveRunnerMessages.screenshotWritten(options.out),
+    );
+    return undefined;
+  }
+
+  const { failureReason } = result.value;
+  switch (failureReason) {
     // Permanent until the caller acts, so not a retry: only a run starts the
     // desktop, and waiting is what a caller does with `screen-not-ready`.
     case "screen-needs-a-run":
@@ -107,5 +109,13 @@ export async function handleRunnerScreenshot(
         error: interactiveRunnerMessages.runnerUnreachable,
         exitCode: exitCodes.network,
       };
+    default: {
+      failureReason satisfies never;
+      return {
+        error:
+          interactiveRunnerMessages.screenshotAnsweredUnknown(failureReason),
+        exitCode: exitCodes.network,
+      };
+    }
   }
 }

--- a/src/domains/interactiveRunner/terminate.test.ts
+++ b/src/domains/interactiveRunner/terminate.test.ts
@@ -1,50 +1,50 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import { describe, expect, it } from "bun:test";
 
-import { handleRunnerStop } from "./stop.js";
+import { handleRunnerTerminate } from "./terminate.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 
-describe("handleRunnerStop", () => {
-  it("stops the runner the flag names", async () => {
+describe("handleRunnerTerminate", () => {
+  it("terminates the runner the flag names", async () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { id: "ci", outcome: "stopped" },
+      value: { id: "ci", outcome: "success", wasRunning: true },
     });
 
     expect(
-      await handleRunnerStop(ctx, { runner: "ci" }, makeTestDeps()),
+      await handleRunnerTerminate(ctx, { runner: "ci" }, makeTestDeps()),
     ).toBeUndefined();
 
     expect(callPublicApi).toHaveBeenCalledWith(
-      publicContractsV1.runner.stop,
+      publicContractsV1.runner.terminate,
       { id: "ci" },
       runnerCallOptions,
     );
-    expect(outputs()[0]?.humanMessage).toContain("Stopped runner ci");
+    expect(outputs()[0]?.humanMessage).toContain("Terminated runner ci");
   });
 
-  // A retried stop should read as plainly as the first, which is why the
+  // A retried terminate should read as plainly as the first, which is why the
   // contract answers rather than raises.
   it("reports a runner that was not running without failing", async () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { id: "ci", outcome: "not-running" },
+      value: { id: "ci", outcome: "success", wasRunning: false },
     });
 
     expect(
-      await handleRunnerStop(ctx, { runner: "ci" }, makeTestDeps()),
+      await handleRunnerTerminate(ctx, { runner: "ci" }, makeTestDeps()),
     ).toBeUndefined();
     expect(outputs()[0]?.humanMessage).toContain("was not running");
   });
 
-  // Launching a runner in order to stop it would bill one for nothing.
+  // Launching a runner in order to terminate it would bill one for nothing.
   it("never launches a runner, and says what to do instead", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
 
-    const result = await handleRunnerStop(
+    const result = await handleRunnerTerminate(
       ctx,
       { runner: undefined },
       makeTestDeps(),
@@ -55,45 +55,45 @@ describe("handleRunnerStop", () => {
     expect(callPublicApi).not.toHaveBeenCalled();
   });
 
-  it("stops the stored default, and stops sending later commands to it", async () => {
+  it("terminates the stored default, and stops sending later commands to it", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { id: "ci", outcome: "stopped" },
+      value: { id: "ci", outcome: "success", wasRunning: true },
     });
     const deps = makeTestDeps();
     await deps.store.writeDefaultRunnerId("ci");
 
-    await handleRunnerStop(ctx, { runner: undefined }, deps);
+    await handleRunnerTerminate(ctx, { runner: undefined }, deps);
 
     expect(await deps.store.readDefaultRunnerId()).toBeUndefined();
   });
 
-  it("leaves the stored default alone when it stopped a different runner", async () => {
+  it("leaves the stored default alone when it terminated a different runner", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { id: "other", outcome: "stopped" },
+      value: { id: "other", outcome: "success", wasRunning: true },
     });
     const deps = makeTestDeps();
     await deps.store.writeDefaultRunnerId("ci");
 
-    await handleRunnerStop(ctx, { runner: "other" }, deps);
+    await handleRunnerTerminate(ctx, { runner: "other" }, deps);
 
     expect(await deps.store.readDefaultRunnerId()).toBe("ci");
   });
 
-  // The pod is what costs money, and by this point it is already stopped. A
+  // The pod is what costs money, and by this point it is already gone. A
   // directory the CLI cannot write to must not turn that into a failed command.
-  it("still reports the stop when the stored default cannot be cleared", async () => {
+  it("still reports the terminate when the stored default cannot be cleared", async () => {
     const { callPublicApi, ctx, outputs } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: { id: "ci", outcome: "stopped" },
+      value: { id: "ci", outcome: "success", wasRunning: true },
     });
     const deps = makeTestDeps();
 
-    const result = await handleRunnerStop(
+    const result = await handleRunnerTerminate(
       ctx,
       { runner: "ci" },
       {
@@ -106,7 +106,7 @@ describe("handleRunnerStop", () => {
     );
 
     expect(result).toBeUndefined();
-    expect(outputs()[0]?.humanMessage).toContain("Stopped runner ci");
+    expect(outputs()[0]?.humanMessage).toContain("Terminated runner ci");
     expect(ctx.ui.warn).toHaveBeenCalled();
   });
 });

--- a/src/domains/interactiveRunner/terminate.ts
+++ b/src/domains/interactiveRunner/terminate.ts
@@ -12,13 +12,13 @@ import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRunner } from "./resolveRunner.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 
-export async function handleRunnerStop(
+export async function handleRunnerTerminate(
   ctx: AuthCommandContext,
   options: { runner: string | undefined },
   deps: InteractiveRunnerDeps,
 ): Promise<CommandResult> {
-  // Never launches: starting a runner in order to stop it would bill one for
-  // nothing, so a caller with no runner is told rather than served.
+  // Never launches: starting a runner in order to terminate it would bill one
+  // for nothing, so a caller with no runner is told rather than served.
   const resolved = await resolveRunner(
     ctx,
     { autoLaunch: false, runner: options.runner },
@@ -29,7 +29,7 @@ export async function handleRunnerStop(
   }
 
   const result = await ctx.platformClient.callPublicApi(
-    publicContractsV1.runner.stop,
+    publicContractsV1.runner.terminate,
     {
       id: resolved.runnerId,
     },
@@ -58,9 +58,9 @@ export async function handleRunnerStop(
 
   ctx.ui.output(
     result.value,
-    result.value.outcome === "stopped"
-      ? interactiveRunnerMessages.stopped(result.value.id)
-      : interactiveRunnerMessages.notRunning(result.value.id),
+    result.value.wasRunning
+      ? interactiveRunnerMessages.terminated(result.value.id)
+      : interactiveRunnerMessages.wasNotRunning(result.value.id),
   );
   return undefined;
 }

--- a/src/domains/publicApi/skippedContracts.ts
+++ b/src/domains/publicApi/skippedContracts.ts
@@ -5,23 +5,27 @@
 // serves it, and until then stays out and lets the generator report what it
 // cannot express.
 //
-// The whole `runner.*` family is hand-written as `qawolf runner`. Three of its
-// inputs carry a file list or an action union and have no flag shape at all, and
-// the four that do need UX the generator cannot give them: an optional
-// `--runner` resolved from flag, environment and stored default; a runner
-// launched on demand and announced; a screenshot decoded into a file. Half the
-// group generated beside the other half hand-written would read as two unrelated
-// command sets sharing a prefix. The group is claimed as a whole here, so the
-// contracts whose commands land in a later change are absent rather than
-// generated in a shape the rest of the group does not match.
+// The whole `runner.*` family is hand-written as `qawolf runner`, and the whole
+// family is listed. Some of these inputs carry a file list or an action union and
+// have no flag shape at all; the ones that do need UX the generator cannot give
+// them, such as an optional `--runner` resolved from flag, environment and stored
+// default, a runner launched on demand and announced, a screenshot decoded into a
+// file, and one verb served as three subcommands. Half the group generated beside
+// the other half hand-written would read as two unrelated command sets sharing a
+// prefix. The group is claimed as a whole here, so the contracts whose commands
+// land in a later change are absent rather than generated in a shape the rest of
+// the group does not match.
 /** Every contract the generator passes over. */
 export const skippedContractNames: ReadonlySet<string> = new Set([
   "flow.list",
   "runner.evaluateSnippet",
+  "runner.importPackage",
+  "runner.inspect",
   "runner.launch",
   "runner.performAction",
   "runner.readJournal",
   "runner.runFlow",
-  "runner.stop",
+  "runner.stopRun",
   "runner.takeScreenshot",
+  "runner.terminate",
 ]);


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.27.0` reshaped every published runner verb at once. All seven moved to a `success`/`failure` outcome vocabulary keyed by `failureReason`, `runner.stop` became `runner.terminate`, three verbs were added (`stopRun`, `inspect`, `importPackage`), and runner names have been renamed to families so `node20WithPlaywright` is now `playwright` etc.

- [x] Pin `@qawolf/api-contracts` to `0.27.0`
- [x] Move all eight runner handlers to the `success`/`failure` outcome vocabulary, keying each failure on `failureReason`
- [x] Rename `stop.ts` to `terminate.ts` and the `runner stop` command to `runner terminate`, since `publicContractsV1.runner.stop` no longer exists
- [x] Read `alreadyRunning` and `wasRunning` where the outcome literals they replace used to be read
- [x] Derive `LaunchedRunner` from the contract's own output so it cannot drift from what `runner.launch` answers
- [x] Move `runFlow`'s failure mapping into `runSubmitFailure.ts`, with no change to what it does
- [x] Guard both `outcome` and `failureReason` against values this version does not know, so a later contracts bump is a compile error rather than a silent exit 0
- [x] Narrow those guards through an aliased discriminant, which drops the `as` cast the old one needed
- [x] Claim the whole `runner.*` family in `skippedContractNames`, so the generator mints no command that collides with a hand-written one and documents none in a shape the group does not match
- [x] Rename runner names to families across help text, messages, examples and tests
- [x] Scope that rename to the public-contract surface, leaving the local `flows run` engine on its own `@qawolf/flow-targets` name
- [x] Update `references/runner.md` for `terminate`, the 30 MiB payload cap and `alreadyRunning`
- [x] Derive `runFiles.test.ts`'s oversize fixture from the cap, so the raise from 4 MiB to 30 MiB cannot rot it again
- [x] Move roughly 70 assertion sites across 21 test files to the new shapes


### Breaking Changes

- `qawolf runner stop` is now `qawolf runner terminate`
-  `--name` takes a family (`playwright`, `android`, `ios`, `basic`) rather than an image name.

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1697 pass  0 fail`. The other five give exit 0.

- `bun run generate` produces exactly one line of change, the `terminate` rename in `SKILL.md`, and no camelCase rows, which is what confirms the skip list works.
- `qawolf runner --help` lists `terminate` and not `stop`, and `qawolf runner stop --help` falls back to the group help.
- Added lines, excluding `bun.lock` and snapshots: 329, under the 400 warning threshold in `scripts/check-pr-size.sh`.
