### PR TITLE
feat(runner): add content addressable delta shipping support

### DIFF
--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -168,6 +168,13 @@ at most 30 MiB in total. A missing file, a missing `package.json` and files over
 the cap are all refused before any runner is resolved or launched, so a typo
 costs nothing.
 
+After the first run on a runner, later runs send only the files whose content
+changed, so iterating on one flow costs a small request rather than the whole
+graph again. `--json` reports which happened as `fileSync`, `delta` or `full`.
+Nothing about this needs managing: the baseline lives in `.qawolf/runner-files.json`,
+a switch to another runner ignores it, and a runner that turns out not to hold
+what was claimed gets the whole set resent automatically.
+
 The call answers with a run id as soon as the run is accepted. **The outcome is
 not in that answer**, it is in the `run-status` stream, whose entries carry
 `runId`, `status` and an `errorMessage` when there is one.

--- a/src/core/interactiveRunner/fileDelta.test.ts
+++ b/src/core/interactiveRunner/fileDelta.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildRunFileDelta,
+  hashRunFile,
+  toRunFilesManifest,
+} from "./fileDelta.js";
+
+const flowPath = "src/flows/checkout.flow.ts";
+const files = {
+  "package.json": "{}",
+  "src/flows/checkout.flow.ts": "export default {};",
+  "src/pages/login.ts": "export const login = 1;",
+};
+
+const manifestFor = (from: Record<string, string>, runnerId = "ci") =>
+  toRunFilesManifest({ files: from, runnerId });
+
+const delta = (
+  held: ReturnType<typeof manifestFor> | undefined,
+  runnerId = "ci",
+) => buildRunFileDelta({ entryPointPath: flowPath, files, held, runnerId });
+
+describe("hashRunFile", () => {
+  it("hashes content, not the path it came from", () => {
+    expect(hashRunFile("a")).toBe(hashRunFile("a"));
+    expect(hashRunFile("a")).not.toBe(hashRunFile("b"));
+    expect(hashRunFile("")).toHaveLength(64);
+  });
+});
+
+describe("toRunFilesManifest", () => {
+  it("records every file by path, sorted", () => {
+    expect(manifestFor(files).files.map((entry) => entry.path)).toEqual([
+      "package.json",
+      "src/flows/checkout.flow.ts",
+      "src/pages/login.ts",
+    ]);
+  });
+});
+
+describe("buildRunFileDelta", () => {
+  it("sends everything when the runner holds nothing", () => {
+    expect(delta(undefined)).toEqual({ files, unchangedFiles: undefined });
+  });
+
+  it("sends everything when the baseline belongs to another runner", () => {
+    expect(delta(manifestFor(files, "other"))).toEqual({
+      files,
+      unchangedFiles: undefined,
+    });
+  });
+
+  it("keeps the entry point and package.json in full even when unchanged", () => {
+    const built = delta(manifestFor(files));
+
+    expect(Object.keys(built.files).sort()).toEqual([
+      "package.json",
+      "src/flows/checkout.flow.ts",
+    ]);
+    expect(built.unchangedFiles).toEqual({
+      "src/pages/login.ts": hashRunFile(files["src/pages/login.ts"]),
+    });
+  });
+
+  it("sends a file whose content moved since the baseline", () => {
+    const stale = manifestFor({ ...files, "src/pages/login.ts": "old" });
+    const built = delta(stale);
+
+    expect(built.files["src/pages/login.ts"]).toBe(files["src/pages/login.ts"]);
+    expect(built.unchangedFiles).toBeUndefined();
+  });
+
+  it("sends a file the baseline never held", () => {
+    const partial = manifestFor({
+      "package.json": "{}",
+      "src/flows/checkout.flow.ts": "export default {};",
+    });
+
+    expect(delta(partial).unchangedFiles).toBeUndefined();
+  });
+
+  it("never names a path in both halves", () => {
+    const built = delta(manifestFor(files));
+
+    for (const path of Object.keys(built.unchangedFiles ?? {})) {
+      expect(Object.hasOwn(built.files, path)).toBe(false);
+    }
+  });
+});

--- a/src/core/interactiveRunner/fileDelta.ts
+++ b/src/core/interactiveRunner/fileDelta.ts
@@ -1,0 +1,70 @@
+import { type RunFiles, runPackageJsonPath } from "@qawolf/api-contracts/v1";
+import { createHash } from "node:crypto";
+
+type RunFileEntry = { contentHash: string; path: string };
+
+export type RunFilesManifest = {
+  files: RunFileEntry[];
+  runnerId: string;
+  version: 1;
+};
+
+export type RunFileDelta = {
+  files: RunFiles;
+  unchangedFiles: Record<string, string> | undefined;
+};
+
+/** Matches the platform's `sha256Hex`, so both sides agree on a file's hash. */
+export function hashRunFile(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export function toRunFilesManifest(options: {
+  files: RunFiles;
+  runnerId: string;
+}): RunFilesManifest {
+  return {
+    files: Object.entries(options.files)
+      .map(([path, content]) => ({ contentHash: hashRunFile(content), path }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+    runnerId: options.runnerId,
+    version: 1,
+  };
+}
+
+/**
+ * The entry point and `package.json` always travel in full. The server reads an
+ * execution target from one and dependencies from the other, and neither can be
+ * satisfied from a hash.
+ */
+export function buildRunFileDelta(options: {
+  entryPointPath: string;
+  files: RunFiles;
+  held: RunFilesManifest | undefined;
+  runnerId: string;
+}): RunFileDelta {
+  const { held } = options;
+  if (held === undefined || held.runnerId !== options.runnerId) {
+    return { files: options.files, unchangedFiles: undefined };
+  }
+
+  const heldHashes = new Map(
+    held.files.map((entry) => [entry.path, entry.contentHash]),
+  );
+  const alwaysSent = new Set([options.entryPointPath, runPackageJsonPath]);
+
+  const files: RunFiles = {};
+  const unchangedFiles: Record<string, string> = {};
+  for (const [path, content] of Object.entries(options.files)) {
+    const hash = hashRunFile(content);
+    if (!alwaysSent.has(path) && heldHashes.get(path) === hash) {
+      unchangedFiles[path] = hash;
+      continue;
+    }
+    files[path] = content;
+  }
+
+  return Object.keys(unchangedFiles).length === 0
+    ? { files: options.files, unchangedFiles: undefined }
+    : { files, unchangedFiles };
+}

--- a/src/core/messages/interactiveRunner/run.ts
+++ b/src/core/messages/interactiveRunner/run.ts
@@ -28,6 +28,10 @@ export const runMessages = {
     "The run settled, but the last window of its followed streams could not be read, so the output above may be missing its final lines.",
   followTimedOut: (runId: string, runnerId: string, seconds: number) =>
     `Stopped following run ${runId} after ${formatSeconds(seconds * 1000)}. The run may still be going: read it with qawolf runner events run-status --run ${runId}, and terminate the runner with qawolf runner terminate --runner ${runnerId} when you are done. Pass --timeout to wait longer.`,
+  fullSyncTwice:
+    "The runner asked for every file even after being sent every file. Nothing is stale on this side, so this is worth reporting.",
+  shippedDelta:
+    "Sent only the files that changed since this runner's last run.",
   needsFullSync: (missingPaths: readonly string[]) =>
     `The runner does not hold ${missingPaths.join(", ")}, so it refused a run that referenced them without sending them. Run the flow again to ship every file it needs.`,
   missingPackageJson:

--- a/src/domains/interactiveRunner/deps.testUtils.ts
+++ b/src/domains/interactiveRunner/deps.testUtils.ts
@@ -10,6 +10,7 @@ import {
   makeCallPublicApiMock,
   makeMockPlatformClient,
 } from "~/shell/platform/createPlatformClient.testUtils.js";
+import { makeRunFilesManifestStore } from "~/shell/interactiveRunner/runFilesManifest.js";
 import { makeRunnerStore } from "~/shell/interactiveRunner/runnerStore.js";
 import type {
   AuthCommandContext,
@@ -93,6 +94,10 @@ export function makeTestDeps(
       return content;
     },
     readStdin: async () => "",
+    runFilesManifest: makeRunFilesManifestStore({
+      cwd: testCwd,
+      fs: makeMemoryFs(),
+    }),
     sleep: async () => {},
     store: makeRunnerStore({ cwd: testCwd, fs: makeMemoryFs() }),
     writeScreenshot: (screenshot) =>

--- a/src/domains/interactiveRunner/deps.ts
+++ b/src/domains/interactiveRunner/deps.ts
@@ -6,6 +6,10 @@ import {
 } from "~/shell/interactiveRunner/collectRunFiles.js";
 import { makeRunnerId } from "~/shell/interactiveRunner/makeRunnerId.js";
 import {
+  type RunFilesManifestStore,
+  makeRunFilesManifestStore,
+} from "~/shell/interactiveRunner/runFilesManifest.js";
+import {
   type RunnerStore,
   makeRunnerStore,
 } from "~/shell/interactiveRunner/runnerStore.js";
@@ -27,6 +31,7 @@ export type InteractiveRunnerDeps = {
   makeRunnerId: () => string;
   readFile: (path: string) => Promise<string>;
   readStdin: () => Promise<string>;
+  runFilesManifest: RunFilesManifestStore;
   sleep: (ms: number) => Promise<void>;
   store: RunnerStore;
   writeScreenshot: (options: {
@@ -48,6 +53,10 @@ export function makeInteractiveRunnerDeps(options: {
     makeRunnerId,
     readFile: (path) => options.fs.readFile(path),
     readStdin,
+    runFilesManifest: makeRunFilesManifestStore({
+      cwd: options.cwd,
+      fs: options.fs,
+    }),
     sleep: defaultSleep,
     store: makeRunnerStore({ cwd: options.cwd, fs: options.fs }),
     writeScreenshot: (screenshot) =>

--- a/src/domains/interactiveRunner/runFlow.delta.test.ts
+++ b/src/domains/interactiveRunner/runFlow.delta.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  hashRunFile,
+  toRunFilesManifest,
+} from "~/core/interactiveRunner/fileDelta.js";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { handleRunnerRun } from "./runFlow.js";
+
+const files = {
+  "flow.ts": "export default {};",
+  "package.json": "{}",
+  "pages/login.ts": "export const login = 1;",
+};
+const submitted = { outcome: "success" as const, runId: "run-a" };
+
+function makeDeps() {
+  return makeTestDeps({
+    collectRunFiles: async () => ({ files, unresolvedImports: [] }),
+  });
+}
+
+async function run(
+  deps: ReturnType<typeof makeDeps>,
+  answers: readonly unknown[] = [submitted],
+) {
+  const { callPublicApi, ctx } = makeAuthCtx();
+  for (const answer of answers) {
+    callPublicApi.mockResolvedValueOnce({ ok: true, value: answer });
+  }
+  const result = await handleRunnerRun(
+    ctx,
+    {
+      entryPoint: "flow.ts",
+      envFile: undefined,
+      follow: false,
+      lines: undefined,
+      linesFile: undefined,
+      logs: false,
+      recorderEvents: false,
+      runEvents: false,
+      runner: "ci",
+      timeout: undefined,
+    },
+    deps,
+  );
+  return { callPublicApi, ctx, result };
+}
+
+const requestAt = (
+  callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"],
+  index: number,
+): Record<string, unknown> => {
+  const request = callPublicApi.mock.calls[index]?.[1];
+  if (request === null || typeof request !== "object") return {};
+  return Object.fromEntries(Object.entries(request));
+};
+
+describe("handleRunnerRun file delta", () => {
+  it("sends every file when the directory holds no baseline", async () => {
+    const { callPublicApi, result } = await run(makeDeps());
+
+    expect(result).toBeUndefined();
+    expect(requestAt(callPublicApi, 0)["unchangedFiles"]).toBeUndefined();
+  });
+
+  it("records what it sent, so the next run can send less", async () => {
+    const deps = makeDeps();
+
+    await run(deps);
+
+    expect(await deps.runFilesManifest.read()).toEqual(
+      toRunFilesManifest({ files, runnerId: "ci" }),
+    );
+  });
+
+  it("sends only what changed once a baseline exists", async () => {
+    const deps = makeDeps();
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files, runnerId: "ci" }),
+    );
+
+    const { callPublicApi } = await run(deps);
+
+    const request = requestAt(callPublicApi, 0);
+    expect(request["unchangedFiles"]).toEqual({
+      "pages/login.ts": hashRunFile(files["pages/login.ts"]),
+    });
+    expect(Object.keys(request["files"] ?? {}).sort()).toEqual([
+      "flow.ts",
+      "package.json",
+    ]);
+  });
+
+  it("says on stdout which way the files went", async () => {
+    const deps = makeDeps();
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files, runnerId: "ci" }),
+    );
+
+    const { ctx } = await run(deps);
+
+    expect(ctx.ui.output).toHaveBeenCalledWith(
+      expect.objectContaining({ fileSync: "delta" }),
+      expect.any(String),
+    );
+  });
+
+  it("ignores a baseline another runner left behind", async () => {
+    const deps = makeDeps();
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files, runnerId: "other" }),
+    );
+
+    const { callPublicApi } = await run(deps);
+
+    expect(requestAt(callPublicApi, 0)["unchangedFiles"]).toBeUndefined();
+  });
+
+  it("resends everything once when the runner does not hold what was claimed", async () => {
+    const deps = makeDeps();
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files, runnerId: "ci" }),
+    );
+
+    const { callPublicApi, result } = await run(deps, [
+      {
+        failureReason: "needs-full-sync",
+        missingPaths: ["pages/login.ts"],
+        outcome: "failure",
+      },
+      submitted,
+    ]);
+
+    expect(result).toBeUndefined();
+    expect(callPublicApi).toHaveBeenCalledTimes(2);
+    expect(requestAt(callPublicApi, 1)["unchangedFiles"]).toBeUndefined();
+    expect(
+      Object.keys(requestAt(callPublicApi, 1)["files"] ?? {}),
+    ).toHaveLength(3);
+  });
+
+  it("reports rather than looping when a full request is refused the same way", async () => {
+    const deps = makeDeps();
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files, runnerId: "ci" }),
+    );
+    const refusal = {
+      failureReason: "needs-full-sync",
+      missingPaths: ["pages/login.ts"],
+      outcome: "failure",
+    };
+
+    const { callPublicApi, result } = await run(deps, [refusal, refusal]);
+
+    expect(callPublicApi).toHaveBeenCalledTimes(2);
+    expect(result?.exitCode).toBe(4);
+  });
+
+  it("claims no baseline when the submission failed", async () => {
+    const deps = makeDeps();
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "runner-unreachable", outcome: "failure" },
+    });
+
+    await handleRunnerRun(
+      ctx,
+      {
+        entryPoint: "flow.ts",
+        envFile: undefined,
+        follow: false,
+        lines: undefined,
+        linesFile: undefined,
+        logs: false,
+        recorderEvents: false,
+        runEvents: false,
+        runner: "ci",
+        timeout: undefined,
+      },
+      deps,
+    );
+
+    expect(await deps.runFilesManifest.read()).toBeUndefined();
+  });
+});

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -1,5 +1,3 @@
-import { publicContractsV1 } from "@qawolf/api-contracts/v1";
-
 import { parseFollowTimeout } from "~/core/interactiveRunner/followTimeout.js";
 import { toCollectedPath } from "~/core/interactiveRunner/runFiles.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
@@ -12,11 +10,10 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { resolveRecorderAnchor } from "./followPrinters.js";
-import { describeRunSubmitFailure } from "./runSubmitFailure.js";
 import { followRun } from "./followRun.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
 import { prepareRun } from "./prepareRun.js";
-import { runnerCallOptions } from "./runnerCallOptions.js";
+import { submitRun } from "./submitRun.js";
 
 export async function handleRunnerRun(
   ctx: AuthCommandContext,
@@ -73,49 +70,26 @@ export async function handleRunnerRun(
     recorderSinceSequence = anchor.sinceSequence;
   }
 
-  const result = await ctx.platformClient.callPublicApi(
-    publicContractsV1.runner.runFlow,
+  const submitted = await submitRun(
+    ctx,
     {
       entryPointPath,
+      environment: prepared.environment,
       files: prepared.files,
-      id: resolved.runnerId,
-      ...(prepared.environment === undefined
-        ? {}
-        : { env: prepared.environment }),
-      ...(prepared.selection === undefined
-        ? {}
-        : { selection: prepared.selection }),
+      resolved,
+      selection: prepared.selection,
     },
-    runnerCallOptions,
+    deps,
   );
-  if (!result.ok) {
-    return { ...failureFields(result), exitCode: exitCodes.network };
+  if (!submitted.ok) {
+    const { ok: _ok, ...failure } = submitted;
+    return failure;
   }
-
-  const { outcome } = result.value;
-  switch (outcome) {
-    case "failure":
-      return describeRunSubmitFailure(result.value);
-    case "success":
-      break;
-    // An outcome added to the contract must not fall through to exit 0: today
-    // the response schema refuses one this version does not know, and this keeps
-    // a future contracts bump a compile error rather than a silent pass.
-    default:
-      outcome satisfies never;
-      return {
-        error: interactiveRunnerMessages.runSubmitAnsweredUnknown(outcome),
-        exitCode: exitCodes.network,
-      };
-  }
-
-  // Absent means false. The pod and apex halves of this field land later, so a
-  // runner that did bootstrap may still say nothing.
-  if (result.value.bootstrappedRunner === true) {
+  if (submitted.bootstrappedRunner) {
     ctx.ui.info(interactiveRunnerMessages.bootstrappedForSelection);
   }
 
-  const runId = result.value.runId;
+  const runId = submitted.runId;
   // The stream flags imply --follow: each only chooses what a follow prints, so
   // alone it can only mean "follow, with that stream".
   const follow =
@@ -125,7 +99,7 @@ export async function handleRunnerRun(
     options.recorderEvents;
   if (!follow) {
     ctx.ui.output(
-      { runId, runnerId: resolved.runnerId },
+      { fileSync: submitted.fileSync, runId, runnerId: resolved.runnerId },
       interactiveRunnerMessages.runSubmitted(runId),
     );
     return undefined;
@@ -134,6 +108,9 @@ export async function handleRunnerRun(
   // then is the run's journal entries, and a differently shaped object among
   // them leaves a reader of the stream sniffing keys to tell which lines are log
   // entries.
+  if (submitted.fileSync === "delta") {
+    ctx.ui.info(interactiveRunnerMessages.shippedDelta);
+  }
   ctx.ui.info(interactiveRunnerMessages.runSubmitted(runId));
   return followRun(
     ctx,

--- a/src/domains/interactiveRunner/runSubmitFailure.ts
+++ b/src/domains/interactiveRunner/runSubmitFailure.ts
@@ -2,7 +2,6 @@ import type { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import type { z } from "zod";
 
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
-import type { CommandResult } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 
 type RunSubmitFailure = Extract<
@@ -11,9 +10,15 @@ type RunSubmitFailure = Extract<
 >;
 
 /** Why a submission was refused, and what the caller should do about it. */
+export type RunSubmitRefusal = {
+  error: string;
+  errorBody?: string;
+  exitCode: number;
+};
+
 export function describeRunSubmitFailure(
   failure: RunSubmitFailure,
-): CommandResult {
+): RunSubmitRefusal {
   const { failureReason } = failure;
   switch (failureReason) {
     case "runner-target-mismatch":

--- a/src/domains/interactiveRunner/sendRunFlowRequest.ts
+++ b/src/domains/interactiveRunner/sendRunFlowRequest.ts
@@ -1,0 +1,89 @@
+import {
+  type RunFiles,
+  type RunSelection,
+  publicContractsV1,
+} from "@qawolf/api-contracts/v1";
+
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type { AuthCommandContext } from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
+
+import type { ResolvedRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+import {
+  type RunSubmitRefusal,
+  describeRunSubmitFailure,
+} from "./runSubmitFailure.js";
+
+type Runner = Extract<ResolvedRunner, { type: "launched" | "resolved" }>;
+
+export type SendResult =
+  | { type: "submitted"; bootstrappedRunner: boolean; runId: string }
+  | { type: "needs-full-sync" }
+  | { type: "failed"; failure: RunSubmitRefusal };
+
+export async function sendRunFlowRequest(
+  ctx: AuthCommandContext,
+  options: {
+    entryPointPath: string;
+    environment: Record<string, string> | undefined;
+    resolved: Runner;
+    selection: RunSelection | undefined;
+  },
+  delta: {
+    files: RunFiles;
+    unchangedFiles: Record<string, string> | undefined;
+  },
+): Promise<SendResult> {
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.runFlow,
+    {
+      entryPointPath: options.entryPointPath,
+      files: delta.files,
+      id: options.resolved.runnerId,
+      ...(options.environment === undefined
+        ? {}
+        : { env: options.environment }),
+      ...(options.selection === undefined
+        ? {}
+        : { selection: options.selection }),
+      ...(delta.unchangedFiles === undefined
+        ? {}
+        : { unchangedFiles: delta.unchangedFiles }),
+    },
+    runnerCallOptions,
+  );
+  if (!result.ok) {
+    return {
+      failure: { ...failureFields(result), exitCode: exitCodes.network },
+      type: "failed",
+    };
+  }
+
+  const { outcome } = result.value;
+  switch (outcome) {
+    case "failure":
+      return result.value.failureReason === "needs-full-sync"
+        ? { type: "needs-full-sync" }
+        : { failure: describeRunSubmitFailure(result.value), type: "failed" };
+    case "success":
+      return {
+        bootstrappedRunner: result.value.bootstrappedRunner === true,
+        runId: result.value.runId,
+        type: "submitted",
+      };
+    // An outcome added to the contract must not fall through to exit 0. Today
+    // the response schema refuses one this version does not know, and this keeps
+    // a future contracts bump a compile error rather than a silent pass.
+    default:
+      outcome satisfies never;
+      return {
+        failure: {
+          error: interactiveRunnerMessages.runSubmitAnsweredUnknown(outcome),
+          exitCode: exitCodes.network,
+        },
+        type: "failed",
+      };
+  }
+}

--- a/src/domains/interactiveRunner/submitRun.ts
+++ b/src/domains/interactiveRunner/submitRun.ts
@@ -1,0 +1,104 @@
+import type { RunFiles, RunSelection } from "@qawolf/api-contracts/v1";
+
+import {
+  buildRunFileDelta,
+  toRunFilesManifest,
+} from "~/core/interactiveRunner/fileDelta.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type { AuthCommandContext } from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+import type { ResolvedRunner } from "./resolveRunner.js";
+import type { RunSubmitRefusal } from "./runSubmitFailure.js";
+import { type SendResult, sendRunFlowRequest } from "./sendRunFlowRequest.js";
+
+type FileSync = "delta" | "full";
+
+export type SubmittedRun =
+  | {
+      ok: true;
+      bootstrappedRunner: boolean;
+      fileSync: FileSync;
+      runId: string;
+    }
+  | ({ ok: false } & RunSubmitRefusal);
+
+type Runner = Extract<ResolvedRunner, { type: "launched" | "resolved" }>;
+
+export async function submitRun(
+  ctx: AuthCommandContext,
+  options: {
+    entryPointPath: string;
+    environment: Record<string, string> | undefined;
+    files: RunFiles;
+    resolved: Runner;
+    selection: RunSelection | undefined;
+  },
+  deps: InteractiveRunnerDeps,
+): Promise<SubmittedRun> {
+  // A runner the CLI just started holds nothing worth claiming a baseline from.
+  const held =
+    options.resolved.type === "launched"
+      ? undefined
+      : await deps.runFilesManifest.read().catch(() => undefined);
+
+  const delta = buildRunFileDelta({
+    entryPointPath: options.entryPointPath,
+    files: options.files,
+    held,
+    runnerId: options.resolved.runnerId,
+  });
+
+  const first = await sendRunFlowRequest(ctx, options, delta);
+  if (first.type === "needs-full-sync") {
+    // Bounded to one. The runner cannot answer this to a request that already
+    // carries every file, so a second miss is something else and should surface.
+    const retried = await sendRunFlowRequest(ctx, options, {
+      files: options.files,
+      unchangedFiles: undefined,
+    });
+    return finish(retried, "full", options, deps);
+  }
+  return finish(
+    first,
+    delta.unchangedFiles === undefined ? "full" : "delta",
+    options,
+    deps,
+  );
+}
+
+async function finish(
+  sent: SendResult,
+  fileSync: FileSync,
+  options: { files: RunFiles; resolved: Runner },
+  deps: InteractiveRunnerDeps,
+): Promise<SubmittedRun> {
+  if (sent.type === "failed") return { ...sent.failure, ok: false };
+  if (sent.type === "needs-full-sync") {
+    return {
+      error: interactiveRunnerMessages.fullSyncTwice,
+      exitCode: exitCodes.network,
+      ok: false,
+    };
+  }
+
+  // Only after a success, and never before. An answer that never arrived may or
+  // may not have reached the pod, and claiming a baseline it does not hold is
+  // the one stale state with no way back.
+  await deps.runFilesManifest
+    .write(
+      toRunFilesManifest({
+        files: options.files,
+        runnerId: options.resolved.runnerId,
+      }),
+    )
+    .catch(() => undefined);
+
+  return {
+    bootstrappedRunner: sent.bootstrappedRunner,
+    fileSync,
+    ok: true,
+    runId: sent.runId,
+  };
+}

--- a/src/shell/interactiveRunner/runFilesManifest.ts
+++ b/src/shell/interactiveRunner/runFilesManifest.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { z } from "zod";
+
+import type { RunFilesManifest } from "~/core/interactiveRunner/fileDelta.js";
+import { qawolfDir } from "~/core/paths.js";
+import type { Fs } from "~/shell/fs.js";
+
+/**
+ * A sibling of `runner.json`, not a field in it. `clearDefaultRunnerId` removes
+ * that whole file, so a `runner terminate` would take the baseline with it and
+ * the next run would ship everything without knowing why.
+ */
+const manifestFileName = "runner-files.json";
+
+const manifestSchema = z.object({
+  files: z.array(z.object({ contentHash: z.string(), path: z.string() })),
+  runnerId: z.string(),
+  version: z.literal(1),
+});
+
+export type RunFilesManifestStore = {
+  read: () => Promise<RunFilesManifest | undefined>;
+  write: (manifest: RunFilesManifest) => Promise<void>;
+};
+
+export function makeRunFilesManifestStore(options: {
+  cwd: string;
+  fs: Fs;
+}): RunFilesManifestStore {
+  const directory = join(options.cwd, qawolfDir);
+  const path = join(directory, manifestFileName);
+  let pendingWrites = 0;
+
+  return {
+    // Unparseable reads as absent, because falling back to the whole file set is
+    // always correct and refusing to run over a stale cache file never is.
+    async read() {
+      const contents = await options.fs.readFile(path).catch(() => undefined);
+      if (contents === undefined) return undefined;
+      const parsed = manifestSchema.safeParse(parseJson(contents));
+      return parsed.success ? parsed.data : undefined;
+    },
+
+    async write(manifest) {
+      const pendingPath = `${path}.${String(process.pid)}.${String(++pendingWrites)}.tmp`;
+      await options.fs.mkdir(directory, { recursive: true });
+      await options.fs.writeFile(
+        pendingPath,
+        `${JSON.stringify(manifest, undefined, 2)}\n`,
+      );
+      await options.fs.rename(pendingPath, path);
+    },
+  };
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
# Overview of Changes

`runner.runFlow` takes an `unchangedFiles` map so a run can send only what moved since the last one, and the CLI sent the whole file set every time. Iterating on one flow therefore re-uploaded its entire import graph on every run.

- [x] Send `unchangedFiles` for the files whose content matches what this runner was last sent, and the rest in full
- [x] Keep the entry point and `package.json` in full every time, since the server reads an execution target from one and dependencies from the other and neither can come from a hash
- [x] Record the baseline in `.qawolf/runner-files.json`, a sibling of `runner.json` so a `runner terminate` cannot take it along
- [x] Write it with the temp-and-rename `runnerStore` uses, so two runs in one directory cannot leave half a file
- [x] Write it only after a successful submission, since a lost answer may or may not have reached the pod
- [x] Hash file content the same way the server does, so both sides agree on what changed
- [x] Ignore a baseline belonging to another runner, and skip it entirely for a runner this invocation just launched
- [x] Treat an unparseable baseline as absent, because falling back to the whole set is always correct
- [x] Resend everything once when the runner does not hold what was claimed, and report rather than loop if that is refused too
- [x] Report which way the files went as `fileSync` on the JSON output, and on stderr when following
- [x] Move the submission out of `runFlow.ts` into `submitRun.ts` and `sendRunFlowRequest.ts`, with no change to what it does
- [x] Document the delta in `references/runner.md`
- [x] Cover the hashing, the always-sent files, every invalidation signal, both sides of the retry bound, and that a failed submission claims no baseline

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
```

`bun test` gives `1810 pass  0 fail`, 16 of them new. The other five give exit 0.

- Added lines, excluding `bun.lock` and snapshots: 650, past the 600 error threshold in `scripts/check-pr-size.sh`. 277 are tests and 193 are the submission moving out of `runFlow.ts`, which was at the 150-line file cap.
