### PR TITLE
feat(runner): add import-package to install into a live run

### DIFF
--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -144,6 +144,7 @@ current branch.
 | `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin |
 | `qawolf runner events` | read | Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status |
 | `qawolf runner exec` | write | Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin |
+| `qawolf runner import-package` | write | Install a package into a runner's live run, so a snippet or a selection can import it |
 | `qawolf runner inspect element-html` | read | Print the HTML of the first element a selector matches |
 | `qawolf runner inspect page-html` | read | Print the page's HTML, simplified for a model to read |
 | `qawolf runner inspect variable` | read | Print a top-level variable's value from the running workflow |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -267,32 +267,34 @@ exports[`--help output qawolf runner 1`] = `
 Drive an interactive runner on the QA Wolf platform
 
 Options:
-  -h, --help                 display help for command
+  -h, --help                       display help for command
 
 Commands:
-  launch [options]           Launch an interactive runner and make it this
-                             directory's default
-  terminate [options]        End an interactive runner, and the pod it runs on
-                             with it
-  stop-run [options]         Stop what a runner is currently executing, leaving
-                             the runner up
-  keepalive [options]        Reset a runner's inactivity clock, for a caller
-                             that pauses between actions
-  run [options] <file>       Run a flow on an interactive runner, shipping the
-                             current directory's files with it
-  events [options] <stream>  Print a runner's journal, one entry per line. QA
-                             Wolf writes console, recorder, run-events,
-                             run-logs, run-status
-  screenshot [options]       Save a JPEG of an interactive runner's screen to a
-                             file
-  act [options] <action>     Perform one raw action on a runner's screen: click,
-                             double_click, scroll, move, drag, keypress,
-                             navigate or type. Use - to read a whole action as
-                             JSON from stdin
-  exec [options] <file>      Evaluate a snippet against a runner's live page.
-                             Use - to read the snippet from stdin
-  inspect                    Read one thing off a runner's live page
-  help [command]             display help for command
+  launch [options]                 Launch an interactive runner and make it this
+                                   directory's default
+  terminate [options]              End an interactive runner, and the pod it
+                                   runs on with it
+  stop-run [options]               Stop what a runner is currently executing,
+                                   leaving the runner up
+  keepalive [options]              Reset a runner's inactivity clock, for a
+                                   caller that pauses between actions
+  run [options] <file>             Run a flow on an interactive runner, shipping
+                                   the current directory's files with it
+  events [options] <stream>        Print a runner's journal, one entry per line.
+                                   QA Wolf writes console, recorder, run-events,
+                                   run-logs, run-status
+  screenshot [options]             Save a JPEG of an interactive runner's screen
+                                   to a file
+  act [options] <action>           Perform one raw action on a runner's screen:
+                                   click, double_click, scroll, move, drag,
+                                   keypress, navigate or type. Use - to read a
+                                   whole action as JSON from stdin
+  exec [options] <file>            Evaluate a snippet against a runner's live
+                                   page. Use - to read the snippet from stdin
+  inspect                          Read one thing off a runner's live page
+  import-package [options] <name>  Install a package into a runner's live run,
+                                   so a snippet or a selection can import it
+  help [command]                   display help for command
 "
 `;
 
@@ -456,6 +458,24 @@ Examples:
   $ qawolf runner act navigate --url https://example.com
   $ qawolf runner act drag --path '[{"x":10,"y":20},{"x":80,"y":90}]'
   $ echo '{"type":"click","button":"left","x":1,"y":2}' | qawolf runner act -
+"
+`;
+
+exports[`--help output qawolf runner import-package 1`] = `
+"Usage: qawolf runner import-package [options] <name>
+
+Install a package into a runner's live run, so a snippet or a selection can
+import it
+
+Options:
+  --package-version <version>  Version to install (default: "latest")
+  --runner <id>                Runner to target. Defaults to QAWOLF_RUNNER_ID,
+                               then this directory's stored runner
+  -h, --help                   display help for command
+
+Examples:
+  $ qawolf runner import-package dayjs
+  $ qawolf runner import-package dayjs --package-version 1.11.13
 "
 `;
 

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -114,6 +114,10 @@ describe("--help output", () => {
     expect(helpFor("runner", "act")).toMatchSnapshot();
   });
 
+  it("qawolf runner import-package", () => {
+    expect(helpFor("runner", "import-package")).toMatchSnapshot();
+  });
+
   it("qawolf runner inspect", () => {
     expect(helpFor("runner", "inspect")).toMatchSnapshot();
   });
@@ -157,6 +161,7 @@ describe("--help output", () => {
       ["runner", "screenshot"],
       ["runner", "act"],
       ["runner", "exec"],
+      ["runner", "import-package"],
       ["runner", "inspect"],
       ["runner", "inspect", "element-html"],
       ["runner", "inspect", "page-html"],

--- a/src/commands/runner/importPackage.register.ts
+++ b/src/commands/runner/importPackage.register.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+
+import { declareCommandKind } from "~/commands/commandKind.js";
+import { withAuthContext } from "~/commands/context.js";
+import { handleRunnerImportPackage } from "~/domains/interactiveRunner/importPackage.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { runnerDeps, runnerFlagDescription } from "./context.js";
+
+const importPackageExamples = `
+Examples:
+  $ qawolf runner import-package dayjs
+  $ qawolf runner import-package dayjs --package-version 1.11.13`;
+
+export function registerRunnerImportPackageCommand(
+  runner: Command,
+  signals: SignalRegistry,
+): void {
+  declareCommandKind(runner.command("import-package <name>"), "write")
+    .description(
+      "Install a package into a runner's live run, so a snippet or a selection can import it",
+    )
+    .option("--package-version <version>", "Version to install", "latest")
+    .option("--runner <id>", runnerFlagDescription)
+    .addHelpText("after", importPackageExamples)
+    .action(
+      (
+        name: string,
+        opts: { packageVersion: string; runner?: string },
+        command: Command,
+      ) =>
+        withAuthContext(signals, (ctx) =>
+          handleRunnerImportPackage(
+            ctx,
+            { name, runner: opts.runner, version: opts.packageVersion },
+            runnerDeps(ctx),
+          ),
+        )(opts, command),
+    );
+}

--- a/src/commands/runner/index.ts
+++ b/src/commands/runner/index.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
+import { registerRunnerImportPackageCommand } from "./importPackage.register.js";
 import { registerRunnerInspectCommands } from "./inspect.register.js";
 import { registerRunnerInteractCommands } from "./interact.register.js";
 import { registerRunnerLifecycleCommands } from "./lifecycle.register.js";
@@ -19,4 +20,5 @@ export function registerRunnerCommand(
   registerRunnerRunCommands(runner, signals);
   registerRunnerInteractCommands(runner, signals);
   registerRunnerInspectCommands(runner, signals);
+  registerRunnerImportPackageCommand(runner, signals);
 }

--- a/src/core/interactiveRunner/npmDependencies.test.ts
+++ b/src/core/interactiveRunner/npmDependencies.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import { readNpmDependencies } from "./npmDependencies.js";
+
+const read = (manifest: unknown) =>
+  readNpmDependencies(JSON.stringify(manifest));
+
+describe("readNpmDependencies", () => {
+  it("reads both dependency sections into one record", () => {
+    expect(
+      read({
+        dependencies: { dayjs: "1.11.13" },
+        devDependencies: { typescript: "6.0.3" },
+      }),
+    ).toEqual({
+      dependencies: { dayjs: "1.11.13", typescript: "6.0.3" },
+      ok: true,
+    });
+  });
+
+  // The server resolves a run the same way, so an install has to agree with it.
+  it("takes dependencies over devDependencies for a name in both", () => {
+    expect(
+      read({
+        dependencies: { dayjs: "1.11.13" },
+        devDependencies: { dayjs: "1.0.0" },
+      }),
+    ).toEqual({ dependencies: { dayjs: "1.11.13" }, ok: true });
+  });
+
+  // A runner cannot install one, and @qawolf/flows is already on it.
+  it("drops a workspace range", () => {
+    expect(
+      read({
+        dependencies: { "@qawolf/flows": "workspace:*", dayjs: "1.11.13" },
+      }),
+    ).toEqual({ dependencies: { dayjs: "1.11.13" }, ok: true });
+  });
+
+  it("reads a manifest declaring nothing as declaring nothing", () => {
+    expect(read({ name: "project" })).toEqual({ dependencies: {}, ok: true });
+  });
+
+  it("ignores sections it does not install from", () => {
+    expect(
+      read({
+        dependencies: { dayjs: "1.11.13" },
+        optionalDependencies: { sharp: "0.34.0" },
+        peerDependencies: { zod: "4.4.3" },
+      }),
+    ).toEqual({ dependencies: { dayjs: "1.11.13" }, ok: true });
+  });
+
+  it("names what is wrong with a manifest it cannot read", () => {
+    expect(readNpmDependencies("{ not json")).toEqual({
+      ok: false,
+      reason: "it is not valid JSON",
+    });
+    expect(readNpmDependencies("[]")).toEqual({
+      ok: false,
+      reason: "it is not an object",
+    });
+    expect(read({ dependencies: "dayjs" })).toEqual({
+      ok: false,
+      reason: "dependencies is not an object",
+    });
+    expect(read({ dependencies: { dayjs: 1 } })).toEqual({
+      ok: false,
+      reason: "dependencies.dayjs is not a string",
+    });
+  });
+});

--- a/src/core/interactiveRunner/npmDependencies.ts
+++ b/src/core/interactiveRunner/npmDependencies.ts
@@ -1,0 +1,45 @@
+type NpmDependencies = Record<string, string>;
+
+export type ReadNpmDependencies =
+  | { ok: true; dependencies: NpmDependencies }
+  | { ok: false; reason: string };
+
+const sectionsInPrecedenceOrder = ["dependencies", "devDependencies"] as const;
+
+// A runner cannot install a workspace range, and @qawolf/flows is already on it.
+const isInstallable = (version: string) => !version.startsWith("workspace:");
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** What a run installs, read the same way the server derives it. */
+export function readNpmDependencies(
+  packageJsonContent: string,
+): ReadNpmDependencies {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(packageJsonContent);
+  } catch {
+    return { ok: false, reason: "it is not valid JSON" };
+  }
+  if (!isRecord(parsed)) return { ok: false, reason: "it is not an object" };
+
+  const dependencies: NpmDependencies = {};
+  for (const section of sectionsInPrecedenceOrder) {
+    const declared = parsed[section];
+    if (declared === undefined) continue;
+    if (!isRecord(declared)) {
+      return { ok: false, reason: `${section} is not an object` };
+    }
+
+    for (const [name, version] of Object.entries(declared)) {
+      if (typeof version !== "string") {
+        return { ok: false, reason: `${section}.${name} is not a string` };
+      }
+      if (Object.hasOwn(dependencies, name)) continue;
+      if (isInstallable(version)) dependencies[name] = version;
+    }
+  }
+  return { dependencies, ok: true };
+}

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -54,6 +54,9 @@ export const interactiveRunnerMessages = {
     `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
+  missingPackageJsonForImport:
+    "No package.json in the current directory. The install resolves against the run's own dependencies, which are read from one.",
+  noRunnerIdForImport: `${noRunnerId} An install also needs a live run to go into, which a runner gets from qawolf runner run.`,
   noRunnerIdForInspect: `${noRunnerId} Inspecting also needs a page, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
   noRunnerIdForScreenshot: `${noRunnerId} A screenshot also needs a screen, which a runner gets from its first run: run a flow on it with qawolf runner run.`,
   noRunnerId,
@@ -114,6 +117,18 @@ export const interactiveRunnerMessages = {
   stdinEmptySnippet:
     'Nothing arrived on stdin. Pipe the snippet in, or name a file instead of "-".',
   terminated: (id: string) => `Terminated runner ${id}.`,
+  packageInstalled: (name: string, version: string) =>
+    `Installed ${name}@${version} into the runner's live run.`,
+  packageJsonUnreadable: (reason: string) =>
+    `package.json could not be read because ${reason}. Fix it and try again.`,
+  installFailed: (
+    name: string,
+    version: string,
+    errorMessage: string | undefined,
+  ) =>
+    `npm could not install ${name}@${version}${errorMessage === undefined ? "" : `. ${errorMessage}`}. Check the name and the version; waiting will not change this.`,
+  importAnsweredUnknown: (failureReason: string) =>
+    `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
   requestTooLarge: (byteLength: number, maxByteLength: number) =>
     `The run request encodes to ${String(byteLength)} bytes, over the ${String(maxByteLength)} a runner accepts. Escaping inflates file content, so a set of files inside the content cap can still encode to more than this. Run from a directory holding only the flow and what it imports.`,
   unknownStream: (stream: string, known: readonly string[]) =>

--- a/src/domains/interactiveRunner/deps.testUtils.ts
+++ b/src/domains/interactiveRunner/deps.testUtils.ts
@@ -84,7 +84,12 @@ export function makeTestDeps(
     env: {},
     makeRunnerId: () => "cli-minted",
     readFile: async (path) => {
-      const content = files[path];
+      // Handlers that build an absolute path from `cwd` and ones that pass a
+      // collected path through both land here.
+      const collected = path.startsWith(`${testCwd}/`)
+        ? path.slice(testCwd.length + 1)
+        : path;
+      const content = files[collected];
       if (content === undefined) throw Error(`no such file: ${path}`);
       return content;
     },

--- a/src/domains/interactiveRunner/importPackage.test.ts
+++ b/src/domains/interactiveRunner/importPackage.test.ts
@@ -1,0 +1,149 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import { describe, expect, it } from "bun:test";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { handleRunnerImportPackage } from "./importPackage.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+const manifest = JSON.stringify({
+  dependencies: { "@qawolf/flows": "workspace:*", zod: "4.4.3" },
+  devDependencies: { typescript: "6.0.3" },
+});
+
+function depsWithManifest(content = manifest) {
+  return makeTestDeps({
+    collectRunFiles: async () => ({ "package.json": content }),
+    readFile: async () => content,
+  });
+}
+
+describe("handleRunnerImportPackage", () => {
+  it("installs a version the caller named, against the project's dependencies", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success" },
+    });
+
+    expect(
+      await handleRunnerImportPackage(
+        ctx,
+        { name: "dayjs", runner: "ci", version: "1.11.13" },
+        depsWithManifest(),
+      ),
+    ).toBeUndefined();
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.importPackage,
+      {
+        id: "ci",
+        npmDependencies: { typescript: "6.0.3", zod: "4.4.3" },
+        packageName: "dayjs",
+        packageVersion: "1.11.13",
+      },
+      runnerCallOptions,
+    );
+    expect(outputs()[0]?.humanMessage).toContain("dayjs@1.11.13");
+  });
+
+  it("asks npm for latest when no version is named", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { outcome: "success" },
+    });
+
+    await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: undefined },
+      depsWithManifest(),
+    );
+
+    expect(callPublicApi.mock.calls[0]?.[1]).toMatchObject({
+      packageVersion: "latest",
+    });
+  });
+
+  it("reports a directory with no package.json rather than installing blind", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    const deps = makeTestDeps({
+      readFile: () => Promise.reject(Error("ENOENT")),
+    });
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: undefined },
+      deps,
+    );
+
+    expect(result?.error).toContain("No package.json");
+    expect(result?.exitCode).toBe(5);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("names what is wrong with a package.json it cannot read", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: undefined },
+      depsWithManifest("{ not json"),
+    );
+
+    expect(result?.error).toContain("not valid JSON");
+    expect(result?.exitCode).toBe(5);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("never launches a runner, and says an install needs a live run", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: undefined, version: undefined },
+      depsWithManifest(),
+    );
+
+    expect(result?.error).toContain("qawolf runner run");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("passes on npm's reason for refusing the install", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        errorMessage: "No matching version found for dayjs@99.0.0",
+        failureReason: "install-failed",
+        outcome: "failure",
+      },
+    });
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: "99.0.0" },
+      depsWithManifest(),
+    );
+
+    expect(result?.error).toContain("No matching version found");
+    expect(result?.exitCode).toBe(2);
+  });
+
+  it("reads an unreachable runner as worth retrying", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
+    });
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: undefined },
+      depsWithManifest(),
+    );
+
+    expect(result?.error).toContain("Retry");
+    expect(result?.exitCode).toBe(4);
+  });
+});

--- a/src/domains/interactiveRunner/importPackage.ts
+++ b/src/domains/interactiveRunner/importPackage.ts
@@ -1,0 +1,121 @@
+import {
+  publicContractsV1,
+  runPackageJsonPath,
+} from "@qawolf/api-contracts/v1";
+import { join } from "node:path";
+
+import { readNpmDependencies } from "~/core/interactiveRunner/npmDependencies.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type {
+  AuthCommandContext,
+  CommandResult,
+} from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+const defaultPackageVersion = "latest";
+
+/**
+ * Installs one package into a runner's live run. The runner discards the
+ * `package.json` a run shipped, so the request carries the project's
+ * dependencies for the install to resolve against.
+ */
+export async function handleRunnerImportPackage(
+  ctx: AuthCommandContext,
+  options: {
+    name: string;
+    runner: string | undefined;
+    version: string | undefined;
+  },
+  deps: InteractiveRunnerDeps,
+): Promise<CommandResult> {
+  // A run ships this file unchanged, so reading it directly gives the same
+  // content without walking the project for files this command never sends.
+  const content = await deps
+    .readFile(join(deps.cwd, runPackageJsonPath))
+    .catch(() => undefined);
+  if (content === undefined) {
+    return {
+      error: interactiveRunnerMessages.missingPackageJsonForImport,
+      exitCode: exitCodes.config,
+    };
+  }
+  const dependencies = readNpmDependencies(content);
+  if (!dependencies.ok) {
+    return {
+      error: interactiveRunnerMessages.packageJsonUnreadable(
+        dependencies.reason,
+      ),
+      exitCode: exitCodes.config,
+    };
+  }
+
+  // Never launches: the install goes into a live run, which a fresh runner has
+  // no way to have.
+  const resolved = await resolveRunner(
+    ctx,
+    {
+      autoLaunch: false,
+      noRunnerIdMessage: interactiveRunnerMessages.noRunnerIdForImport,
+      runner: options.runner,
+    },
+    deps,
+  );
+  if (resolved.type === "failed") {
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
+  }
+
+  const packageVersion = options.version ?? defaultPackageVersion;
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.importPackage,
+    {
+      id: resolved.runnerId,
+      npmDependencies: dependencies.dependencies,
+      packageName: options.name,
+      packageVersion,
+    },
+    runnerCallOptions,
+  );
+  if (!result.ok) {
+    return { ...failureFields(result), exitCode: exitCodes.network };
+  }
+
+  if (result.value.outcome === "failure") {
+    const failure = result.value;
+    const { failureReason } = failure;
+    switch (failureReason) {
+      // npm's own refusal, so a name or a version to correct rather than retry.
+      case "install-failed":
+        return {
+          error: interactiveRunnerMessages.installFailed(
+            options.name,
+            packageVersion,
+            failure.errorMessage,
+          ),
+          exitCode: exitCodes.invalidArgs,
+        };
+      case "runner-unreachable":
+        return {
+          error: interactiveRunnerMessages.runnerUnreachable,
+          exitCode: exitCodes.network,
+        };
+      default: {
+        failureReason satisfies never;
+        return {
+          error: interactiveRunnerMessages.importAnsweredUnknown(failureReason),
+          exitCode: exitCodes.network,
+        };
+      }
+    }
+  }
+
+  ctx.ui.output(
+    result.value,
+    interactiveRunnerMessages.packageInstalled(options.name, packageVersion),
+  );
+  return undefined;
+}


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.27.0` added `runner.importPackage`, which installs a package into a runner's live run so a snippet or a selection can import it without a full run to reinstall dependencies. The CLI had no way to reach it, so adding a dependency mid-session meant running the whole flow again.

- [x] Add `qawolf runner import-package <name> [--package-version <version>]`, defaulting the version to `latest`
- [x] Name the flag `--package-version` rather than `--version`, which is a program-level flag a subcommand cannot claim
- [x] Read the project's dependencies from `package.json` and send them, since the runner discards the one a run shipped and installs from run configuration
- [x] Read only `dependencies` and `devDependencies`, with the former winning, so an install resolves against the same set the run installed
- [x] Drop `workspace:` ranges, which a runner cannot install and which `@qawolf/flows` is already present for
- [x] Read `package.json` straight from the working directory, since a run ships it unchanged and the collector would walk files this command never sends
- [x] Report a missing or unreadable `package.json` before addressing a runner, naming what is wrong with it
- [x] Exit 2 on `install-failed` and pass on npm's reason, since it is a name or a version to correct rather than retry
- [x] Exit 4 on `runner-unreachable`, which is transient
- [x] Never launch a runner, since an install needs a live run a fresh runner cannot have
- [x] Accept a `cwd`-joined path in the test filesystem fixture, which every handler that builds one now needs
- [x] Cover the dependency rules, both failure reasons, the default version and the unreadable-manifest cases

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1738 pass  0 fail`. The other five give exit 0.

- `qawolf runner import-package --help` shows `--package-version` defaulting to `latest`.
- `bun run generate` adds one row to `SKILL.md`.
- Added lines, excluding `bun.lock` and snapshots: 456, over the 400 warning threshold in `scripts/check-pr-size.sh` and under the 600 error threshold.
