### PR TITLE
feat(runner): add inspect for element html, page html and variables

### DIFF
--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -144,6 +144,9 @@ current branch.
 | `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin |
 | `qawolf runner events` | read | Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status |
 | `qawolf runner exec` | write | Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin |
+| `qawolf runner inspect element-html` | read | Print the HTML of the first element a selector matches |
+| `qawolf runner inspect page-html` | read | Print the page's HTML, simplified for a model to read |
+| `qawolf runner inspect variable` | read | Print a top-level variable's value from the running workflow |
 | `qawolf runner keepalive` | read | Reset a runner's inactivity clock, for a caller that pauses between actions |
 | `qawolf runner launch` | write | Launch an interactive runner and make it this directory's default |
 | `qawolf runner run` | write | Run a flow on an interactive runner, shipping the current directory's files with it |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -291,6 +291,7 @@ Commands:
                              JSON from stdin
   exec [options] <file>      Evaluate a snippet against a runner's live page.
                              Use - to read the snippet from stdin
+  inspect                    Read one thing off a runner's live page
   help [command]             display help for command
 "
 `;
@@ -455,6 +456,67 @@ Examples:
   $ qawolf runner act navigate --url https://example.com
   $ qawolf runner act drag --path '[{"x":10,"y":20},{"x":80,"y":90}]'
   $ echo '{"type":"click","button":"left","x":1,"y":2}' | qawolf runner act -
+"
+`;
+
+exports[`--help output qawolf runner inspect 1`] = `
+"Usage: qawolf runner inspect [options] [command]
+
+Read one thing off a runner's live page
+
+Options:
+  -h, --help              display help for command
+
+Commands:
+  element-html [options]  Print the HTML of the first element a selector matches
+  page-html [options]     Print the page's HTML, simplified for a model to read
+  variable [options]      Print a top-level variable's value from the running
+                          workflow
+  help [command]          display help for command
+
+Examples:
+  $ qawolf runner inspect element-html --selector "#email"
+  $ qawolf runner inspect page-html > page.html
+  $ qawolf runner inspect variable --name cart | jq .total
+"
+`;
+
+exports[`--help output qawolf runner inspect element-html 1`] = `
+"Usage: qawolf runner inspect element-html [options]
+
+Print the HTML of the first element a selector matches
+
+Options:
+  --selector <selector>  Playwright selector to inspect
+  --runner <id>          Runner to target. Defaults to QAWOLF_RUNNER_ID, then
+                         this directory's stored runner
+  -h, --help             display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect page-html 1`] = `
+"Usage: qawolf runner inspect page-html [options]
+
+Print the page's HTML, simplified for a model to read
+
+Options:
+  --selector <selector>  Limit the output to this subtree
+  --runner <id>          Runner to target. Defaults to QAWOLF_RUNNER_ID, then
+                         this directory's stored runner
+  -h, --help             display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect variable 1`] = `
+"Usage: qawolf runner inspect variable [options]
+
+Print a top-level variable's value from the running workflow
+
+Options:
+  --name <name>  Name of the variable to read
+  --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                 directory's stored runner
+  -h, --help     display help for command
 "
 `;
 

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -114,6 +114,22 @@ describe("--help output", () => {
     expect(helpFor("runner", "act")).toMatchSnapshot();
   });
 
+  it("qawolf runner inspect", () => {
+    expect(helpFor("runner", "inspect")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect element-html", () => {
+    expect(helpFor("runner", "inspect", "element-html")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect page-html", () => {
+    expect(helpFor("runner", "inspect", "page-html")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect variable", () => {
+    expect(helpFor("runner", "inspect", "variable")).toMatchSnapshot();
+  });
+
   it("qawolf runner exec", () => {
     expect(helpFor("runner", "exec")).toMatchSnapshot();
   });
@@ -141,6 +157,10 @@ describe("--help output", () => {
       ["runner", "screenshot"],
       ["runner", "act"],
       ["runner", "exec"],
+      ["runner", "inspect"],
+      ["runner", "inspect", "element-html"],
+      ["runner", "inspect", "page-html"],
+      ["runner", "inspect", "variable"],
     ];
     for (const path of paths) {
       expect(helpFor(...path)).not.toContain("—");

--- a/src/commands/runner/index.ts
+++ b/src/commands/runner/index.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
+import { registerRunnerInspectCommands } from "./inspect.register.js";
 import { registerRunnerInteractCommands } from "./interact.register.js";
 import { registerRunnerLifecycleCommands } from "./lifecycle.register.js";
 import { registerRunnerRunCommands } from "./run.register.js";
@@ -17,4 +18,5 @@ export function registerRunnerCommand(
   registerRunnerLifecycleCommands(runner, signals);
   registerRunnerRunCommands(runner, signals);
   registerRunnerInteractCommands(runner, signals);
+  registerRunnerInspectCommands(runner, signals);
 }

--- a/src/commands/runner/inspect.register.ts
+++ b/src/commands/runner/inspect.register.ts
@@ -1,0 +1,82 @@
+import type { Command } from "commander";
+
+import { declareCommandKind } from "~/commands/commandKind.js";
+import { withAuthContext } from "~/commands/context.js";
+import { handleRunnerInspect } from "~/domains/interactiveRunner/inspect.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { runnerDeps, runnerFlagDescription } from "./context.js";
+
+const inspectExamples = `
+Examples:
+  $ qawolf runner inspect element-html --selector "#email"
+  $ qawolf runner inspect page-html > page.html
+  $ qawolf runner inspect variable --name cart | jq .total`;
+
+/**
+ * A group rather than one command with a positional, because each of the three
+ * needs different flags and only `page-html` can be asked without one.
+ */
+export function registerRunnerInspectCommands(
+  runner: Command,
+  signals: SignalRegistry,
+): void {
+  const inspect = runner
+    .command("inspect")
+    .description("Read one thing off a runner's live page")
+    .addHelpText("after", inspectExamples);
+
+  declareCommandKind(inspect.command("element-html"), "read")
+    .description("Print the HTML of the first element a selector matches")
+    .requiredOption("--selector <selector>", "Playwright selector to inspect")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { runner?: string; selector: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspect(
+          ctx,
+          {
+            flags: { name: undefined, selector: opts.selector },
+            runner: opts.runner,
+            what: "element-html",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+
+  declareCommandKind(inspect.command("page-html"), "read")
+    .description("Print the page's HTML, simplified for a model to read")
+    .option("--selector <selector>", "Limit the output to this subtree")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { runner?: string; selector?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspect(
+          ctx,
+          {
+            flags: { name: undefined, selector: opts.selector },
+            runner: opts.runner,
+            what: "page-html",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+
+  declareCommandKind(inspect.command("variable"), "read")
+    .description("Print a top-level variable's value from the running workflow")
+    .requiredOption("--name <name>", "Name of the variable to read")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { name: string; runner?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspect(
+          ctx,
+          {
+            flags: { name: opts.name, selector: undefined },
+            runner: opts.runner,
+            what: "variable",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+}

--- a/src/core/interactiveRunner/inspectRequest.test.ts
+++ b/src/core/interactiveRunner/inspectRequest.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildInspectRequest } from "./inspectRequest.js";
+
+const noFlags = { name: undefined, selector: undefined };
+
+describe("buildInspectRequest", () => {
+  it("carries a selector into an element request", () => {
+    expect(
+      buildInspectRequest("element-html", { ...noFlags, selector: "#email" }),
+    ).toEqual({
+      ok: true,
+      request: { selector: "#email", what: "element-html" },
+    });
+  });
+
+  it("omits the selector a page request was not given", () => {
+    expect(buildInspectRequest("page-html", noFlags)).toEqual({
+      ok: true,
+      request: { what: "page-html" },
+    });
+  });
+
+  it("names a variable rather than passing a selector", () => {
+    expect(
+      buildInspectRequest("variable", { ...noFlags, name: "cart" }),
+    ).toEqual({
+      ok: true,
+      request: { variableName: "cart", what: "variable" },
+    });
+  });
+
+  it("refuses an element request with no selector to match on", () => {
+    const built = buildInspectRequest("element-html", noFlags);
+
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toContain("selector");
+  });
+
+  it("refuses a variable request with no name", () => {
+    expect(buildInspectRequest("variable", noFlags).ok).toBe(false);
+  });
+
+  // The caps come from the published schema, so the CLI cannot drift from what
+  // the server accepts.
+  it("refuses a selector past the published length", () => {
+    expect(
+      buildInspectRequest("element-html", {
+        ...noFlags,
+        selector: "a".repeat(2_001),
+      }).ok,
+    ).toBe(false);
+    expect(
+      buildInspectRequest("element-html", {
+        ...noFlags,
+        selector: "a".repeat(2_000),
+      }).ok,
+    ).toBe(true);
+  });
+
+  it("refuses a variable name past the published length", () => {
+    expect(
+      buildInspectRequest("variable", { ...noFlags, name: "a".repeat(257) }).ok,
+    ).toBe(false);
+  });
+
+  it("refuses an empty selector rather than sending one", () => {
+    expect(
+      buildInspectRequest("element-html", { ...noFlags, selector: "" }).ok,
+    ).toBe(false);
+  });
+});

--- a/src/core/interactiveRunner/inspectRequest.ts
+++ b/src/core/interactiveRunner/inspectRequest.ts
@@ -1,0 +1,38 @@
+import {
+  type InspectOnRunnerRequest,
+  inspectRequestSchema,
+} from "@qawolf/api-contracts/v1";
+import { z } from "zod";
+
+export type InspectFlags = {
+  name: string | undefined;
+  selector: string | undefined;
+};
+
+export type BuiltInspectRequest =
+  | { ok: true; request: InspectOnRunnerRequest }
+  | { ok: false; error: string };
+
+/**
+ * Turns a subcommand and its flags into one inspect request.
+ *
+ * Put to the published schema rather than checked by hand, so the selector and
+ * variable-name limits come from the same place the server applies them and an
+ * over-long selector is refused before a runner is addressed.
+ */
+export function buildInspectRequest(
+  what: InspectOnRunnerRequest["what"],
+  flags: InspectFlags,
+): BuiltInspectRequest {
+  const candidate = {
+    what,
+    ...(flags.selector === undefined ? {} : { selector: flags.selector }),
+    ...(flags.name === undefined ? {} : { variableName: flags.name }),
+  };
+
+  const parsed = inspectRequestSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return { error: z.prettifyError(parsed.error), ok: false };
+  }
+  return { ok: true, request: parsed.data };
+}

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -54,6 +54,7 @@ export const interactiveRunnerMessages = {
     `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
+  noRunnerIdForInspect: `${noRunnerId} Inspecting also needs a page, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
   noRunnerIdForScreenshot: `${noRunnerId} A screenshot also needs a screen, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
   noRunnerId,
   wasNotRunning: (id: string) => `Runner ${id} was not running.`,
@@ -78,6 +79,10 @@ export const interactiveRunnerMessages = {
     "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until a run opens one, so run a flow on it with qawolf runner run first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
   runStopped: (id: string) =>
     `Stopped the run on runner ${id}. The runner is still up, on whatever page the run reached.`,
+  nothingToInspect: (errorMessage: string | undefined) =>
+    `The runner had nothing to inspect${errorMessage === undefined ? "" : `: ${errorMessage}`}. There is no live page, nothing matched the selector, or no variable has that name; a runner cannot tell those apart. Run a flow on it first, or check the selector or name.`,
+  inspectAnsweredUnknown: (failureReason: string) =>
+    `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
   nothingToStop: (id: string) =>
     `Runner ${id} had nothing to stop. The run had already finished, or none had been submitted.`,
   runnerUnreachable:

--- a/src/domains/interactiveRunner/inspect.test.ts
+++ b/src/domains/interactiveRunner/inspect.test.ts
@@ -1,0 +1,193 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import { describe, expect, it } from "bun:test";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { handleRunnerInspect } from "./inspect.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+const noFlags = { name: undefined, selector: undefined };
+
+describe("handleRunnerInspect", () => {
+  it("asks for an element's html and prints it on its own", async () => {
+    const { callPublicApi, ctx, outputs, streamed } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", value: "<input id='email'>" },
+    });
+
+    expect(
+      await handleRunnerInspect(
+        ctx,
+        {
+          flags: { name: undefined, selector: "#email" },
+          runner: "ci",
+          what: "element-html",
+        },
+        makeTestDeps(),
+      ),
+    ).toBeUndefined();
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspect,
+      { id: "ci", request: { selector: "#email", what: "element-html" } },
+      runnerCallOptions,
+    );
+    // The value and nothing else, so a caller can redirect it into a file.
+    expect(streamed()).toEqual(["<input id='email'>"]);
+    expect(outputs()).toEqual([]);
+  });
+
+  it("asks for the whole page when no selector narrows it", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", value: "<html></html>" },
+    });
+
+    await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspect,
+      { id: "ci", request: { what: "page-html" } },
+      runnerCallOptions,
+    );
+  });
+
+  it("asks for a variable by name", async () => {
+    const { callPublicApi, ctx, streamed } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", value: '{"total":42}' },
+    });
+
+    await handleRunnerInspect(
+      ctx,
+      {
+        flags: { name: "cart", selector: undefined },
+        runner: "ci",
+        what: "variable",
+      },
+      makeTestDeps(),
+    );
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspect,
+      { id: "ci", request: { variableName: "cart", what: "variable" } },
+      runnerCallOptions,
+    );
+    expect(streamed()).toEqual(['{"total":42}']);
+  });
+
+  it("refuses a selector over the published limit without addressing a runner", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerInspect(
+      ctx,
+      {
+        flags: { name: undefined, selector: "a".repeat(2_001) },
+        runner: "ci",
+        what: "element-html",
+      },
+      makeTestDeps(),
+    );
+
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("never launches a runner, and says a page comes from a run", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: undefined, what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("qawolf runner run");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  // Waiting clears none of the three conditions behind this reason, so it must
+  // not read as something to retry.
+  it("reads nothing-to-inspect as needing the caller to act", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "nothing-to-inspect", outcome: "failure" },
+    });
+
+    const result = await handleRunnerInspect(
+      ctx,
+      {
+        flags: { name: undefined, selector: "#gone" },
+        runner: "ci",
+        what: "element-html",
+      },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("nothing to inspect");
+    expect(result?.exitCode).toBe(2);
+  });
+
+  it("passes on what the runner said when it said anything", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        errorMessage: "no live page",
+        failureReason: "nothing-to-inspect",
+        outcome: "failure",
+      },
+    });
+
+    const result = await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("no live page");
+  });
+
+  it("reads an unreachable runner as worth retrying", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
+    });
+
+    const result = await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("Retry");
+    expect(result?.exitCode).toBe(4);
+  });
+
+  it("carries the value as data too, for --json", async () => {
+    const { callPublicApi, ctx, streamedData } = makeAuthCtx("json");
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success", value: "<html></html>" },
+    });
+
+    await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(streamedData()).toEqual([
+      { outcome: "success", value: "<html></html>" },
+    ]);
+  });
+});

--- a/src/domains/interactiveRunner/inspect.ts
+++ b/src/domains/interactiveRunner/inspect.ts
@@ -1,0 +1,97 @@
+import {
+  type InspectOnRunnerRequest,
+  publicContractsV1,
+} from "@qawolf/api-contracts/v1";
+
+import {
+  buildInspectRequest,
+  type InspectFlags,
+} from "~/core/interactiveRunner/inspectRequest.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type {
+  AuthCommandContext,
+  CommandResult,
+} from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+/**
+ * Reads one thing off a runner's live page and prints it.
+ *
+ * The value goes to stdout on its own, so a caller can pipe it into a file or a
+ * parser. Everything else the command has to say goes to stderr, because a
+ * diagnostic mixed into the value would corrupt whatever is reading it.
+ */
+export async function handleRunnerInspect(
+  ctx: AuthCommandContext,
+  options: {
+    flags: InspectFlags;
+    runner: string | undefined;
+    what: InspectOnRunnerRequest["what"];
+  },
+  deps: InteractiveRunnerDeps,
+): Promise<CommandResult> {
+  const built = buildInspectRequest(options.what, options.flags);
+  if (!built.ok) {
+    return { error: built.error, exitCode: exitCodes.invalidArgs };
+  }
+
+  const resolved = await resolveRunner(
+    ctx,
+    {
+      autoLaunch: false,
+      noRunnerIdMessage: interactiveRunnerMessages.noRunnerIdForInspect,
+      runner: options.runner,
+    },
+    deps,
+  );
+  if (resolved.type === "failed") {
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
+  }
+
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.inspect,
+    { id: resolved.runnerId, request: built.request },
+    runnerCallOptions,
+  );
+  if (!result.ok) {
+    return { ...failureFields(result), exitCode: exitCodes.network };
+  }
+
+  if (result.value.outcome === "failure") {
+    const failure = result.value;
+    const { failureReason } = failure;
+    switch (failureReason) {
+      // A pod cannot tell a missing page from a missing element
+      // from a missing variable. None of them clears by waiting,
+      // so this is not a retry.
+      case "nothing-to-inspect":
+        return {
+          error: interactiveRunnerMessages.nothingToInspect(
+            failure.errorMessage,
+          ),
+          exitCode: exitCodes.invalidArgs,
+        };
+      case "runner-unreachable":
+        return {
+          error: interactiveRunnerMessages.runnerUnreachable,
+          exitCode: exitCodes.network,
+        };
+      default: {
+        failureReason satisfies never;
+        return {
+          error:
+            interactiveRunnerMessages.inspectAnsweredUnknown(failureReason),
+          exitCode: exitCodes.network,
+        };
+      }
+    }
+  }
+
+  ctx.ui.stream(result.value, result.value.value);
+  return undefined;
+}


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.27.0` added `runner.inspect`, which reads one thing off a runner's live page: an element's HTML, the page's HTML simplified for a model, or a top-level variable's value as JSON. The CLI had no way to reach it, so the only way to get a value out of a page was to print it from a snippet and then read it back off the `console` journal stream.

- [x] Add `qawolf runner inspect` with `element-html`, `page-html` and `variable` subcommands over the one verb
- [x] Register them as a Commander group rather than one command with a positional, since each needs different flags and only `page-html` can be asked without one
- [x] Give the group its own `inspect.register.ts`, matching the existing `lifecycle` and `run` register files, since `interact.register.ts` would have passed the 150-line cap
- [x] Print the value through `ctx.ui.stream` so it lands on stdout by itself and a caller can redirect or pipe it
- [x] Send diagnostics to stderr, since a message mixed into the value would corrupt whatever is reading it
- [x] Build each request from its flags and put it to the published `inspectRequestSchema`, so the 2,000-character selector and 256-character name limits come from the same place the server applies them
- [x] Validate before resolving a runner, so a malformed selector costs no round trip
- [x] Exit 2 on `nothing-to-inspect`, since none of the three conditions behind it clears by waiting
- [x] Exit 4 on `runner-unreachable`, which is transient
- [x] Pass on the runner's `errorMessage` when it gave one, because a pod cannot tell a missing page from a missing element from a missing variable
- [x] Never launch a runner, since one that has just started has no page to read
- [x] Cover all three subcommands, both failure reasons, the length limits and the `--json` envelope

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1724 pass  0 fail`. The other five give exit 0.

- `qawolf runner inspect --help` lists the three subcommands, and each subcommand's help shows only the flags it takes.
- `bun run generate` adds three leaf rows to `SKILL.md` and no row for the group, since a parent earns one only when it takes a positional.
- Added lines, excluding `bun.lock` and snapshots: 513, over the 400 warning threshold in `scripts/check-pr-size.sh` and under the 600 error threshold.
