### PR TITLE
refactor(runner): add the flow import resolver

### DIFF
--- a/src/core/interactiveRunner/getImports.test.ts
+++ b/src/core/interactiveRunner/getImports.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import typescript from "typescript";
+
+import { getImports } from "./getImports.js";
+
+const importsOf = (content: string, path = "src/flows/checkout.flow.ts") =>
+  getImports({
+    content,
+    path,
+    tsconfigPaths: { "~/*": ["src/*"] },
+    typescript,
+  });
+
+describe("getImports", () => {
+  it("collects relative and aliased static imports", () => {
+    expect(
+      importsOf(`
+        import { login } from "../pages/login";
+        import type { Cart } from "~/types/cart";
+        export default {};
+      `),
+    ).toEqual(["../pages/login", "~/types/cart"]);
+  });
+
+  it("leaves bare specifiers to npm", () => {
+    expect(
+      importsOf(`
+        import { expect } from "playwright";
+        import { flow } from "@qawolf/flows";
+        import { login } from "./login";
+      `),
+    ).toEqual(["./login"]);
+  });
+
+  it("collects a dynamic import anywhere in the file, awaited or not", () => {
+    expect(
+      importsOf(`
+        const lazy = () => import("./lazy");
+        async function run() {
+          const eager = await import("~/pages/login");
+          return eager;
+        }
+      `),
+    ).toEqual(["./lazy", "~/pages/login"]);
+  });
+
+  it("reports a path once when it is both statically and dynamically imported", () => {
+    expect(
+      importsOf(`
+        import type { Page } from "./page";
+        const lazy = () => import("./page");
+      `),
+    ).toEqual(["./page"]);
+  });
+
+  it("ignores a dynamic import whose specifier is not a literal", () => {
+    expect(importsOf("const load = (p: string) => import(p);")).toEqual([]);
+  });
+
+  it("does not see export-from or require, matching the socket path", () => {
+    expect(
+      importsOf(`
+        export { login } from "./login";
+        export * from "./helpers";
+        const legacy = require("./legacy");
+      `),
+    ).toEqual([]);
+  });
+
+  it("parses a tsx file as tsx, from the filename", () => {
+    expect(
+      importsOf(
+        'import { Widget } from "./widget";\nconst node = <Widget />;',
+        "src/flows/checkout.flow.tsx",
+      ),
+    ).toEqual(["./widget"]);
+  });
+
+  it("collects nothing from a file that imports nothing", () => {
+    expect(importsOf("export default {};")).toEqual([]);
+  });
+});

--- a/src/core/interactiveRunner/getImports.ts
+++ b/src/core/interactiveRunner/getImports.ts
@@ -1,0 +1,70 @@
+import type ts from "typescript";
+
+import type { TsconfigPaths } from "./tsconfigPaths.js";
+
+export function getImports(options: {
+  content: string;
+  path: string;
+  tsconfigPaths: TsconfigPaths | undefined;
+  typescript: typeof ts;
+}): string[] {
+  const { typescript: compiler } = options;
+  const sourceFile = compiler.createSourceFile(
+    options.path,
+    options.content,
+    compiler.ScriptTarget.Latest,
+    true,
+  );
+
+  const isLocal = (importPath: string) =>
+    importPath.startsWith("./") ||
+    importPath.startsWith("../") ||
+    isPathAlias(importPath, options.tsconfigPaths);
+
+  const found: string[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (!compiler.isImportDeclaration(statement)) continue;
+    const { moduleSpecifier } = statement;
+    if (!compiler.isStringLiteral(moduleSpecifier)) continue;
+    if (isLocal(moduleSpecifier.text)) found.push(moduleSpecifier.text);
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (isDynamicImportCall(node, compiler)) {
+      const [argument] = node.arguments;
+      if (
+        argument !== undefined &&
+        compiler.isStringLiteral(argument) &&
+        isLocal(argument.text)
+      ) {
+        found.push(argument.text);
+      }
+    }
+    compiler.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return [...new Set(found)];
+}
+
+function isDynamicImportCall(
+  node: ts.Node,
+  compiler: typeof ts,
+): node is ts.CallExpression {
+  return (
+    compiler.isCallExpression(node) &&
+    node.expression.kind === compiler.SyntaxKind.ImportKeyword
+  );
+}
+
+/** A prefix match alone. The socket path collects a pattern naming no target. */
+function isPathAlias(
+  importPath: string,
+  paths: TsconfigPaths | undefined,
+): boolean {
+  if (paths === undefined) return false;
+  return Object.keys(paths).some((pattern) =>
+    importPath.startsWith(pattern.replace("*", "")),
+  );
+}

--- a/src/core/interactiveRunner/resolveImportPath.test.ts
+++ b/src/core/interactiveRunner/resolveImportPath.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveImportPath } from "./resolveImportPath.js";
+
+const held = new Set([
+  "package.json",
+  "src/flows/checkout.flow.ts",
+  "src/helpers.js",
+  "src/pages/index.ts",
+  "src/pages/login.ts",
+]);
+
+const resolve = (
+  importPath: string,
+  importingFilePath = "src/flows/checkout.flow.ts",
+) =>
+  resolveImportPath({
+    importPath,
+    importingFilePath,
+    repositoryFilePaths: held,
+    tsconfigPaths: { "~/*": ["src/*"] },
+  });
+
+describe("resolveImportPath", () => {
+  it("resolves a relative import against the importing file's directory", () => {
+    expect(resolve("../pages/login")).toEqual({
+      path: "src/pages/login.ts",
+      type: "resolved",
+    });
+  });
+
+  it("resolves an alias target against the project root", () => {
+    expect(resolve("~/pages/login")).toEqual({
+      path: "src/pages/login.ts",
+      type: "resolved",
+    });
+  });
+
+  it("tries .ts, .js, /index.ts then /index.js, and never the bare path", () => {
+    expect(resolve("../helpers")).toEqual({
+      path: "src/helpers.js",
+      type: "resolved",
+    });
+    expect(resolve("../pages")).toEqual({
+      path: "src/pages/index.ts",
+      type: "resolved",
+    });
+    expect(
+      resolveImportPath({
+        importPath: "./bare",
+        importingFilePath: "src/flow.ts",
+        repositoryFilePaths: new Set(["src/bare"]),
+        tsconfigPaths: undefined,
+      }),
+    ).toEqual({ type: "unresolved-repository-import" });
+  });
+
+  it("tries the other supported extension when one is explicit", () => {
+    expect(resolve("../pages/login.js")).toEqual({
+      path: "src/pages/login.ts",
+      type: "resolved",
+    });
+    expect(resolve("../helpers.ts")).toEqual({
+      path: "src/helpers.js",
+      type: "resolved",
+    });
+  });
+
+  it("does not reach an extension the resolver does not try", () => {
+    expect(
+      resolveImportPath({
+        importPath: "./widget.tsx",
+        importingFilePath: "src/flow.ts",
+        repositoryFilePaths: new Set(["src/widget.tsx"]),
+        tsconfigPaths: undefined,
+      }),
+    ).toEqual({ type: "unresolved-repository-import" });
+  });
+
+  it("leaves a bare specifier to npm rather than reporting it", () => {
+    expect(resolve("playwright")).toEqual({ type: "not-a-repository-import" });
+    expect(resolve("@qawolf/flows")).toEqual({
+      type: "not-a-repository-import",
+    });
+  });
+
+  it("reports a relative or aliased import that matches nothing", () => {
+    expect(resolve("./missing")).toEqual({
+      type: "unresolved-repository-import",
+    });
+    expect(resolve("~/missing")).toEqual({
+      type: "unresolved-repository-import",
+    });
+  });
+
+  it("resolves with forward slashes whatever the platform separator is", () => {
+    expect(resolve("./nested/../../pages/login")).toEqual({
+      path: "src/pages/login.ts",
+      type: "resolved",
+    });
+  });
+});

--- a/src/core/interactiveRunner/resolveImportPath.ts
+++ b/src/core/interactiveRunner/resolveImportPath.ts
@@ -1,0 +1,83 @@
+// Posix, not the platform's separator. Collected paths always use forward
+// slashes, so resolving with backslashes on Windows would match nothing.
+import { dirname, join, normalize } from "node:path/posix";
+
+import { resolvePathAlias, type TsconfigPaths } from "./tsconfigPaths.js";
+
+/** So `.tsx`, `.json`, `.mjs` and `.cjs` imports are unreachable. */
+const supportedExtensions = [".ts", ".js"];
+
+export type ResolvedImportPath =
+  | { type: "resolved"; path: string }
+  | { type: "not-a-repository-import" }
+  | { type: "unresolved-repository-import" };
+
+/** Tries the other extension too, since `./page.js` may be `./page.ts` on disk. */
+function candidatesForExplicitExtension(options: {
+  importPath: string;
+  resolvedPath: string;
+}): string[] {
+  const matching = supportedExtensions.find((extension) =>
+    options.importPath.endsWith(extension),
+  );
+  if (matching === undefined) return [options.resolvedPath];
+
+  const withoutExtension = options.resolvedPath.slice(0, -matching.length);
+  return [
+    options.resolvedPath,
+    ...supportedExtensions
+      .filter((extension) => extension !== matching)
+      .map((extension) => `${withoutExtension}${extension}`),
+  ];
+}
+
+/**
+ * An alias target roots at the project, a relative import at the importing
+ * file's directory. Conflating those two is the easiest way to get this wrong.
+ */
+export function resolveImportPath(options: {
+  importPath: string;
+  importingFilePath: string;
+  repositoryFilePaths: ReadonlySet<string>;
+  tsconfigPaths: TsconfigPaths | undefined;
+}): ResolvedImportPath {
+  const aliasTarget = resolvePathAlias(
+    options.importPath,
+    options.tsconfigPaths,
+  );
+  const resolvedPath =
+    aliasTarget === undefined
+      ? normalize(join(dirname(options.importingFilePath), options.importPath))
+      : normalize(aliasTarget);
+
+  const hasExplicitExtension = supportedExtensions.some((extension) =>
+    options.importPath.endsWith(extension),
+  );
+  // No bare path, so a directory resolves through its index rather than itself.
+  const candidates = hasExplicitExtension
+    ? candidatesForExplicitExtension({
+        importPath: options.importPath,
+        resolvedPath,
+      })
+    : [
+        `${resolvedPath}.ts`,
+        `${resolvedPath}.js`,
+        `${resolvedPath}/index.ts`,
+        `${resolvedPath}/index.js`,
+      ];
+
+  for (const candidate of candidates) {
+    if (options.repositoryFilePaths.has(candidate)) {
+      return { path: candidate, type: "resolved" };
+    }
+  }
+
+  const isRepositoryImport =
+    aliasTarget !== undefined ||
+    options.importPath.startsWith("./") ||
+    options.importPath.startsWith("../");
+
+  return isRepositoryImport
+    ? { type: "unresolved-repository-import" }
+    : { type: "not-a-repository-import" };
+}

--- a/src/core/interactiveRunner/tsconfigPaths.test.ts
+++ b/src/core/interactiveRunner/tsconfigPaths.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseTsconfigPaths, resolvePathAlias } from "./tsconfigPaths.js";
+
+describe("parseTsconfigPaths", () => {
+  it("reads compilerOptions.paths", () => {
+    expect(
+      parseTsconfigPaths('{"compilerOptions":{"paths":{"~/*":["src/*"]}}}'),
+    ).toEqual({ "~/*": ["src/*"] });
+  });
+
+  it("contributes nothing rather than throwing", () => {
+    expect(parseTsconfigPaths("{ not json")).toBeUndefined();
+    expect(parseTsconfigPaths("[]")).toBeUndefined();
+    expect(parseTsconfigPaths("{}")).toBeUndefined();
+    expect(parseTsconfigPaths('{"compilerOptions":{}}')).toBeUndefined();
+    expect(
+      parseTsconfigPaths('{"compilerOptions":{"paths":"~/*"}}'),
+    ).toBeUndefined();
+    expect(
+      parseTsconfigPaths('{"compilerOptions":{"paths":{"~/*":[1]}}}'),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolvePathAlias", () => {
+  const paths = { "@pages/*": ["src/pages/*"], "~/*": ["src/*"] };
+
+  it("substitutes the suffix into the target", () => {
+    expect(resolvePathAlias("~/pages/login", paths)).toBe("src/pages/login");
+    expect(resolvePathAlias("@pages/login", paths)).toBe("src/pages/login");
+  });
+
+  it("matches a pattern with no wildcard by its whole name", () => {
+    expect(resolvePathAlias("~config", { "~config": ["src/config.ts"] })).toBe(
+      "src/config.ts",
+    );
+  });
+
+  it("answers nothing for an import no pattern prefixes", () => {
+    expect(resolvePathAlias("playwright", paths)).toBeUndefined();
+    expect(resolvePathAlias("./relative", paths)).toBeUndefined();
+    expect(resolvePathAlias("~/anything", undefined)).toBeUndefined();
+  });
+
+  it("honours only the first target", () => {
+    expect(resolvePathAlias("~/page", { "~/*": ["first/*", "second/*"] })).toBe(
+      "first/page",
+    );
+  });
+
+  it("answers nothing for a pattern naming no target", () => {
+    expect(resolvePathAlias("~/page", { "~/*": [] })).toBeUndefined();
+  });
+});

--- a/src/core/interactiveRunner/tsconfigPaths.ts
+++ b/src/core/interactiveRunner/tsconfigPaths.ts
@@ -1,0 +1,56 @@
+export type TsconfigPaths = Record<string, string[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTsconfigPaths(value: unknown): value is TsconfigPaths {
+  return (
+    isRecord(value) &&
+    Object.values(value).every(
+      (targets) =>
+        Array.isArray(targets) &&
+        targets.every((target) => typeof target === "string"),
+    )
+  );
+}
+
+/** An unreadable tsconfig contributes no aliases rather than failing the run. */
+export function parseTsconfigPaths(
+  tsconfigContent: string,
+): TsconfigPaths | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(tsconfigContent);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) return undefined;
+
+  const compilerOptions = parsed["compilerOptions"];
+  if (!isRecord(compilerOptions)) return undefined;
+
+  const paths = compilerOptions["paths"];
+  return isTsconfigPaths(paths) ? paths : undefined;
+}
+
+/**
+ * Only the first target of the first matching pattern, as the socket path does.
+ * Honouring the rest would ship a different file set than a socket run.
+ */
+export function resolvePathAlias(
+  importPath: string,
+  paths: TsconfigPaths | undefined,
+): string | undefined {
+  if (paths === undefined) return undefined;
+
+  for (const [pattern, targets] of Object.entries(paths)) {
+    const prefix = pattern.replace("*", "");
+    if (!importPath.startsWith(prefix)) continue;
+    const [target] = targets;
+    if (target !== undefined) {
+      return target.replace("*", importPath.slice(prefix.length));
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
# Overview of Changes

`qawolf runner run` ships every shippable file under the working directory, so on a workspace where a flow reaches ten files it collects thousands and the request is refused on size before it ever runs. A socket run does not do this: it walks the flow's import graph. This ports that resolver so the CLI can do the same, as pure functions with no disk access; the walk that uses them is a separate change.

- [x] Port `parseTsconfigPaths` and `resolvePathAlias`, honouring only the first target of the first matching pattern as the socket path does
- [x] Port `getImports`, collecting top-level static imports and dynamic `import()` calls anywhere in the file, deduplicated
- [x] Keep that walk's gaps, so `export ... from` and `require()` stay invisible and the CLI ships the same file set a socket run does
- [x] Match on an alias prefix alone rather than a resolvable target, since a pattern naming no target still counts as an import to collect
- [x] Port `resolveImportPath`, resolving an alias against the project root and a relative import against the importing file's directory
- [x] Try `.ts`, `.js`, `/index.ts` then `/index.js`, never the bare path, and try the other supported extension when one is explicit
- [x] Answer `not-a-repository-import` for a bare specifier and `unresolved-repository-import` for a relative or aliased import that matches nothing
- [x] Resolve with `node:path/posix`, since collected paths always use forward slashes and backslashes would match nothing on Windows
- [x] Take the TypeScript compiler as a parameter, so `core/` stays free of I/O and nothing loads the compiler at runtime yet
- [x] Cover every behaviour above, including the two gaps and the unreachable `.tsx` extension

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1788 pass  0 fail`, 31 of them new. The other five give exit 0.

- `bun run build` leaves `dist/cli.js` at 7.1 MB with no `createSourceFile` in it, confirming the type-only compiler import erases and nothing new is bundled.
- Added lines, excluding `bun.lock` and snapshots: 453, over the 400 warning threshold in `scripts/check-pr-size.sh` and under the 600 error threshold.
