### PR TITLE
feat(runner): run a line selection with --lines

### DIFF
--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -153,7 +153,7 @@ so the snippet can use your own page objects and helpers.
 
 ## Running a flow
 
-`qawolf runner run <file>` ships the current directory's runnable files with the
+`qawolf runner run <flowFile>` ships the current directory's runnable files with the
 request. The runner holds no copy of your project, so what runs is exactly what
 is on disk at that moment, uncommitted edits included. A `package.json` has to
 be there, since the run reads its npm dependencies from it, and the files may
@@ -165,6 +165,36 @@ resolved or launched, so a typo costs nothing.
 The call answers with a run id as soon as the run is accepted. **The outcome is
 not in that answer**, it is in the `run-status` stream, whose entries carry
 `runId`, `status` and an `errorMessage` when there is one.
+
+### Running part of a flow
+
+`--lines 12-40` runs those lines against the browser as it stands, so nothing is
+re-navigated and nothing is signed in again. Use it to iterate on a step without
+paying for the whole flow to reach it again.
+
+The two file paths are the thing to get right, because getting them backwards
+runs the wrong code and nothing reports it:
+
+- the positional is **always the flow file**. It is the run's entry point, and it
+  is required for every run, selection or not.
+- `--lines-file` is **where the lines live**. It defaults to the positional, so
+  pass it only when the range is in another file, typically a page object whose
+  method you want to run against the instance your last run left alive.
+
+```sh
+qawolf runner run flows/checkout.flow.ts --lines 12-40          # lines in the flow file
+qawolf runner run flows/checkout.flow.ts --lines 4-9 \
+  --lines-file pages/login.ts                                   # lines in a page object
+```
+
+The lines-file has to be one of the files that travel, so it lives under the
+directory you run from. A range whose file is not collected is refused before a
+runner is addressed, naming the path.
+
+If the runner had no browser, one is started before your lines run, and the
+command says so on stderr. Those lines then ran against a fresh page rather than
+the one an earlier run left, which is worth reading before you act on what you
+see.
 
 **Pass `--follow` to `run` and let it wait for you.** It reports the run's
 status — in progress, then passed or failed — and ends on the settled status.

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -278,7 +278,7 @@ Commands:
                                    leaving the runner up
   keepalive [options]              Reset a runner's inactivity clock, for a
                                    caller that pauses between actions
-  run [options] <file>             Run a flow on an interactive runner, shipping
+  run [options] <flowFile>         Run a flow on an interactive runner, shipping
                                    the current directory's files with it
   events [options] <stream>        Print a runner's journal, one entry per line.
                                    QA Wolf writes console, recorder, run-events,
@@ -340,7 +340,7 @@ Options:
 `;
 
 exports[`--help output qawolf runner run 1`] = `
-"Usage: qawolf runner run [options] <file>
+"Usage: qawolf runner run [options] <flowFile>
 
 Run a flow on an interactive runner, shipping the current directory's files with
 it
@@ -356,6 +356,11 @@ Options:
                        lines while following, from an anchor taken just before
                        submission: the recorder is runner-wide, not run-scoped.
                        Implies --follow (default: false)
+  --lines <start-end>  Run only these 1-indexed lines against the browser as it
+                       stands, instead of the whole flow from a fresh one
+  --lines-file <path>  File the --lines range lives in. Defaults to <flowFile>;
+                       pass it only when the lines are in another file, such as
+                       a page object
   --runner <id>        Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
                        directory's stored runner
   --timeout <seconds>  Give up following after this long. Following keeps the
@@ -367,6 +372,8 @@ Examples:
   $ qawolf runner run flows/checkout.flow.ts
   $ qawolf runner run flows/checkout.flow.ts --follow
   $ qawolf runner run flows/checkout.flow.ts --follow --logs
+  $ qawolf runner run flows/checkout.flow.ts --lines 12-40
+  $ qawolf runner run flows/checkout.flow.ts --lines 4-9 --lines-file pages/login.ts
 "
 `;
 

--- a/src/commands/runner/events.register.ts
+++ b/src/commands/runner/events.register.ts
@@ -1,0 +1,72 @@
+import type { Command } from "commander";
+import { knownJournalStreams } from "@qawolf/api-contracts/v1";
+
+import { declareCommandKind } from "~/commands/commandKind.js";
+import { withAuthContext } from "~/commands/context.js";
+import { defaultFollowTimeoutSeconds } from "~/core/interactiveRunner/followTimeout.js";
+import { handleRunnerEvents } from "~/domains/interactiveRunner/events.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { runnerDeps, runnerFlagDescription } from "./context.js";
+
+const eventsExamples = `
+Examples:
+  $ qawolf runner events recorder --tail 5
+  $ qawolf runner events run-logs --run <runId> --follow
+  $ qawolf runner events console --since 120 --json`;
+
+type EventsFlags = {
+  follow: boolean;
+  run?: string;
+  runner?: string;
+  since?: string;
+  tail?: string;
+  timeout: string;
+};
+
+export function registerRunnerEventsCommand(
+  runner: Command,
+  signals: SignalRegistry,
+): void {
+  declareCommandKind(runner.command("events <stream>"), "read")
+    .description(
+      `Print a runner's journal, one entry per line. QA Wolf writes ${knownJournalStreams.join(", ")}`,
+    )
+    .option(
+      "--follow",
+      "Keep reading as new entries arrive. Reading counts as activity, so a follow left open keeps the runner alive and billing",
+      false,
+    )
+    .option("--run <id>", "Restrict run-scoped streams to one run")
+    .option("--runner <id>", runnerFlagDescription)
+    .option("--since <sequence>", "Read entries after this sequence")
+    .option("--tail <count>", "Read only the newest <count> entries")
+    .option(
+      "--timeout <seconds>",
+      "Give up following after this long. Reading keeps the runner alive, so a follow left open would otherwise bill until the terminal closed",
+      String(defaultFollowTimeoutSeconds),
+    )
+    .addHelpText("after", eventsExamples)
+    .action((stream: string, opts: EventsFlags, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerEvents(
+          ctx,
+          {
+            // --json is a global flag, so it is read from the parsed globals
+            // rather than declared here.
+            envelope: Boolean(
+              command.optsWithGlobals<{ json?: boolean }>().json,
+            ),
+            follow: opts.follow,
+            run: opts.run,
+            runner: opts.runner,
+            since: opts.since,
+            stream,
+            tail: opts.tail,
+            timeout: opts.timeout,
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+}

--- a/src/commands/runner/index.ts
+++ b/src/commands/runner/index.ts
@@ -6,7 +6,8 @@ import { registerRunnerImportPackageCommand } from "./importPackage.register.js"
 import { registerRunnerInspectCommands } from "./inspect.register.js";
 import { registerRunnerInteractCommands } from "./interact.register.js";
 import { registerRunnerLifecycleCommands } from "./lifecycle.register.js";
-import { registerRunnerRunCommands } from "./run.register.js";
+import { registerRunnerEventsCommand } from "./events.register.js";
+import { registerRunCommand } from "./run.register.js";
 
 export function registerRunnerCommand(
   program: Command,
@@ -17,7 +18,8 @@ export function registerRunnerCommand(
     .description("Drive an interactive runner on the QA Wolf platform");
 
   registerRunnerLifecycleCommands(runner, signals);
-  registerRunnerRunCommands(runner, signals);
+  registerRunCommand(runner, signals);
+  registerRunnerEventsCommand(runner, signals);
   registerRunnerInteractCommands(runner, signals);
   registerRunnerInspectCommands(runner, signals);
   registerRunnerImportPackageCommand(runner, signals);

--- a/src/commands/runner/run.register.ts
+++ b/src/commands/runner/run.register.ts
@@ -1,10 +1,8 @@
 import type { Command } from "commander";
-import { knownJournalStreams } from "@qawolf/api-contracts/v1";
 
 import { declareCommandKind } from "~/commands/commandKind.js";
 import { withAuthContext } from "~/commands/context.js";
 import { defaultFollowTimeoutSeconds } from "~/core/interactiveRunner/followTimeout.js";
-import { handleRunnerEvents } from "~/domains/interactiveRunner/events.js";
 import { handleRunnerRun } from "~/domains/interactiveRunner/runFlow.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
@@ -14,16 +12,14 @@ const runExamples = `
 Examples:
   $ qawolf runner run flows/checkout.flow.ts
   $ qawolf runner run flows/checkout.flow.ts --follow
-  $ qawolf runner run flows/checkout.flow.ts --follow --logs`;
-
-const eventsExamples = `
-Examples:
-  $ qawolf runner events recorder --tail 5
-  $ qawolf runner events run-logs --run <runId> --follow
-  $ qawolf runner events console --since 120 --json`;
+  $ qawolf runner run flows/checkout.flow.ts --follow --logs
+  $ qawolf runner run flows/checkout.flow.ts --lines 12-40
+  $ qawolf runner run flows/checkout.flow.ts --lines 4-9 --lines-file pages/login.ts`;
 
 type RunFlags = {
   follow: boolean;
+  lines?: string;
+  linesFile?: string;
   logs: boolean;
   recorderEvents: boolean;
   runEvents: boolean;
@@ -31,20 +27,11 @@ type RunFlags = {
   timeout: string;
 };
 
-type EventsFlags = {
-  follow: boolean;
-  run?: string;
-  runner?: string;
-  since?: string;
-  tail?: string;
-  timeout: string;
-};
-
-export function registerRunnerRunCommands(
+export function registerRunCommand(
   runner: Command,
   signals: SignalRegistry,
 ): void {
-  declareCommandKind(runner.command("run <file>"), "write")
+  declareCommandKind(runner.command("run <flowFile>"), "write")
     .description(
       "Run a flow on an interactive runner, shipping the current directory's files with it",
     )
@@ -70,6 +57,14 @@ export function registerRunnerRunCommands(
       "Stream the browser actions the runner records as JSON lines while following, from an anchor taken just before submission: the recorder is runner-wide, not run-scoped. Implies --follow",
       false,
     )
+    .option(
+      "--lines <start-end>",
+      "Run only these 1-indexed lines against the browser as it stands, instead of the whole flow from a fresh one",
+    )
+    .option(
+      "--lines-file <path>",
+      "File the --lines range lives in. Defaults to <flowFile>; pass it only when the lines are in another file, such as a page object",
+    )
     .option("--runner <id>", runnerFlagDescription)
     .option(
       "--timeout <seconds>",
@@ -77,59 +72,19 @@ export function registerRunnerRunCommands(
       String(defaultFollowTimeoutSeconds),
     )
     .addHelpText("after", runExamples)
-    .action((file: string, opts: RunFlags, command: Command) =>
+    .action((flowFile: string, opts: RunFlags, command: Command) =>
       withAuthContext(signals, (ctx) =>
         handleRunnerRun(
           ctx,
           {
-            entryPoint: file,
+            entryPoint: flowFile,
             follow: opts.follow,
+            lines: opts.lines,
+            linesFile: opts.linesFile,
             logs: opts.logs,
             recorderEvents: opts.recorderEvents,
             runEvents: opts.runEvents,
             runner: opts.runner,
-            timeout: opts.timeout,
-          },
-          runnerDeps(ctx),
-        ),
-      )(opts, command),
-    );
-
-  declareCommandKind(runner.command("events <stream>"), "read")
-    .description(
-      `Print a runner's journal, one entry per line. QA Wolf writes ${knownJournalStreams.join(", ")}`,
-    )
-    .option(
-      "--follow",
-      "Keep reading as new entries arrive. Reading counts as activity, so a follow left open keeps the runner alive and billing",
-      false,
-    )
-    .option("--run <id>", "Restrict run-scoped streams to one run")
-    .option("--runner <id>", runnerFlagDescription)
-    .option("--since <sequence>", "Read entries after this sequence")
-    .option("--tail <count>", "Read only the newest <count> entries")
-    .option(
-      "--timeout <seconds>",
-      "Give up following after this long. Reading keeps the runner alive, so a follow left open would otherwise bill until the terminal closed",
-      String(defaultFollowTimeoutSeconds),
-    )
-    .addHelpText("after", eventsExamples)
-    .action((stream: string, opts: EventsFlags, command: Command) =>
-      withAuthContext(signals, (ctx) =>
-        handleRunnerEvents(
-          ctx,
-          {
-            // --json is a global flag, so it is read from the parsed globals
-            // rather than declared here.
-            envelope: Boolean(
-              command.optsWithGlobals<{ json?: boolean }>().json,
-            ),
-            follow: opts.follow,
-            run: opts.run,
-            runner: opts.runner,
-            since: opts.since,
-            stream,
-            tail: opts.tail,
             timeout: opts.timeout,
           },
           runnerDeps(ctx),

--- a/src/core/interactiveRunner/lineSelection.test.ts
+++ b/src/core/interactiveRunner/lineSelection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildRunSelection } from "./lineSelection.js";
+
+const path = "flows/checkout.flow.ts";
+
+describe("buildRunSelection", () => {
+  it("reads a range as two 1-indexed inclusive lines", () => {
+    expect(buildRunSelection({ lines: "12-40", path })).toEqual({
+      ok: true,
+      selection: { endLine: 40, path, startLine: 12 },
+    });
+  });
+
+  it("takes a single-line range", () => {
+    expect(buildRunSelection({ lines: "7-7", path })).toEqual({
+      ok: true,
+      selection: { endLine: 7, path, startLine: 7 },
+    });
+  });
+
+  it("tolerates spaces around the dash", () => {
+    expect(buildRunSelection({ lines: " 12 - 40 ", path }).ok).toBe(true);
+  });
+
+  it("refuses a range that ends before it starts", () => {
+    const built = buildRunSelection({ lines: "40-12", path });
+
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toContain("startLine");
+  });
+
+  it("refuses a line that is not a positive whole number", () => {
+    expect(buildRunSelection({ lines: "0-4", path }).ok).toBe(false);
+    expect(buildRunSelection({ lines: "1.5-4", path }).ok).toBe(false);
+    expect(buildRunSelection({ lines: "-1-4", path }).ok).toBe(false);
+  });
+
+  it("names the flag's shape when the range is not one", () => {
+    const built = buildRunSelection({ lines: "12", path });
+
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toContain("--lines 12-40");
+  });
+
+  it("refuses a path that would not travel to a runner", () => {
+    expect(buildRunSelection({ lines: "1-2", path: "../outside.ts" }).ok).toBe(
+      false,
+    );
+  });
+});

--- a/src/core/interactiveRunner/lineSelection.ts
+++ b/src/core/interactiveRunner/lineSelection.ts
@@ -1,0 +1,38 @@
+import {
+  type RunSelection,
+  runSelectionSchema,
+} from "@qawolf/api-contracts/v1";
+import { z } from "zod";
+
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+
+export type BuiltRunSelection =
+  | { ok: true; selection: RunSelection }
+  | { ok: false; error: string };
+
+const lineRangePattern = /^(\d+)\s*-\s*(\d+)$/;
+
+/** One `--lines start-end` range, against the file the lines live in. */
+export function buildRunSelection(options: {
+  lines: string;
+  path: string;
+}): BuiltRunSelection {
+  const match = lineRangePattern.exec(options.lines.trim());
+  if (match === null) {
+    return {
+      error: interactiveRunnerMessages.malformedLineRange(options.lines),
+      ok: false,
+    };
+  }
+
+  const [, startLine, endLine] = match;
+  const parsed = runSelectionSchema.safeParse({
+    endLine: Number(endLine),
+    path: options.path,
+    startLine: Number(startLine),
+  });
+  if (!parsed.success) {
+    return { error: z.prettifyError(parsed.error), ok: false };
+  }
+  return { ok: true, selection: parsed.data };
+}

--- a/src/core/messages/interactiveRunner.ts
+++ b/src/core/messages/interactiveRunner.ts
@@ -54,6 +54,12 @@ export const interactiveRunnerMessages = {
     `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:
     "No package.json in the current directory. A run reads its npm dependencies from one, so it has to travel with the flow.",
+  malformedLineRange: (lines: string) =>
+    `"${lines}" is not a line range. Pass --lines as two 1-indexed line numbers joined by a dash, e.g. --lines 12-40.`,
+  linesFileWithoutLines:
+    "--lines-file names where a line range lives, so it only means something with --lines. Pass --lines, or drop --lines-file to run the whole flow.",
+  bootstrappedForSelection:
+    "This runner had no browser, so one was started before your lines ran. They ran against a fresh page, not the one an earlier run left: nothing is signed in and nothing was set up.",
   missingPackageJsonForImport:
     "No package.json in the current directory. The install resolves against the run's own dependencies, which are read from one.",
   noRunnerIdForImport: `${noRunnerId} An install also needs a live run to go into, which a runner gets from qawolf runner run.`,

--- a/src/domains/interactiveRunner/prepareRun.ts
+++ b/src/domains/interactiveRunner/prepareRun.ts
@@ -1,0 +1,72 @@
+import type { RunFiles, RunSelection } from "@qawolf/api-contracts/v1";
+
+import { buildRunSelection } from "~/core/interactiveRunner/lineSelection.js";
+import {
+  checkRunFiles,
+  describeRunFilesCheck,
+  toCollectedPath,
+} from "~/core/interactiveRunner/runFiles.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import { exitCodes } from "~/shell/exit.js";
+
+import { collectRunFiles } from "./collectFiles.js";
+import type { InteractiveRunnerDeps } from "./deps.js";
+
+export type PreparedRun =
+  | { ok: true; files: RunFiles; selection: RunSelection | undefined }
+  | { ok: false; error: string; exitCode: number };
+
+const refused = (error: string, exitCode: number): PreparedRun => ({
+  error,
+  exitCode,
+  ok: false,
+});
+
+/**
+ * Everything a run needs off disk, gathered before a runner is resolved so a
+ * misspelled flow name is not answered with a billed pod. A selection naming a
+ * path the request does not carry is caught here, where the path can be named,
+ * rather than coming back as a schema error.
+ */
+export async function prepareRun(
+  options: {
+    entryPointPath: string;
+    lines: string | undefined;
+    linesFile: string | undefined;
+  },
+  deps: InteractiveRunnerDeps,
+): Promise<PreparedRun> {
+  const collected = await collectRunFiles(deps);
+  if (!collected.ok) return refused(collected.error, exitCodes.config);
+
+  const files = collected.files;
+  const check = checkRunFiles(files, options.entryPointPath);
+  if (check.type !== "ok") {
+    return refused(describeRunFilesCheck(check), exitCodes.invalidArgs);
+  }
+
+  if (options.lines === undefined) {
+    return options.linesFile === undefined
+      ? { files, ok: true, selection: undefined }
+      : refused(
+          interactiveRunnerMessages.linesFileWithoutLines,
+          exitCodes.invalidArgs,
+        );
+  }
+
+  const path =
+    options.linesFile === undefined
+      ? options.entryPointPath
+      : toCollectedPath(deps.cwd, options.linesFile);
+  if (!Object.hasOwn(files, path)) {
+    return refused(
+      interactiveRunnerMessages.fileNotCollected(path),
+      exitCodes.invalidArgs,
+    );
+  }
+
+  const built = buildRunSelection({ lines: options.lines, path });
+  return built.ok
+    ? { files, ok: true, selection: built.selection }
+    : refused(built.error, exitCodes.invalidArgs);
+}

--- a/src/domains/interactiveRunner/runFlow.follow.test.ts
+++ b/src/domains/interactiveRunner/runFlow.follow.test.ts
@@ -22,6 +22,8 @@ const runFollowing = (
     {
       entryPoint: "flow.ts",
       follow: options.follow ?? true,
+      lines: undefined,
+      linesFile: undefined,
       logs: options.logs ?? false,
       recorderEvents: options.recorderEvents ?? false,
       runEvents: options.runEvents ?? false,

--- a/src/domains/interactiveRunner/runFlow.selection.test.ts
+++ b/src/domains/interactiveRunner/runFlow.selection.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { handleRunnerRun } from "./runFlow.js";
+
+const submitted = { outcome: "success" as const, runId: "run-a" };
+
+async function runWith(options: {
+  bootstrappedRunner?: boolean | undefined;
+  entryPoint?: string;
+  lines?: string;
+  linesFile?: string;
+}) {
+  const { callPublicApi, ctx } = makeAuthCtx();
+  callPublicApi.mockResolvedValue({
+    ok: true,
+    value:
+      options.bootstrappedRunner === undefined
+        ? submitted
+        : { ...submitted, bootstrappedRunner: options.bootstrappedRunner },
+  });
+  const result = await handleRunnerRun(
+    ctx,
+    {
+      entryPoint: options.entryPoint ?? "flow.ts",
+      follow: false,
+      lines: options.lines,
+      linesFile: options.linesFile,
+      logs: false,
+      recorderEvents: false,
+      runEvents: false,
+      runner: "ci",
+      timeout: undefined,
+    },
+    makeTestDeps({
+      collectRunFiles: async () => ({
+        "flow.ts": "export default {};",
+        "package.json": "{}",
+        "pages/login.ts": "export const login = () => {};",
+      }),
+    }),
+  );
+  return { callPublicApi, ctx, result };
+}
+
+function selectionOf(
+  callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"],
+): unknown {
+  const [request] = callPublicApi.mock.calls[0]?.slice(1) ?? [];
+  if (request === null || typeof request !== "object") return undefined;
+  return Reflect.get(request, "selection");
+}
+
+describe("handleRunnerRun with --lines", () => {
+  it("sends the range against the flow file by default", async () => {
+    const { callPublicApi, result } = await runWith({ lines: "12-40" });
+
+    expect(result).toBeUndefined();
+    expect(selectionOf(callPublicApi)).toEqual({
+      endLine: 40,
+      path: "flow.ts",
+      startLine: 12,
+    });
+  });
+
+  it("sends the range against another file when one is named", async () => {
+    const { callPublicApi } = await runWith({
+      lines: "4-9",
+      linesFile: "pages/login.ts",
+    });
+
+    expect(selectionOf(callPublicApi)).toMatchObject({
+      path: "pages/login.ts",
+    });
+  });
+
+  it("sends no selection when no range was asked for", async () => {
+    const { callPublicApi } = await runWith({});
+
+    expect(selectionOf(callPublicApi)).toBeUndefined();
+  });
+
+  it("refuses a lines-file that would not travel with the run", async () => {
+    const { callPublicApi, result } = await runWith({
+      lines: "1-2",
+      linesFile: "../outside.ts",
+    });
+
+    expect(result?.error).toContain("outside.ts");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("refuses a lines-file with no range to put in it", async () => {
+    const { callPublicApi, result } = await runWith({
+      linesFile: "pages/login.ts",
+    });
+
+    expect(result?.error).toContain("--lines");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("refuses a malformed range before addressing a runner", async () => {
+    const { callPublicApi, result } = await runWith({ lines: "twelve" });
+
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("says so when the runner had to be bootstrapped first", async () => {
+    const { ctx } = await runWith({
+      bootstrappedRunner: true,
+      lines: "12-40",
+    });
+
+    expect(ctx.ui.info).toHaveBeenCalledWith(
+      expect.stringContaining("fresh page"),
+    );
+  });
+
+  it("stays quiet about a bootstrap the runner did not report", async () => {
+    for (const bootstrappedRunner of [false, undefined]) {
+      const { ctx } = await runWith({ bootstrappedRunner, lines: "12-40" });
+
+      expect(ctx.ui.info).not.toHaveBeenCalledWith(
+        expect.stringContaining("fresh page"),
+      );
+    }
+  });
+});

--- a/src/domains/interactiveRunner/runFlow.test.ts
+++ b/src/domains/interactiveRunner/runFlow.test.ts
@@ -9,7 +9,7 @@ const submitted = { outcome: "success" as const, runId: "run-a" };
 
 async function runWith(
   value: unknown,
-  options: { entryPoint?: string } = {},
+  options: { entryPoint?: string; lines?: string; linesFile?: string } = {},
 ): Promise<{
   ctx: ReturnType<typeof makeAuthCtx>["ctx"];
   callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"];
@@ -22,6 +22,8 @@ async function runWith(
     {
       entryPoint: options.entryPoint ?? "flow.ts",
       follow: false,
+      lines: options.lines,
+      linesFile: options.linesFile,
       runner: "ci",
       timeout: undefined,
       logs: false,
@@ -67,6 +69,8 @@ describe("handleRunnerRun", () => {
       {
         entryPoint: "flows/missing.ts",
         follow: false,
+        lines: undefined,
+        linesFile: undefined,
         runner: "ci",
         timeout: undefined,
         logs: false,
@@ -89,6 +93,8 @@ describe("handleRunnerRun", () => {
       {
         entryPoint: "flow.ts",
         follow: false,
+        lines: undefined,
+        linesFile: undefined,
         runner: "ci",
         timeout: undefined,
         logs: false,
@@ -148,6 +154,8 @@ describe("handleRunnerRun", () => {
       {
         entryPoint: "flows/chekcout.flow.ts",
         follow: false,
+        lines: undefined,
+        linesFile: undefined,
         runner: undefined,
         timeout: undefined,
         logs: false,
@@ -182,6 +190,8 @@ describe("handleRunnerRun", () => {
       {
         entryPoint: "flow.ts",
         follow: false,
+        lines: undefined,
+        linesFile: undefined,
         runner: undefined,
         timeout: undefined,
         logs: false,
@@ -216,6 +226,8 @@ describe("handleRunnerRun", () => {
       {
         entryPoint: "flow.ts",
         follow: false,
+        lines: undefined,
+        linesFile: undefined,
         runner: "ci",
         timeout: undefined,
         logs: false,

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -1,11 +1,7 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
 import { parseFollowTimeout } from "~/core/interactiveRunner/followTimeout.js";
-import {
-  checkRunFiles,
-  describeRunFilesCheck,
-  toCollectedPath,
-} from "~/core/interactiveRunner/runFiles.js";
+import { toCollectedPath } from "~/core/interactiveRunner/runFiles.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import type {
   AuthCommandContext,
@@ -14,12 +10,12 @@ import type {
 import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
-import { collectRunFiles } from "./collectFiles.js";
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRecorderAnchor } from "./followPrinters.js";
 import { describeRunSubmitFailure } from "./runSubmitFailure.js";
 import { followRun } from "./followRun.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
+import { prepareRun } from "./prepareRun.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 
 export async function handleRunnerRun(
@@ -27,6 +23,8 @@ export async function handleRunnerRun(
   options: {
     entryPoint: string;
     follow: boolean;
+    lines: string | undefined;
+    linesFile: string | undefined;
     logs: boolean;
     recorderEvents: boolean;
     runEvents: boolean;
@@ -44,17 +42,12 @@ export async function handleRunnerRun(
   // nothing and resolving a runner may launch and bill one. A misspelled flow
   // name should not be answered with a pod.
   const entryPointPath = toCollectedPath(deps.cwd, options.entryPoint);
-  const collected = await collectRunFiles(deps);
-  if (!collected.ok) {
-    return { error: collected.error, exitCode: exitCodes.config };
-  }
-  const files = collected.files;
-  const check = checkRunFiles(files, entryPointPath);
-  if (check.type !== "ok") {
-    return {
-      error: describeRunFilesCheck(check),
-      exitCode: exitCodes.invalidArgs,
-    };
+  const prepared = await prepareRun(
+    { entryPointPath, lines: options.lines, linesFile: options.linesFile },
+    deps,
+  );
+  if (!prepared.ok) {
+    return { error: prepared.error, exitCode: prepared.exitCode };
   }
 
   const resolved = await resolveRunner(
@@ -76,7 +69,14 @@ export async function handleRunnerRun(
 
   const result = await ctx.platformClient.callPublicApi(
     publicContractsV1.runner.runFlow,
-    { entryPointPath, files, id: resolved.runnerId },
+    {
+      entryPointPath,
+      files: prepared.files,
+      id: resolved.runnerId,
+      ...(prepared.selection === undefined
+        ? {}
+        : { selection: prepared.selection }),
+    },
     runnerCallOptions,
   );
   if (!result.ok) {
@@ -98,6 +98,12 @@ export async function handleRunnerRun(
         error: interactiveRunnerMessages.runSubmitAnsweredUnknown(outcome),
         exitCode: exitCodes.network,
       };
+  }
+
+  // Absent means false. The pod and apex halves of this field land later, so a
+  // runner that did bootstrap may still say nothing.
+  if (result.value.bootstrappedRunner === true) {
+    ctx.ui.info(interactiveRunnerMessages.bootstrappedForSelection);
   }
 
   const runId = result.value.runId;


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.27.0` added `selection` to `runner.runFlow`, which runs a line range against the browser as it stands instead of the whole flow from a fresh one. The CLI had no way to send it, so iterating on one step meant running the entire flow to reach it again.

- [x] Add `--lines <start-end>` to `qawolf runner run`, sending the range as the request's `selection`
- [x] Add `--lines-file <path>` for a range that lives in another file, defaulting to the positional
- [x] Rename the positional to `<flowFile>` in the usage line, the help text and the examples, since two file paths with one unlabelled is what makes them easy to swap
- [x] Parse the range against the published `runSelectionSchema`, so the ordering and whole-number rules come from the same place the server applies them
- [x] Refuse a lines-file the request does not carry, naming the path, rather than letting it come back as a schema error
- [x] Refuse `--lines-file` on its own, since it only says where a range lives
- [x] Say on stderr when the runner had no browser and one was started first, so a caller knows the lines ran against a fresh page rather than the one an earlier run left
- [x] Treat an absent `bootstrappedRunner` as false, since the pod and apex halves of that field land later
- [x] Move the collect, check and select phase into `prepareRun.ts`, with no change to what it does
- [x] Move the `events` registration into `events.register.ts`, with no change to what it does
- [x] Document the two file paths and the fresh-page warning in `references/runner.md`
- [x] Cover the range rules, both file paths, the refusals and the bootstrap notice

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1753 pass  0 fail`. The other five give exit 0.

- `qawolf runner run --help` shows `--lines` and `--lines-file`, and the usage line reads `<flowFile>`.
- Added lines, excluding `bun.lock` and snapshots: 471, over the 400 warning threshold in `scripts/check-pr-size.sh` and under the 600 error threshold.
