### PR TITLE
feat(runner): add stop-run to stop a run without ending the runner

### DIFF
--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -148,6 +148,7 @@ current branch.
 | `qawolf runner launch` | write | Launch an interactive runner and make it this directory's default |
 | `qawolf runner run` | write | Run a flow on an interactive runner, shipping the current directory's files with it |
 | `qawolf runner screenshot` | read | Save a JPEG of an interactive runner's screen to a file |
+| `qawolf runner stop-run` | write | Stop what a runner is currently executing, leaving the runner up |
 | `qawolf runner terminate` | write | End an interactive runner, and the pod it runs on with it |
 | `qawolf tag create` | write | Create a tag on the caller's team. Tags select flows in run.create. |
 | `qawolf tag list` | read | List the team's tags, alphabetical by name. Tag names select flows in run.create. |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -274,6 +274,8 @@ Commands:
                              directory's default
   terminate [options]        End an interactive runner, and the pod it runs on
                              with it
+  stop-run [options]         Stop what a runner is currently executing, leaving
+                             the runner up
   keepalive [options]        Reset a runner's inactivity clock, for a caller
                              that pauses between actions
   run [options] <file>       Run a flow on an interactive runner, shipping the
@@ -314,6 +316,18 @@ exports[`--help output qawolf runner terminate 1`] = `
 "Usage: qawolf runner terminate [options]
 
 End an interactive runner, and the pod it runs on with it
+
+Options:
+  --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                 directory's stored runner
+  -h, --help     display help for command
+"
+`;
+
+exports[`--help output qawolf runner stop-run 1`] = `
+"Usage: qawolf runner stop-run [options]
+
+Stop what a runner is currently executing, leaving the runner up
 
 Options:
   --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -90,6 +90,10 @@ describe("--help output", () => {
     expect(helpFor("runner", "terminate")).toMatchSnapshot();
   });
 
+  it("qawolf runner stop-run", () => {
+    expect(helpFor("runner", "stop-run")).toMatchSnapshot();
+  });
+
   it("qawolf runner run", () => {
     expect(helpFor("runner", "run")).toMatchSnapshot();
   });
@@ -130,6 +134,7 @@ describe("--help output", () => {
       ["runner"],
       ["runner", "launch"],
       ["runner", "terminate"],
+      ["runner", "stop-run"],
       ["runner", "run"],
       ["runner", "events"],
       ["runner", "keepalive"],

--- a/src/commands/runner/lifecycle.register.ts
+++ b/src/commands/runner/lifecycle.register.ts
@@ -4,6 +4,7 @@ import { declareCommandKind } from "~/commands/commandKind.js";
 import { withAuthContext } from "~/commands/context.js";
 import { handleRunnerKeepalive } from "~/domains/interactiveRunner/keepalive.js";
 import { handleRunnerLaunch } from "~/domains/interactiveRunner/launch.js";
+import { handleRunnerStopRun } from "~/domains/interactiveRunner/stopRun.js";
 import { handleRunnerTerminate } from "~/domains/interactiveRunner/terminate.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
@@ -50,6 +51,17 @@ export function registerRunnerLifecycleCommands(
     .action((opts: { runner?: string }, command: Command) =>
       withAuthContext(signals, (ctx) =>
         handleRunnerTerminate(ctx, { runner: opts.runner }, runnerDeps(ctx)),
+      )(opts, command),
+    );
+
+  declareCommandKind(runner.command("stop-run"), "write")
+    .description(
+      "Stop what a runner is currently executing, leaving the runner up",
+    )
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { runner?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerStopRun(ctx, { runner: opts.runner }, runnerDeps(ctx)),
       )(opts, command),
     );
 

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -76,6 +76,10 @@ export const interactiveRunnerMessages = {
     "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a playwright runner instead.",
   runnerHasNoScreenToEvaluate:
     "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until a run opens one, so run a flow on it with qawolf runner run first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
+  runStopped: (id: string) =>
+    `Stopped the run on runner ${id}. The runner is still up, on whatever page the run reached.`,
+  nothingToStop: (id: string) =>
+    `Runner ${id} had nothing to stop. The run had already finished, or none had been submitted.`,
   runnerUnreachable:
     "The runner could not be reached. It may still be starting, or it may have terminated after inactivity. Retry, or launch it again.",
   screenNeedsARun:

--- a/src/domains/interactiveRunner/stopRun.test.ts
+++ b/src/domains/interactiveRunner/stopRun.test.ts
@@ -1,0 +1,87 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import { describe, expect, it } from "bun:test";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+import { handleRunnerStopRun } from "./stopRun.js";
+
+describe("handleRunnerStopRun", () => {
+  it("stops the run on the runner the flag names", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", wasRunning: true },
+    });
+
+    expect(
+      await handleRunnerStopRun(ctx, { runner: "ci" }, makeTestDeps()),
+    ).toBeUndefined();
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.stopRun,
+      { id: "ci" },
+      runnerCallOptions,
+    );
+    expect(outputs()[0]?.humanMessage).toContain(
+      "Stopped the run on runner ci",
+    );
+  });
+
+  it("reports a runner with nothing to stop without failing", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", wasRunning: false },
+    });
+
+    expect(
+      await handleRunnerStopRun(ctx, { runner: "ci" }, makeTestDeps()),
+    ).toBeUndefined();
+    expect(outputs()[0]?.humanMessage).toContain("had nothing to stop");
+  });
+
+  it("never launches a runner, and says what to do instead", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerStopRun(
+      ctx,
+      { runner: undefined },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("--runner");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("reads an unreachable runner as worth retrying", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
+    });
+
+    const result = await handleRunnerStopRun(
+      ctx,
+      { runner: "ci" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("Retry");
+    expect(result?.exitCode).toBe(4);
+  });
+
+  it("leaves the directory's stored runner alone", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", wasRunning: true },
+    });
+    const deps = makeTestDeps();
+    await deps.store.writeDefaultRunnerId("ci");
+
+    await handleRunnerStopRun(ctx, { runner: undefined }, deps);
+
+    expect(await deps.store.readDefaultRunnerId()).toBe("ci");
+  });
+});

--- a/src/domains/interactiveRunner/stopRun.ts
+++ b/src/domains/interactiveRunner/stopRun.ts
@@ -1,0 +1,68 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type {
+  AuthCommandContext,
+  CommandResult,
+} from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+/**
+ * Stops what a runner is executing and leaves the runner up, with its browser on
+ * whatever page the run reached.
+ *
+ * The counterpart of `terminate`, which ends the runner itself. Nothing about the
+ * directory's stored default changes here, because the runner this was sent to is
+ * still the one later commands should reach.
+ */
+export async function handleRunnerStopRun(
+  ctx: AuthCommandContext,
+  options: { runner: string | undefined },
+  deps: InteractiveRunnerDeps,
+): Promise<CommandResult> {
+  // Never launches. A fresh runner is running nothing, so the only thing a
+  // launch here could buy the caller is a billed pod.
+  const resolved = await resolveRunner(
+    ctx,
+    { autoLaunch: false, runner: options.runner },
+    deps,
+  );
+  if (resolved.type === "failed") {
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
+  }
+
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.stopRun,
+    { id: resolved.runnerId },
+    runnerCallOptions,
+  );
+  if (!result.ok) {
+    return { ...failureFields(result), exitCode: exitCodes.network };
+  }
+
+  if (result.value.outcome === "failure") {
+    result.value.failureReason satisfies "runner-unreachable";
+    // Retryable, unlike the other verbs that may have taken effect before their
+    // answer was lost. Stopping a runner that is already idle does nothing.
+    return {
+      error: interactiveRunnerMessages.runnerUnreachable,
+      exitCode: exitCodes.network,
+    };
+  }
+
+  // A stop that found nothing to stop is still a stop. The caller asked for the
+  // runner to be idle and it is, so reporting it as a failure would have a
+  // harness retrying its way to the same answer.
+  ctx.ui.output(
+    result.value,
+    result.value.wasRunning
+      ? interactiveRunnerMessages.runStopped(resolved.runnerId)
+      : interactiveRunnerMessages.nothingToStop(resolved.runnerId),
+  );
+  return undefined;
+}


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.27.0` added `runner.stopRun`, which stops what a runner is executing and leaves the runner up with its browser on whatever page the run reached. It is the counterpart of `runner.terminate`, which ends the runner itself, and the CLI had no command for it.

- [x] Add `qawolf runner stop-run`, which stops the run and leaves the runner up
- [x] Resolve the runner with `autoLaunch: false`, since a freshly launched runner is executing nothing and a launch here would only bill a pod
- [x] Report `wasRunning: false` as a success, so a harness is not sent round the loop again for the answer it already has
- [x] Read the runner id from the resolver rather than the response, which carries `wasRunning` but no `id`
- [x] Leave the directory's stored runner untouched, since the runner is still where later commands belong
- [x] Treat `runner-unreachable` as retryable, because stopping an already idle runner does nothing
- [x] Cover the stopped, nothing-to-stop, never-launches, unreachable and stored-runner cases

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1703 pass  0 fail`. The other five give exit 0.

- `qawolf runner stop-run --help` names the command a `write` and offers only `--runner`.
- `bun run generate` adds one row to `SKILL.md`, since that table comes from the Commander tree rather than the contracts.
- Added lines, excluding `bun.lock` and snapshots: 177.
