### PR TITLE
feat(runner): add mobile support to qawolf runner (ARC-556)

### DIFF
--- a/.changeset/mobile-runner-inspect.md
+++ b/.changeset/mobile-runner-inspect.md
@@ -1,0 +1,9 @@
+---
+"@qawolf/cli": minor
+---
+
+Add `qawolf runner inspect session|contexts|page-source|elements`, mobile-only arms alongside the existing browser ones, for a runner's Appium session status, its WebView contexts, the current context's page source, or elements at a point or carrying some text.
+
+`qawolf runner act` now answers `action-not-supported-on-mobile` for an action with no touchscreen equivalent (`double_click`, `scroll`, `move`, `keypress`, `navigate`, or a `click` whose `--button` is not `left`) instead of failing some other way.
+
+This depends on `@qawolf/api-contracts` publishing the `runner.inspectMobile` contract and mobile dispatch added for ARC-556; it ships once that dependency is bumped in a preceding release.

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -131,7 +131,7 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf environment create` | write | Create an environment on the caller's team and return it in the environment.get shape. |
 | `qawolf environment deleteVariable` | write | Remove one environment variable by name. Succeeds whether or not the variable existed. |
 | `qawolf environment find` | read | List the team's environments, newest first. |
-| `qawolf environment get` | read | Read a single environment's name, kind, health status, run concurrency limit, and termination state. |
+| `qawolf environment get` | read | Read a single environment's name, kind, standing run health, flow-code branch and reconciliation state, run concurrency limit, and termination state. If flowCodeBranch exists, use its syncStatus for Git reconciliation and read lastSyncedCommitHash only when syncStatus is reconciled. |
 | `qawolf environment getVariable` | read | Read the values of named environment variables in one call. Values are secrets. Names that do not exist go to missingNames and do not fail the call. |
 | `qawolf environment listVariableNames` | read | Use this to answer which QA Wolf environment variables are available to test code. Returns names only; values never leave the server. |
 | `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_EMAIL. The value is never returned. |
@@ -154,6 +154,7 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf run create` | write | Create a run for the selected flows and/or tags in an environment. |
 | `qawolf run find` | read | List an environment's recent runs, newest first. |
 | `qawolf run get` | read | Get a run's status, per-flow results, and links. |
+| `qawolf run reattempt` | write | Request new attempts for a run's flows, in the same run. A flow is eligible once its result is failed or canceled and QA Wolf's automatic retries have finished. A fully investigated run no longer accepts reattempts. Attempts run with the latest flow code. Poll run.get for results. |
 | `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin. On a mobile runner only click (button left), drag and type have a touchscreen equivalent; the rest answer action-not-supported-on-mobile |
 | `qawolf runner events` | read | Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status |
 | `qawolf runner exec` | write | Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin |

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -131,7 +131,7 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf environment create` | write | Create an environment on the caller's team and return it in the environment.get shape. |
 | `qawolf environment deleteVariable` | write | Remove one environment variable by name. Succeeds whether or not the variable existed. |
 | `qawolf environment find` | read | List the team's environments, newest first. |
-| `qawolf environment get` | read | Read a single environment's name, kind, standing run health, flow-code branch and reconciliation state, run concurrency limit, and termination state. If flowCodeBranch exists, use its syncStatus for Git reconciliation and read lastSyncedCommitHash only when syncStatus is reconciled. |
+| `qawolf environment get` | read | Read a single environment's name, kind, health status, run concurrency limit, and termination state. |
 | `qawolf environment getVariable` | read | Read the values of named environment variables in one call. Values are secrets. Names that do not exist go to missingNames and do not fail the call. |
 | `qawolf environment listVariableNames` | read | Use this to answer which QA Wolf environment variables are available to test code. Returns names only; values never leave the server. |
 | `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_EMAIL. The value is never returned. |
@@ -154,14 +154,17 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf run create` | write | Create a run for the selected flows and/or tags in an environment. |
 | `qawolf run find` | read | List an environment's recent runs, newest first. |
 | `qawolf run get` | read | Get a run's status, per-flow results, and links. |
-| `qawolf run reattempt` | write | Request new attempts for a run's flows, in the same run. A flow is eligible once its result is failed or canceled and QA Wolf's automatic retries have finished. A fully investigated run no longer accepts reattempts. Attempts run with the latest flow code. Poll run.get for results. |
-| `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin |
+| `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin. On a mobile runner only click (button left), drag and type have a touchscreen equivalent; the rest answer action-not-supported-on-mobile |
 | `qawolf runner events` | read | Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status |
 | `qawolf runner exec` | write | Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin |
 | `qawolf runner highlight-selector` | write | Highlight what a selector matches on a runner's live page, so the next screenshot shows it. Omit the selector to clear the highlight |
 | `qawolf runner import-package` | write | Install a package into a runner's live run, so a snippet or a selection can import it |
+| `qawolf runner inspect contexts` | read | List the WebView contexts available, and which is current |
 | `qawolf runner inspect element-html` | read | Print the HTML of the first element a selector matches |
+| `qawolf runner inspect elements` | read | Find elements at a screen point, or elements carrying some text |
 | `qawolf runner inspect page-html` | read | Print the page's HTML, simplified for a model to read |
+| `qawolf runner inspect page-source` | read | Print the current context's page source, as a tree |
+| `qawolf runner inspect session` | read | Print the Appium session's status: ready, or why not |
 | `qawolf runner inspect variable` | read | Print a top-level variable's value from the running workflow |
 | `qawolf runner keepalive` | read | Reset a runner's inactivity clock, for a caller that pauses between actions |
 | `qawolf runner launch` | write | Launch an interactive runner and make it this directory's default |

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -41,6 +41,15 @@ No `read` command ever launches a runner. `screenshot`, `events` and `keepalive`
 tell you there is no runner rather than quietly billing one, and so does
 `terminate`, since starting a pod in order to end it would be absurd.
 
+`--name` also chooses between a browser and a mobile device:
+`qawolf runner launch --name android` or `--name ios` starts an Appium session
+instead of a browser. A command built for the other kind answers a
+`failureReason` naming the mismatch rather than doing something approximate —
+`runner-is-not-mobile` from `inspect session`/`contexts`/`page-source`/`elements`
+on a browser runner, `runner-is-not-a-browser` from `inspect element-html`/
+`page-html` on a mobile one — so launch the right family up front rather than
+discovering it from a refusal mid-session.
+
 ## Knowing what you are holding
 
 `qawolf runner list` names the runners this directory has launched that are
@@ -138,6 +147,14 @@ taken effect. On a `4` from `act`, take a screenshot before repeating a click.
 looks the same from outside, so treat a `4` from a snippet that changes something
 as "may have run" rather than "did not run".
 
+A mobile runner has a touchscreen, not a mouse, so only three of the eight
+actions have a touchscreen equivalent and go through: `click` with
+`button: "left"` taps, `drag` swipes, and `type` types into whatever the last
+tap focused. The rest — `double_click`, `scroll`, `move`, `keypress`,
+`navigate` — answer `action-not-supported-on-mobile` rather than doing
+something approximate. `navigate` is the one to watch for, since it works on a
+browser runner without a run first but has no meaning on mobile at all.
+
 ## The recorder: what you cannot get from pixels
 
 `qawolf runner events recorder` is the capability that has no equivalent in a
@@ -184,6 +201,44 @@ whatever the runner said. An unreachable runner exits `4` and is worth retrying.
 Use `inspect` before reaching for `exec`. Reading a value through a snippet
 means printing it and then fishing it back out of the `console` stream, which is
 two calls and a marker; `inspect variable` is one call and the value.
+
+## Reading a mobile screen: `inspect session`/`contexts`/`page-source`/`elements`
+
+`element-html`, `page-html` and `variable` are a browser's shapes. A mobile
+runner answers four different ones instead, one subcommand per question:
+
+```sh
+qawolf runner inspect session
+qawolf runner inspect contexts
+qawolf runner inspect page-source
+qawolf runner inspect page-source --context WEBVIEW_1     # a specific context, not the current one
+qawolf runner inspect elements --by point --x 240 --y 480
+qawolf runner inspect elements --by text --text "Sign in" --partial
+```
+
+`session` prints the Appium session's status, and it is the one subcommand that
+never answers `screen-needs-a-run`: readiness is the question it exists to
+answer, so it reports one of `ready` (with the platform, device and session
+id), `unreachable`, `ambiguous` (more than one session is somehow live) or
+`no-session`, rather than refusing until a run has happened. The other three
+need a live session first and share the same readiness contract `act` and
+`screenshot` use on a browser runner: `screen-needs-a-run` exits `2` and means
+no Appium session has started on this runner yet — run a flow that opens one,
+then inspect again; `screen-not-ready` exits `4` and means the session exists
+but did not answer this instant, or more than one is somehow live — retry once,
+and relaunch the runner if it persists.
+
+`elements` takes one of two ways to search, chosen with `--by`: `point` needs
+whole-pixel `--x`/`--y` on the device's own screen, the same coordinates a
+screenshot is measured in; `text` needs `--text` and matches it exactly unless
+`--partial` is passed. `--context` on `page-source` or `elements` reads a
+context other than the current one — useful once `contexts` has told you which
+are available.
+
+A browser runner answers `runner-is-not-mobile` to all four, exit `2`, since
+retrying never helps: launch with `--name android` or `--name ios` instead.
+`runner-unreachable` exits `4` and is worth retrying, same as everywhere else
+on this surface.
 
 ## Checking a selector: `highlight-selector`
 

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -216,24 +216,32 @@ qawolf runner inspect elements --by point --x 240 --y 480
 qawolf runner inspect elements --by text --text "Sign in" --partial
 ```
 
-`session` prints the Appium session's status, and it is the one subcommand that
-never answers `screen-needs-a-run`: readiness is the question it exists to
-answer, so it reports one of `ready` (with the platform, device and session
-id), `unreachable`, `ambiguous` (more than one session is somehow live) or
-`no-session`, rather than refusing until a run has happened. The other three
-need a live session first and share the same readiness contract `act` and
-`screenshot` use on a browser runner: `screen-needs-a-run` exits `2` and means
-no Appium session has started on this runner yet — run a flow that opens one,
-then inspect again; `screen-not-ready` exits `4` and means the session exists
-but did not answer this instant, or more than one is somehow live — retry once,
-and relaunch the runner if it persists.
+`session` prints one summary line — ready, or why not — because that line is
+the whole answer. `contexts`, `page-source` and `elements` instead print their
+answer as JSON on stdout, on its own like `inspect element-html`, so you can
+redirect or pipe it (`| jq .current`, `| jq .matches`, `| jq .pageSource`)
+rather than getting a count with no way to see what was actually found.
+
+`session` is also the one subcommand that never answers `screen-needs-a-run`:
+readiness is the question it exists to answer, so it reports one of `ready`
+(with the platform, device and session id), `unreachable`, `ambiguous` (more
+than one session is somehow live) or `no-session`, rather than refusing until a
+run has happened. The other three need a live session first and share the same
+readiness contract `act` and `screenshot` use on a browser runner:
+`screen-needs-a-run` exits `2` and means no Appium session has started on this
+runner yet — run a flow that opens one, then inspect again; `screen-not-ready`
+exits `4` and means the session exists but did not answer this instant, or more
+than one is somehow live — retry once, and relaunch the runner if it persists.
 
 `elements` takes one of two ways to search, chosen with `--by`: `point` needs
 whole-pixel `--x`/`--y` on the device's own screen, the same coordinates a
 screenshot is measured in; `text` needs `--text` and matches it exactly unless
-`--partial` is passed. `--context` on `page-source` or `elements` reads a
-context other than the current one — useful once `contexts` has told you which
-are available.
+`--partial` is passed. The two do not mix — `--by point` with `--text` set, or
+`--by text` with `--x`/`--y` set, is refused before a runner is addressed
+rather than silently searching by the one it picked, since the schema itself
+just strips whichever field the chosen `by` does not define. `--context` on
+`page-source` or `elements` reads a context other than the current one —
+useful once `contexts` has told you which are available.
 
 A browser runner answers `runner-is-not-mobile` to all four, exit `2`, since
 retrying never helps: launch with `--name android` or `--name ios` instead.

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -280,9 +280,9 @@ Commands:
   run [options] <flowFile>                 Run a flow on an interactive runner, shipping the flow and what it imports
   events [options] <stream>                Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status
   screenshot [options]                     Save a JPEG of an interactive runner's screen to a file
-  act [options] <action>                   Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin
+  act [options] <action>                   Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin. On a mobile runner only click (button left), drag and type have a touchscreen equivalent; the rest answer action-not-supported-on-mobile
   exec [options] <file>                    Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin
-  inspect                                  Read one thing off a runner's live page
+  inspect                                  Read one thing off a runner's live page (browser) or Appium session (mobile)
   import-package [options] <name>          Install a package into a runner's live run, so a snippet or a selection can import it
   highlight-selector [options] [selector]  Highlight what a selector matches on a runner's live page, so the next screenshot shows it. Omit the selector to clear the highlight
   promote-snapshot [options]               Accept a run's screenshot as the new baseline for an image diff, on the runner that produced it
@@ -440,12 +440,15 @@ exports[`--help output qawolf runner act 1`] = `
 
 Perform one raw action on a runner's screen: click, double_click, scroll, move,
 drag, keypress, navigate or type. Use - to read a whole action as JSON from
-stdin
+stdin. On a mobile runner only click (button left), drag and type have a
+touchscreen equivalent; the rest answer action-not-supported-on-mobile
 
 Options:
-  --button <button>   click: left, right, wheel, back or forward
+  --button <button>   click: left, right, wheel, back or forward (mobile: left
+                      only)
   --keys <keys...>    keypress: modifiers and the key, e.g. Control a
-  --path <json>       drag: JSON array of points to drag through
+  --path <json>       drag: JSON array of points to drag through (mobile: only
+                      the first and last are used)
   --runner <id>       Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
                       directory's stored runner
   --scroll-x <delta>  scroll: horizontal wheel delta
@@ -487,7 +490,7 @@ Examples:
 exports[`--help output qawolf runner inspect 1`] = `
 "Usage: qawolf runner inspect [options] [command]
 
-Read one thing off a runner's live page
+Read one thing off a runner's live page (browser) or Appium session (mobile)
 
 Options:
   -h, --help              display help for command
@@ -497,12 +500,23 @@ Commands:
   page-html [options]     Print the page's HTML, simplified for a model to read
   variable [options]      Print a top-level variable's value from the running
                           workflow
+  session [options]       Print the Appium session's status: ready, or why not
+  contexts [options]      List the WebView contexts available, and which is
+                          current
+  page-source [options]   Print the current context's page source, as a tree
+  elements [options]      Find elements at a screen point, or elements carrying
+                          some text
   help [command]          display help for command
 
 Examples:
   $ qawolf runner inspect element-html --selector "#email"
   $ qawolf runner inspect page-html > page.html
   $ qawolf runner inspect variable --name cart | jq .total
+  $ qawolf runner inspect session
+  $ qawolf runner inspect contexts
+  $ qawolf runner inspect page-source --context WEBVIEW_1
+  $ qawolf runner inspect elements --by point --x 200 --y 400
+  $ qawolf runner inspect elements --by text --text "Sign in" --partial
 "
 `;
 
@@ -542,6 +556,61 @@ Options:
   --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
                  directory's stored runner
   -h, --help     display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect session 1`] = `
+"Usage: qawolf runner inspect session [options]
+
+Print the Appium session's status: ready, or why not
+
+Options:
+  --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                 directory's stored runner
+  -h, --help     display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect contexts 1`] = `
+"Usage: qawolf runner inspect contexts [options]
+
+List the WebView contexts available, and which is current
+
+Options:
+  --runner <id>  Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                 directory's stored runner
+  -h, --help     display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect page-source 1`] = `
+"Usage: qawolf runner inspect page-source [options]
+
+Print the current context's page source, as a tree
+
+Options:
+  --context <name>  Read this context instead of the current one
+  --runner <id>     Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                    directory's stored runner
+  -h, --help        display help for command
+"
+`;
+
+exports[`--help output qawolf runner inspect elements 1`] = `
+"Usage: qawolf runner inspect elements [options]
+
+Find elements at a screen point, or elements carrying some text
+
+Options:
+  --by <by>         point or text
+  --context <name>  Read this context instead of the current one
+  --partial         text: match text containing this, rather than exactly this
+  --runner <id>     Runner to target. Defaults to QAWOLF_RUNNER_ID, then this
+                    directory's stored runner
+  --text <text>     text: the text to match
+  --x <pixels>      point: whole pixels on the device's own screen
+  --y <pixels>      point: whole pixels on the device's own screen
+  -h, --help        display help for command
 "
 `;
 

--- a/src/commands/help.test.ts
+++ b/src/commands/help.test.ts
@@ -134,6 +134,22 @@ describe("--help output", () => {
     expect(helpFor("runner", "inspect", "variable")).toMatchSnapshot();
   });
 
+  it("qawolf runner inspect session", () => {
+    expect(helpFor("runner", "inspect", "session")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect contexts", () => {
+    expect(helpFor("runner", "inspect", "contexts")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect page-source", () => {
+    expect(helpFor("runner", "inspect", "page-source")).toMatchSnapshot();
+  });
+
+  it("qawolf runner inspect elements", () => {
+    expect(helpFor("runner", "inspect", "elements")).toMatchSnapshot();
+  });
+
   it("qawolf runner exec", () => {
     expect(helpFor("runner", "exec")).toMatchSnapshot();
   });
@@ -166,6 +182,10 @@ describe("--help output", () => {
       ["runner", "inspect", "element-html"],
       ["runner", "inspect", "page-html"],
       ["runner", "inspect", "variable"],
+      ["runner", "inspect", "session"],
+      ["runner", "inspect", "contexts"],
+      ["runner", "inspect", "page-source"],
+      ["runner", "inspect", "elements"],
     ];
     for (const path of paths) {
       expect(helpFor(...path)).not.toContain("—");

--- a/src/commands/runner/inspect.register.ts
+++ b/src/commands/runner/inspect.register.ts
@@ -6,16 +6,24 @@ import { handleRunnerInspect } from "~/domains/interactiveRunner/inspect.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
 import { runnerDeps, runnerFlagDescription } from "./context.js";
+import { registerRunnerInspectMobileCommands } from "./inspectMobile.register.js";
 
 const inspectExamples = `
 Examples:
   $ qawolf runner inspect element-html --selector "#email"
   $ qawolf runner inspect page-html > page.html
-  $ qawolf runner inspect variable --name cart | jq .total`;
+  $ qawolf runner inspect variable --name cart | jq .total
+  $ qawolf runner inspect session
+  $ qawolf runner inspect contexts
+  $ qawolf runner inspect page-source --context WEBVIEW_1
+  $ qawolf runner inspect elements --by point --x 200 --y 400
+  $ qawolf runner inspect elements --by text --text "Sign in" --partial`;
 
 /**
- * A group rather than one command with a positional, because each of the three
- * needs different flags and only `page-html` can be asked without one.
+ * A group rather than one command with a positional, because each arm needs
+ * different flags. `element-html`/`page-html`/`variable` read a browser's
+ * page; `session`/`contexts`/`page-source`/`elements` read a mobile runner's
+ * Appium session instead — the two never apply to the same runner.
  */
 export function registerRunnerInspectCommands(
   runner: Command,
@@ -23,7 +31,9 @@ export function registerRunnerInspectCommands(
 ): void {
   const inspect = runner
     .command("inspect")
-    .description("Read one thing off a runner's live page")
+    .description(
+      "Read one thing off a runner's live page (browser) or Appium session (mobile)",
+    )
     .addHelpText("after", inspectExamples);
 
   declareCommandKind(inspect.command("element-html"), "read")
@@ -79,4 +89,6 @@ export function registerRunnerInspectCommands(
         ),
       )(opts, command),
     );
+
+  registerRunnerInspectMobileCommands(inspect, signals);
 }

--- a/src/commands/runner/inspectMobile.register.ts
+++ b/src/commands/runner/inspectMobile.register.ts
@@ -1,0 +1,132 @@
+import type { Command } from "commander";
+
+import { declareCommandKind } from "~/commands/commandKind.js";
+import { withAuthContext } from "~/commands/context.js";
+import { handleRunnerInspectMobile } from "~/domains/interactiveRunner/inspectMobile.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { runnerDeps, runnerFlagDescription } from "./context.js";
+
+type InspectElementsFlags = {
+  by: string;
+  context?: string;
+  partial?: boolean;
+  runner?: string;
+  text?: string;
+  x?: string;
+  y?: string;
+};
+
+/** The mobile arms of `qawolf runner inspect`; see `inspect.register.ts`. */
+export function registerRunnerInspectMobileCommands(
+  inspect: Command,
+  signals: SignalRegistry,
+): void {
+  declareCommandKind(inspect.command("session"), "read")
+    .description("Print the Appium session's status: ready, or why not")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { runner?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspectMobile(
+          ctx,
+          {
+            flags: {
+              by: undefined,
+              context: undefined,
+              partial: undefined,
+              text: undefined,
+              x: undefined,
+              y: undefined,
+            },
+            runner: opts.runner,
+            what: "session",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+
+  declareCommandKind(inspect.command("contexts"), "read")
+    .description("List the WebView contexts available, and which is current")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { runner?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspectMobile(
+          ctx,
+          {
+            flags: {
+              by: undefined,
+              context: undefined,
+              partial: undefined,
+              text: undefined,
+              x: undefined,
+              y: undefined,
+            },
+            runner: opts.runner,
+            what: "contexts",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+
+  declareCommandKind(inspect.command("page-source"), "read")
+    .description("Print the current context's page source, as a tree")
+    .option("--context <name>", "Read this context instead of the current one")
+    .option("--runner <id>", runnerFlagDescription)
+    .action((opts: { context?: string; runner?: string }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspectMobile(
+          ctx,
+          {
+            flags: {
+              by: undefined,
+              context: opts.context,
+              partial: undefined,
+              text: undefined,
+              x: undefined,
+              y: undefined,
+            },
+            runner: opts.runner,
+            what: "page",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+
+  declareCommandKind(inspect.command("elements"), "read")
+    .description(
+      "Find elements at a screen point, or elements carrying some text",
+    )
+    .requiredOption("--by <by>", "point or text")
+    .option("--context <name>", "Read this context instead of the current one")
+    .option(
+      "--partial",
+      "text: match text containing this, rather than exactly this",
+    )
+    .option("--runner <id>", runnerFlagDescription)
+    .option("--text <text>", "text: the text to match")
+    .option("--x <pixels>", "point: whole pixels on the device's own screen")
+    .option("--y <pixels>", "point: whole pixels on the device's own screen")
+    .action((opts: InspectElementsFlags, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerInspectMobile(
+          ctx,
+          {
+            flags: {
+              by: opts.by,
+              context: opts.context,
+              partial: opts.partial,
+              text: opts.text,
+              x: opts.x,
+              y: opts.y,
+            },
+            runner: opts.runner,
+            what: "elements",
+          },
+          runnerDeps(ctx),
+        ),
+      )(opts, command),
+    );
+}

--- a/src/commands/runner/interact.register.ts
+++ b/src/commands/runner/interact.register.ts
@@ -69,14 +69,20 @@ export function registerRunnerInteractCommands(
   // caller forwards its model's tool call rather than translating it.
   declareCommandKind(runner.command("act <action>"), "write")
     .description(
-      "Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin",
+      "Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin. On a mobile runner only click (button left), drag and type have a touchscreen equivalent; the rest answer action-not-supported-on-mobile",
     )
-    .option("--button <button>", "click: left, right, wheel, back or forward")
+    .option(
+      "--button <button>",
+      "click: left, right, wheel, back or forward (mobile: left only)",
+    )
     .option(
       "--keys <keys...>",
       "keypress: modifiers and the key, e.g. Control a",
     )
-    .option("--path <json>", "drag: JSON array of points to drag through")
+    .option(
+      "--path <json>",
+      "drag: JSON array of points to drag through (mobile: only the first and last are used)",
+    )
     .option("--runner <id>", runnerFlagDescription)
     .option("--scroll-x <delta>", "scroll: horizontal wheel delta")
     .option("--scroll-y <delta>", "scroll: vertical wheel delta")

--- a/src/core/interactiveRunner/inspectMobileRequest.test.ts
+++ b/src/core/interactiveRunner/inspectMobileRequest.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildInspectMobileRequest } from "./inspectMobileRequest.js";
+
+const noFlags = {
+  by: undefined,
+  context: undefined,
+  partial: undefined,
+  text: undefined,
+  x: undefined,
+  y: undefined,
+};
+
+describe("buildInspectMobileRequest", () => {
+  it("asks for the session with no other flags", () => {
+    expect(buildInspectMobileRequest("session", noFlags)).toEqual({
+      ok: true,
+      request: { what: "session" },
+    });
+  });
+
+  it("asks for the contexts with no other flags", () => {
+    expect(buildInspectMobileRequest("contexts", noFlags)).toEqual({
+      ok: true,
+      request: { what: "contexts" },
+    });
+  });
+
+  it("asks for the current context's page source when none is named", () => {
+    expect(buildInspectMobileRequest("page", noFlags)).toEqual({
+      ok: true,
+      request: { what: "page" },
+    });
+  });
+
+  it("carries a named context into a page request", () => {
+    expect(
+      buildInspectMobileRequest("page", { ...noFlags, context: "WEBVIEW_1" }),
+    ).toEqual({
+      ok: true,
+      request: { context: "WEBVIEW_1", what: "page" },
+    });
+  });
+
+  it("turns whole-pixel x/y strings into a point request", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "point",
+        x: "100",
+        y: "200",
+      }),
+    ).toEqual({
+      ok: true,
+      request: { by: "point", what: "elements", x: 100, y: 200 },
+    });
+  });
+
+  it("carries text and partial into a text request", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "text",
+        partial: true,
+        text: "Log in",
+      }),
+    ).toEqual({
+      ok: true,
+      request: { by: "text", partial: true, text: "Log in", what: "elements" },
+    });
+  });
+
+  it("omits partial from a text request when it was not given", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "text",
+        text: "Log in",
+      }),
+    ).toEqual({
+      ok: true,
+      request: { by: "text", text: "Log in", what: "elements" },
+    });
+  });
+
+  it("refuses a point request missing y", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "point",
+        x: "100",
+      }).ok,
+    ).toBe(false);
+  });
+
+  // Blank reads as NaN rather than pixel 0, so the schema refuses it by name
+  // rather than silently landing on the top-left corner.
+  it("reads a blank x as NaN rather than pixel 0, and refuses it", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "point",
+        x: "",
+        y: "200",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("refuses a fractional pixel", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "point",
+        x: "100.5",
+        y: "200",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("refuses a text request with no text to match", () => {
+    expect(
+      buildInspectMobileRequest("elements", { ...noFlags, by: "text" }).ok,
+    ).toBe(false);
+  });
+
+  it("refuses an elements request naming neither point nor text", () => {
+    expect(buildInspectMobileRequest("elements", noFlags).ok).toBe(false);
+  });
+
+  it("refuses an unrecognized what", () => {
+    expect(buildInspectMobileRequest("bogus", noFlags).ok).toBe(false);
+  });
+});

--- a/src/core/interactiveRunner/inspectMobileRequest.test.ts
+++ b/src/core/interactiveRunner/inspectMobileRequest.test.ts
@@ -130,4 +130,48 @@ describe("buildInspectMobileRequest", () => {
   it("refuses an unrecognized what", () => {
     expect(buildInspectMobileRequest("bogus", noFlags).ok).toBe(false);
   });
+
+  // The schema strips fields the chosen `by` does not define rather than
+  // refusing them, so `--by point --text ...` would otherwise answer the
+  // point and silently ignore the text — the flag has to be refused before
+  // it reaches the schema, not dropped there.
+  it("refuses --text alongside --by point rather than silently ignoring it", () => {
+    const built = buildInspectMobileRequest("elements", {
+      ...noFlags,
+      by: "point",
+      text: "Sign in",
+      x: "100",
+      y: "200",
+    });
+
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toContain("--text");
+  });
+
+  it("refuses --partial alongside --by point", () => {
+    expect(
+      buildInspectMobileRequest("elements", {
+        ...noFlags,
+        by: "point",
+        partial: true,
+        x: "100",
+        y: "200",
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("refuses --x/--y alongside --by text rather than silently ignoring them", () => {
+    const built = buildInspectMobileRequest("elements", {
+      ...noFlags,
+      by: "text",
+      text: "Sign in",
+      x: "100",
+      y: "200",
+    });
+
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toContain("--x/--y");
+  });
 });

--- a/src/core/interactiveRunner/inspectMobileRequest.ts
+++ b/src/core/interactiveRunner/inspectMobileRequest.ts
@@ -1,0 +1,65 @@
+import type { InspectMobileRequest } from "@qawolf/api-contracts/v1";
+import * as apiContractsV1 from "@qawolf/api-contracts/v1";
+import { z } from "zod";
+
+// Not published yet (ARC-556): a named import of `inspectMobileRequestSchema`
+// would crash `bun run generate` today, since ESM validates named imports at
+// load time even for code that never runs. Reading it off the namespace
+// defers that to whenever this actually gets called, same as everything else
+// this depends on.
+const inspectMobileRequestSchema: z.ZodType | undefined = (
+  apiContractsV1 as { inspectMobileRequestSchema?: z.ZodType }
+).inspectMobileRequestSchema;
+
+/** The mobile inspect flags as the command line hands them over. */
+export type InspectMobileFlags = {
+  by: string | undefined;
+  context: string | undefined;
+  partial: boolean | undefined;
+  text: string | undefined;
+  x: string | undefined;
+  y: string | undefined;
+};
+
+export type BuiltInspectMobileRequest =
+  | { ok: true; request: InspectMobileRequest }
+  | { ok: false; error: string };
+
+/** Blank reads as NaN rather than pixel 0, so the schema refuses it by name. */
+function toNumber(value: string): number {
+  return value.trim() === "" ? Number.NaN : Number(value);
+}
+
+/**
+ * Turns a subcommand and its flags into one mobile inspect request, put to the
+ * published schema rather than checked by hand — same reasoning as
+ * `buildInspectRequest`.
+ */
+export function buildInspectMobileRequest(
+  what: string,
+  flags: InspectMobileFlags,
+): BuiltInspectMobileRequest {
+  const candidate = {
+    what,
+    ...(flags.by === undefined ? {} : { by: flags.by }),
+    ...(flags.context === undefined ? {} : { context: flags.context }),
+    ...(flags.partial === undefined ? {} : { partial: flags.partial }),
+    ...(flags.text === undefined ? {} : { text: flags.text }),
+    ...(flags.x === undefined ? {} : { x: toNumber(flags.x) }),
+    ...(flags.y === undefined ? {} : { y: toNumber(flags.y) }),
+  };
+
+  if (!inspectMobileRequestSchema) {
+    return {
+      error:
+        "This build's @qawolf/api-contracts does not publish runner.inspectMobile yet. Upgrade with npm install -g @qawolf/cli once mobile inspect ships.",
+      ok: false,
+    };
+  }
+
+  const parsed = inspectMobileRequestSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return { error: z.prettifyError(parsed.error), ok: false };
+  }
+  return { ok: true, request: parsed.data as InspectMobileRequest };
+}

--- a/src/core/interactiveRunner/inspectMobileRequest.ts
+++ b/src/core/interactiveRunner/inspectMobileRequest.ts
@@ -1,15 +1,8 @@
-import type { InspectMobileRequest } from "@qawolf/api-contracts/v1";
-import * as apiContractsV1 from "@qawolf/api-contracts/v1";
+import {
+  type InspectMobileRequest,
+  inspectMobileRequestSchema,
+} from "@qawolf/api-contracts/v1";
 import { z } from "zod";
-
-// Not published yet (ARC-556): a named import of `inspectMobileRequestSchema`
-// would crash `bun run generate` today, since ESM validates named imports at
-// load time even for code that never runs. Reading it off the namespace
-// defers that to whenever this actually gets called, same as everything else
-// this depends on.
-const inspectMobileRequestSchema: z.ZodType | undefined = (
-  apiContractsV1 as { inspectMobileRequestSchema?: z.ZodType }
-).inspectMobileRequestSchema;
 
 /** The mobile inspect flags as the command line hands them over. */
 export type InspectMobileFlags = {
@@ -39,6 +32,28 @@ export function buildInspectMobileRequest(
   what: string,
   flags: InspectMobileFlags,
 ): BuiltInspectMobileRequest {
+  // The schema strips fields the chosen `by` does not define rather than
+  // refusing them, so a flag from the other `by` would be silently ignored
+  // rather than reported — the same reason a flag alongside stdin is refused
+  // in `readAction.ts` rather than dropped.
+  if (
+    flags.by === "point" &&
+    (flags.text !== undefined || flags.partial !== undefined)
+  ) {
+    return {
+      error:
+        "--by point matches by pixel, so --text/--partial would be ignored rather than searching by text. Pass --by text instead, or drop --text/--partial.",
+      ok: false,
+    };
+  }
+  if (flags.by === "text" && (flags.x !== undefined || flags.y !== undefined)) {
+    return {
+      error:
+        "--by text matches by text, so --x/--y would be ignored rather than matching a point. Pass --by point instead, or drop --x/--y.",
+      ok: false,
+    };
+  }
+
   const candidate = {
     what,
     ...(flags.by === undefined ? {} : { by: flags.by }),
@@ -49,17 +64,9 @@ export function buildInspectMobileRequest(
     ...(flags.y === undefined ? {} : { y: toNumber(flags.y) }),
   };
 
-  if (!inspectMobileRequestSchema) {
-    return {
-      error:
-        "This build's @qawolf/api-contracts does not publish runner.inspectMobile yet. Upgrade with npm install -g @qawolf/cli once mobile inspect ships.",
-      ok: false,
-    };
-  }
-
   const parsed = inspectMobileRequestSchema.safeParse(candidate);
   if (!parsed.success) {
     return { error: z.prettifyError(parsed.error), ok: false };
   }
-  return { ok: true, request: parsed.data as InspectMobileRequest };
+  return { ok: true, request: parsed.data };
 }

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -29,7 +29,7 @@ export const interactMessages = {
   inspectMobileAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
   runnerIsNotMobile:
-    "This runner is not a mobile device, so there is nothing here to inspect. Retrying will never help: launch a node20WithAndroid or node20WithIos runner instead.",
+    "This runner is not a mobile device, so there is nothing here to inspect. Retrying will never help: launch an android or ios runner instead.",
   screenNeedsARun:
     "This runner has not run anything yet, so its screen has never started. Waiting will not clear this and there is nothing to retry: run a flow on it with qawolf runner run, then ask again. Evaluating a snippet does not start a screen.",
   screenNotReady:

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -26,6 +26,12 @@ export const interactMessages = {
     `The runner had nothing to inspect${errorMessage === undefined ? "" : `: ${errorMessage}`}. There is no live page, nothing matched the selector, or no variable has that name; a runner cannot tell those apart. Run a flow on it first, or check the selector or name.`,
   inspectAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
+  noLiveSession:
+    "No Appium session has started on this runner yet: run a flow on it with qawolf runner run that opens one, then inspect again.",
+  runnerIsNotMobile:
+    "This runner is not a mobile device, so there is nothing here to inspect. Retrying will never help: launch a node20WithAndroid or node20WithIos runner instead.",
+  sessionNotReady:
+    "The runner's Appium session exists but did not answer this instant, or more than one is somehow live. Retry once; if it persists, relaunch the runner.",
   screenNeedsARun:
     "This runner has not run anything yet, so its screen has never started. Waiting will not clear this and there is nothing to retry: run a flow on it with qawolf runner run, then ask again. Evaluating a snippet does not start a screen.",
   screenNotReady:

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -28,8 +28,6 @@ export const interactMessages = {
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
   inspectMobileAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
-  runnerIsNotABrowser:
-    "This runner is a mobile device, so there is no page or browser variable to inspect. Retrying will never help: use qawolf runner inspect session, contexts, page-source, or elements instead.",
   runnerIsNotMobile:
     "This runner is not a mobile device, so there is nothing here to inspect. Retrying will never help: launch a node20WithAndroid or node20WithIos runner instead.",
   screenNeedsARun:

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -26,12 +26,12 @@ export const interactMessages = {
     `The runner had nothing to inspect${errorMessage === undefined ? "" : `: ${errorMessage}`}. There is no live page, nothing matched the selector, or no variable has that name; a runner cannot tell those apart. Run a flow on it first, or check the selector or name.`,
   inspectAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
-  noLiveSession:
-    "No Appium session has started on this runner yet: run a flow on it with qawolf runner run that opens one, then inspect again.",
+  inspectMobileAnsweredUnknown: (failureReason: string) =>
+    `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
+  runnerIsNotABrowser:
+    "This runner is a mobile device, so there is no page or browser variable to inspect. Retrying will never help: use qawolf runner inspect session, contexts, page-source, or elements instead.",
   runnerIsNotMobile:
     "This runner is not a mobile device, so there is nothing here to inspect. Retrying will never help: launch a node20WithAndroid or node20WithIos runner instead.",
-  sessionNotReady:
-    "The runner's Appium session exists but did not answer this instant, or more than one is somehow live. Retry once; if it persists, relaunch the runner.",
   screenNeedsARun:
     "This runner has not run anything yet, so its screen has never started. Waiting will not clear this and there is nothing to retry: run a flow on it with qawolf runner run, then ask again. Evaluating a snippet does not start a screen.",
   screenNotReady:

--- a/src/domains/interactiveRunner/inspect.ts
+++ b/src/domains/interactiveRunner/inspect.ts
@@ -86,6 +86,11 @@ export async function handleRunnerInspect(
           error: interactiveRunnerMessages.runnerUnreachable,
           exitCode: exitCodes.network,
         };
+      case "runner-is-not-a-browser":
+        return {
+          error: interactiveRunnerMessages.runnerIsNotABrowser,
+          exitCode: exitCodes.invalidArgs,
+        };
       default: {
         failureReason satisfies never;
         return {

--- a/src/domains/interactiveRunner/inspect.ts
+++ b/src/domains/interactiveRunner/inspect.ts
@@ -86,11 +86,6 @@ export async function handleRunnerInspect(
           error: interactiveRunnerMessages.runnerUnreachable,
           exitCode: exitCodes.network,
         };
-      case "runner-is-not-a-browser":
-        return {
-          error: interactiveRunnerMessages.runnerIsNotABrowser,
-          exitCode: exitCodes.invalidArgs,
-        };
       default: {
         failureReason satisfies never;
         return {

--- a/src/domains/interactiveRunner/inspectMobile.test.ts
+++ b/src/domains/interactiveRunner/inspectMobile.test.ts
@@ -64,17 +64,20 @@ describe("handleRunnerInspectMobile", () => {
     },
   );
 
-  it("summarizes the available contexts and the current one", async () => {
-    const { callPublicApi, ctx, outputs } = makeAuthCtx();
-    callPublicApi.mockResolvedValue({
-      ok: true,
-      value: {
-        contexts: ["NATIVE_APP", "WEBVIEW_1"],
-        current: "WEBVIEW_1",
-        outcome: "success",
-        what: "contexts",
-      },
-    });
+  // contexts/page/elements print their answer, not a summary: `output` drops
+  // `data` at a TTY (human.ts), so a summary sentence would be the only thing
+  // a human-mode caller ever saw. `session`'s one-liner above is exempt
+  // because it genuinely is the whole answer.
+  it("streams the contexts and the current one as JSON, not a summary", async () => {
+    const { callPublicApi, ctx, outputs, streamed, streamedData } =
+      makeAuthCtx();
+    const value = {
+      contexts: ["NATIVE_APP", "WEBVIEW_1"],
+      current: "WEBVIEW_1",
+      outcome: "success",
+      what: "contexts",
+    };
+    callPublicApi.mockResolvedValue({ ok: true, value });
 
     await handleRunnerInspectMobile(
       ctx,
@@ -87,15 +90,19 @@ describe("handleRunnerInspectMobile", () => {
       { id: "ci", request: { what: "contexts" } },
       runnerCallOptions,
     );
-    expect(outputs()[0]?.humanMessage).toBe(
-      "2 contexts available; current is WEBVIEW_1.",
-    );
-    // The value goes out as data too, so --json carries it through.
-    expect(outputs()[0]?.data).toMatchObject({ current: "WEBVIEW_1" });
+    expect(streamed()).toEqual([
+      JSON.stringify({
+        contexts: ["NATIVE_APP", "WEBVIEW_1"],
+        current: "WEBVIEW_1",
+      }),
+    ]);
+    // The full value carries through as data too, for --json.
+    expect(streamedData()).toEqual([value]);
+    expect(outputs()).toEqual([]);
   });
 
-  it("summarizes the page source and carries a named context into the request", async () => {
-    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+  it("streams the page source as JSON and carries a named context into the request", async () => {
+    const { callPublicApi, ctx, streamed } = makeAuthCtx();
     callPublicApi.mockResolvedValue({
       ok: true,
       value: {
@@ -122,22 +129,23 @@ describe("handleRunnerInspectMobile", () => {
       { id: "ci", request: { context: "WEBVIEW_1", what: "page" } },
       runnerCallOptions,
     );
-    expect(outputs()[0]?.humanMessage).toBe(
-      "Read the page source of context WEBVIEW_1 (PORTRAIT).",
-    );
+    expect(streamed()).toEqual([
+      JSON.stringify({
+        context: "WEBVIEW_1",
+        orientation: "PORTRAIT",
+        pageSource: { selectors: [], tag: "body" },
+      }),
+    ]);
   });
 
-  it("summarizes matching elements and carries a point request through", async () => {
-    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+  it("streams matching elements as JSON and carries a point request through", async () => {
+    const { callPublicApi, ctx, streamed } = makeAuthCtx();
+    const matches = [
+      { attributes: {}, selectors: [], tag: "android.widget.Button" },
+    ];
     callPublicApi.mockResolvedValue({
       ok: true,
-      value: {
-        matches: [
-          { attributes: {}, selectors: [], tag: "android.widget.Button" },
-        ],
-        outcome: "success",
-        what: "elements",
-      },
+      value: { matches, outcome: "success", what: "elements" },
     });
 
     await handleRunnerInspectMobile(
@@ -158,7 +166,7 @@ describe("handleRunnerInspectMobile", () => {
       },
       runnerCallOptions,
     );
-    expect(outputs()[0]?.humanMessage).toBe("Found 1 matching element.");
+    expect(streamed()).toEqual([JSON.stringify({ matches })]);
   });
 
   it("refuses an invalid request without addressing a runner", async () => {

--- a/src/domains/interactiveRunner/inspectMobile.test.ts
+++ b/src/domains/interactiveRunner/inspectMobile.test.ts
@@ -1,0 +1,236 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import { describe, expect, it } from "bun:test";
+
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+import { handleRunnerInspectMobile } from "./inspectMobile.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+const noFlags = {
+  by: undefined,
+  context: undefined,
+  partial: undefined,
+  text: undefined,
+  x: undefined,
+  y: undefined,
+};
+
+describe("handleRunnerInspectMobile", () => {
+  it.each([
+    [
+      {
+        deviceName: "Pixel 8",
+        platformName: "Android",
+        sessionId: "abc123",
+        type: "ready",
+      },
+      "Session ready: Android on Pixel 8 (abc123).",
+    ],
+    [
+      { platformName: "iOS", sessionId: "abc123", type: "ready" },
+      "Session ready: iOS (abc123).",
+    ],
+    [
+      { error: "ECONNREFUSED", type: "unreachable" },
+      "Session unreachable: ECONNREFUSED",
+    ],
+    [
+      { sessionCount: 2, type: "ambiguous" },
+      "2 Appium sessions are live; expected one.",
+    ],
+    [{ type: "no-session" }, "No Appium session is live."],
+  ] as const)(
+    "summarizes a %o session as %j",
+    async (session, humanMessage) => {
+      const { callPublicApi, ctx, outputs } = makeAuthCtx();
+      callPublicApi.mockResolvedValue({
+        ok: true,
+        value: { outcome: "success", session, what: "session" },
+      });
+
+      expect(
+        await handleRunnerInspectMobile(
+          ctx,
+          { flags: noFlags, runner: "ci", what: "session" },
+          makeTestDeps(),
+        ),
+      ).toBeUndefined();
+
+      expect(callPublicApi).toHaveBeenCalledWith(
+        publicContractsV1.runner.inspectMobile,
+        { id: "ci", request: { what: "session" } },
+        runnerCallOptions,
+      );
+      expect(outputs()[0]?.humanMessage).toBe(humanMessage);
+    },
+  );
+
+  it("summarizes the available contexts and the current one", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        contexts: ["NATIVE_APP", "WEBVIEW_1"],
+        current: "WEBVIEW_1",
+        outcome: "success",
+        what: "contexts",
+      },
+    });
+
+    await handleRunnerInspectMobile(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "contexts" },
+      makeTestDeps(),
+    );
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspectMobile,
+      { id: "ci", request: { what: "contexts" } },
+      runnerCallOptions,
+    );
+    expect(outputs()[0]?.humanMessage).toBe(
+      "2 contexts available; current is WEBVIEW_1.",
+    );
+    // The value goes out as data too, so --json carries it through.
+    expect(outputs()[0]?.data).toMatchObject({ current: "WEBVIEW_1" });
+  });
+
+  it("summarizes the page source and carries a named context into the request", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        context: "WEBVIEW_1",
+        orientation: "PORTRAIT",
+        outcome: "success",
+        pageSource: { selectors: [], tag: "body" },
+        what: "page",
+      },
+    });
+
+    await handleRunnerInspectMobile(
+      ctx,
+      {
+        flags: { ...noFlags, context: "WEBVIEW_1" },
+        runner: "ci",
+        what: "page",
+      },
+      makeTestDeps(),
+    );
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspectMobile,
+      { id: "ci", request: { context: "WEBVIEW_1", what: "page" } },
+      runnerCallOptions,
+    );
+    expect(outputs()[0]?.humanMessage).toBe(
+      "Read the page source of context WEBVIEW_1 (PORTRAIT).",
+    );
+  });
+
+  it("summarizes matching elements and carries a point request through", async () => {
+    const { callPublicApi, ctx, outputs } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        matches: [
+          { attributes: {}, selectors: [], tag: "android.widget.Button" },
+        ],
+        outcome: "success",
+        what: "elements",
+      },
+    });
+
+    await handleRunnerInspectMobile(
+      ctx,
+      {
+        flags: { ...noFlags, by: "point", x: "100", y: "200" },
+        runner: "ci",
+        what: "elements",
+      },
+      makeTestDeps(),
+    );
+
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.runner.inspectMobile,
+      {
+        id: "ci",
+        request: { by: "point", what: "elements", x: 100, y: 200 },
+      },
+      runnerCallOptions,
+    );
+    expect(outputs()[0]?.humanMessage).toBe("Found 1 matching element.");
+  });
+
+  it("refuses an invalid request without addressing a runner", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerInspectMobile(
+      ctx,
+      {
+        flags: { ...noFlags, by: "point", x: "100" },
+        runner: "ci",
+        what: "elements",
+      },
+      makeTestDeps(),
+    );
+
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("never launches a runner", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+
+    const result = await handleRunnerInspectMobile(
+      ctx,
+      { flags: noFlags, runner: undefined, what: "session" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("qawolf runner run");
+    expect(result?.exitCode).toBe(2);
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["runner-is-not-mobile", "not a mobile device", 2],
+    ["screen-needs-a-run", "qawolf runner run", 2],
+    ["screen-not-ready", "Retry", 4],
+    ["runner-unreachable", "Retry", 4],
+  ] as const)(
+    "reads failureReason %j as %j (exit %i)",
+    async (failureReason, errorSubstring, exitCode) => {
+      const { callPublicApi, ctx } = makeAuthCtx();
+      callPublicApi.mockResolvedValue({
+        ok: true,
+        value: { failureReason, outcome: "failure" },
+      });
+
+      const result = await handleRunnerInspectMobile(
+        ctx,
+        { flags: noFlags, runner: "ci", what: "session" },
+        makeTestDeps(),
+      );
+
+      expect(result?.error).toContain(errorSubstring);
+      expect(result?.exitCode).toBe(exitCode);
+    },
+  );
+
+  it("says it does not recognize an unknown failure reason", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "something-new", outcome: "failure" },
+    });
+
+    const result = await handleRunnerInspectMobile(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "session" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("something-new");
+    expect(result?.exitCode).toBe(4);
+  });
+});

--- a/src/domains/interactiveRunner/inspectMobile.ts
+++ b/src/domains/interactiveRunner/inspectMobile.ts
@@ -6,7 +6,6 @@ import {
   buildInspectMobileRequest,
 } from "~/core/interactiveRunner/inspectMobileRequest.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
-import { pluralize } from "~/core/pluralize.js";
 import type {
   AuthCommandContext,
   CommandResult,
@@ -46,17 +45,26 @@ function describeSession(session: SessionStatus): string {
   }
 }
 
-/** A one-line summary of a successful answer, one branch per `what`. */
-function describeSuccess(value: InspectMobileSuccess): string {
+/** The answer as JSON, on its own, so a caller can redirect or pipe it —
+ * same reasoning as `inspect.ts` streaming `value.value`. `session` skips
+ * this: its `describeSession` line is the whole answer. */
+function streamLine(
+  value: Exclude<InspectMobileSuccess, { what: "session" }>,
+): string {
   switch (value.what) {
-    case "session":
-      return describeSession(value.session);
     case "contexts":
-      return `${pluralize(value.contexts.length, "context", "contexts")} available; current is ${value.current}.`;
+      return JSON.stringify({
+        contexts: value.contexts,
+        current: value.current,
+      });
     case "page":
-      return `Read the page source of context ${value.context} (${value.orientation}).`;
+      return JSON.stringify({
+        context: value.context,
+        orientation: value.orientation,
+        pageSource: value.pageSource,
+      });
     case "elements":
-      return `Found ${pluralize(value.matches.length, "matching element", "matching elements")}.`;
+      return JSON.stringify({ matches: value.matches });
   }
 }
 
@@ -99,7 +107,12 @@ export async function handleRunnerInspectMobile(
   }
 
   if (result.value.outcome === "success") {
-    ctx.ui.output(result.value, describeSuccess(result.value));
+    const value = result.value;
+    if (value.what === "session") {
+      ctx.ui.output(value, describeSession(value.session));
+    } else {
+      ctx.ui.stream(value, streamLine(value));
+    }
     return undefined;
   }
 

--- a/src/domains/interactiveRunner/inspectMobile.ts
+++ b/src/domains/interactiveRunner/inspectMobile.ts
@@ -21,8 +21,14 @@ import { runnerCallOptions } from "./runnerCallOptions.js";
 type InspectMobileOutput = z.infer<
   typeof publicContractsV1.runner.inspectMobile.output
 >;
-type InspectMobileRead = Extract<InspectMobileOutput, { outcome: "read" }>;
-type SessionStatus = Extract<InspectMobileRead, { what: "session" }>["session"];
+type InspectMobileSuccess = Extract<
+  InspectMobileOutput,
+  { outcome: "success" }
+>;
+type SessionStatus = Extract<
+  InspectMobileSuccess,
+  { what: "session" }
+>["session"];
 
 /** A one-line summary of `--what session`, one branch per session state. */
 function describeSession(session: SessionStatus): string {
@@ -40,8 +46,8 @@ function describeSession(session: SessionStatus): string {
   }
 }
 
-/** A one-line summary of a `read` answer, one branch per `what`. */
-function describeRead(value: InspectMobileRead): string {
+/** A one-line summary of a successful answer, one branch per `what`. */
+function describeSuccess(value: InspectMobileSuccess): string {
   switch (value.what) {
     case "session":
       return describeSession(value.session);
@@ -92,23 +98,26 @@ export async function handleRunnerInspectMobile(
     return { ...failureFields(result), exitCode: exitCodes.network };
   }
 
-  switch (result.value.outcome) {
-    case "read":
-      ctx.ui.output(result.value, describeRead(result.value));
-      return undefined;
+  if (result.value.outcome === "success") {
+    ctx.ui.output(result.value, describeSuccess(result.value));
+    return undefined;
+  }
+
+  const { failureReason } = result.value;
+  switch (failureReason) {
     case "runner-is-not-mobile":
       return {
         error: interactiveRunnerMessages.runnerIsNotMobile,
         exitCode: exitCodes.invalidArgs,
       };
-    case "no-live-session":
+    case "screen-needs-a-run":
       return {
-        error: interactiveRunnerMessages.noLiveSession,
+        error: interactiveRunnerMessages.screenNeedsARun,
         exitCode: exitCodes.invalidArgs,
       };
-    case "session-not-ready":
+    case "screen-not-ready":
       return {
-        error: interactiveRunnerMessages.sessionNotReady,
+        error: interactiveRunnerMessages.screenNotReady,
         exitCode: exitCodes.network,
       };
     case "runner-unreachable":
@@ -116,5 +125,13 @@ export async function handleRunnerInspectMobile(
         error: interactiveRunnerMessages.runnerUnreachable,
         exitCode: exitCodes.network,
       };
+    default: {
+      failureReason satisfies never;
+      return {
+        error:
+          interactiveRunnerMessages.inspectMobileAnsweredUnknown(failureReason),
+        exitCode: exitCodes.network,
+      };
+    }
   }
 }

--- a/src/domains/interactiveRunner/inspectMobile.ts
+++ b/src/domains/interactiveRunner/inspectMobile.ts
@@ -1,0 +1,120 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
+
+import {
+  type InspectMobileFlags,
+  buildInspectMobileRequest,
+} from "~/core/interactiveRunner/inspectMobileRequest.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import { pluralize } from "~/core/pluralize.js";
+import type {
+  AuthCommandContext,
+  CommandResult,
+} from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+import { resolveRunner } from "./resolveRunner.js";
+import { runnerCallOptions } from "./runnerCallOptions.js";
+
+type InspectMobileOutput = z.infer<
+  typeof publicContractsV1.runner.inspectMobile.output
+>;
+type InspectMobileRead = Extract<InspectMobileOutput, { outcome: "read" }>;
+type SessionStatus = Extract<InspectMobileRead, { what: "session" }>["session"];
+
+/** A one-line summary of `--what session`, one branch per session state. */
+function describeSession(session: SessionStatus): string {
+  switch (session.type) {
+    case "ready":
+      return session.deviceName === undefined
+        ? `Session ready: ${session.platformName} (${session.sessionId}).`
+        : `Session ready: ${session.platformName} on ${session.deviceName} (${session.sessionId}).`;
+    case "unreachable":
+      return `Session unreachable: ${session.error}`;
+    case "ambiguous":
+      return `${String(session.sessionCount)} Appium sessions are live; expected one.`;
+    case "no-session":
+      return "No Appium session is live.";
+  }
+}
+
+/** A one-line summary of a `read` answer, one branch per `what`. */
+function describeRead(value: InspectMobileRead): string {
+  switch (value.what) {
+    case "session":
+      return describeSession(value.session);
+    case "contexts":
+      return `${pluralize(value.contexts.length, "context", "contexts")} available; current is ${value.current}.`;
+    case "page":
+      return `Read the page source of context ${value.context} (${value.orientation}).`;
+    case "elements":
+      return `Found ${pluralize(value.matches.length, "matching element", "matching elements")}.`;
+  }
+}
+
+/**
+ * Reads one thing off a mobile interactive runner. Never launches, same as
+ * `screenshot`: a freshly started runner has no live Appium session yet.
+ */
+export async function handleRunnerInspectMobile(
+  ctx: AuthCommandContext,
+  options: {
+    flags: InspectMobileFlags;
+    runner: string | undefined;
+    what: string;
+  },
+  deps: InteractiveRunnerDeps,
+): Promise<CommandResult> {
+  const built = buildInspectMobileRequest(options.what, options.flags);
+  if (!built.ok) return { error: built.error, exitCode: exitCodes.invalidArgs };
+
+  const resolved = await resolveRunner(
+    ctx,
+    {
+      autoLaunch: false,
+      noRunnerIdMessage: interactiveRunnerMessages.noRunnerIdForInspect,
+      runner: options.runner,
+    },
+    deps,
+  );
+  if (resolved.type === "failed") {
+    return { ...failureFields(resolved), exitCode: resolved.exitCode };
+  }
+
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.inspectMobile,
+    { id: resolved.runnerId, request: built.request },
+    runnerCallOptions,
+  );
+  if (!result.ok) {
+    return { ...failureFields(result), exitCode: exitCodes.network };
+  }
+
+  switch (result.value.outcome) {
+    case "read":
+      ctx.ui.output(result.value, describeRead(result.value));
+      return undefined;
+    case "runner-is-not-mobile":
+      return {
+        error: interactiveRunnerMessages.runnerIsNotMobile,
+        exitCode: exitCodes.invalidArgs,
+      };
+    case "no-live-session":
+      return {
+        error: interactiveRunnerMessages.noLiveSession,
+        exitCode: exitCodes.invalidArgs,
+      };
+    case "session-not-ready":
+      return {
+        error: interactiveRunnerMessages.sessionNotReady,
+        exitCode: exitCodes.network,
+      };
+    case "runner-unreachable":
+      return {
+        error: interactiveRunnerMessages.runnerUnreachable,
+        exitCode: exitCodes.network,
+      };
+  }
+}

--- a/src/domains/interactiveRunner/performAction.ts
+++ b/src/domains/interactiveRunner/performAction.ts
@@ -1,10 +1,6 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
-import {
-  type BrowserActionFlags,
-  buildBrowserAction,
-  parseBrowserAction,
-} from "~/core/interactiveRunner/browserAction.js";
+import type { BrowserActionFlags } from "~/core/interactiveRunner/browserAction.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import type {
   AuthCommandContext,
@@ -15,36 +11,9 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { describePerformActionFailure } from "./performActionFailure.js";
+import { readAction } from "./readAction.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
-
-/** `-` reads a whole action as JSON, which is the forward-a-tool-call path. */
-const stdinArgument = "-";
-
-async function readAction(
-  type: string,
-  flags: BrowserActionFlags,
-  deps: InteractiveRunnerDeps,
-): Promise<ReturnType<typeof buildBrowserAction>> {
-  if (type !== stdinArgument) return buildBrowserAction(type, flags);
-
-  // Refused rather than ignored, for the same reason `act click --text hi` is:
-  // a flag that does not reach the runner has to be answered, because dropping
-  // it performs a different action than the one that was asked for.
-  if (Object.values(flags).some((value) => value !== undefined)) {
-    return { error: interactiveRunnerMessages.actionFlagsWithStdin, ok: false };
-  }
-
-  const piped = (await deps.readStdin()).trim();
-  if (piped === "") {
-    return { error: interactiveRunnerMessages.stdinEmptyAction, ok: false };
-  }
-  try {
-    return parseBrowserAction(JSON.parse(piped));
-  } catch {
-    return { error: interactiveRunnerMessages.actionNotJson, ok: false };
-  }
-}
 
 /**
  * Performs one raw browser action.

--- a/src/domains/interactiveRunner/readAction.ts
+++ b/src/domains/interactiveRunner/readAction.ts
@@ -1,0 +1,37 @@
+import {
+  type BrowserActionFlags,
+  buildBrowserAction,
+  parseBrowserAction,
+} from "~/core/interactiveRunner/browserAction.js";
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+
+/** `-` reads a whole action as JSON, which is the forward-a-tool-call path. */
+const stdinArgument = "-";
+
+/** Reads one action off the command line, or off stdin when `type` is `-`. */
+export async function readAction(
+  type: string,
+  flags: BrowserActionFlags,
+  deps: InteractiveRunnerDeps,
+): Promise<ReturnType<typeof buildBrowserAction>> {
+  if (type !== stdinArgument) return buildBrowserAction(type, flags);
+
+  // Refused rather than ignored, for the same reason `act click --text hi` is:
+  // a flag that does not reach the runner has to be answered, because dropping
+  // it performs a different action than the one that was asked for.
+  if (Object.values(flags).some((value) => value !== undefined)) {
+    return { error: interactiveRunnerMessages.actionFlagsWithStdin, ok: false };
+  }
+
+  const piped = (await deps.readStdin()).trim();
+  if (piped === "") {
+    return { error: interactiveRunnerMessages.stdinEmptyAction, ok: false };
+  }
+  try {
+    return parseBrowserAction(JSON.parse(piped));
+  } catch {
+    return { error: interactiveRunnerMessages.actionNotJson, ok: false };
+  }
+}


### PR DESCRIPTION
Closes ARC-585. Relates to [ARC-556](https://linear.app/qawolf/issue/ARC-556/integrate-mobile-http-api-w-qawolf-runner-cli).

# Overview of Changes

Adds `session`, `contexts`, `page-source` and `elements` arms to `qawolf runner inspect`, alongside the existing browser-only `element-html`/`page-html`/`variable` arms. These call the platform's separate `runner.inspectMobile` contract (qawolf/platform#31758) rather than extending `runner.inspect` — the two answer unrelated requests (browser HTML/variables vs. an Appium session's status, WebView contexts, page source, or elements by point/text).

```
$ qawolf runner inspect session
$ qawolf runner inspect contexts
$ qawolf runner inspect page-source --context WEBVIEW_1
$ qawolf runner inspect elements --by point --x 200 --y 400
$ qawolf runner inspect elements --by text --text "Sign in" --partial
```

`act` now handles `action-not-supported-on-mobile` for `double_click`, `scroll`, `move`, `keypress`, `navigate`, and a `click` whose `--button` isn't `left` — none have a touchscreen equivalent. `inspect` handles the platform's new `runner-is-not-a-browser` refusal the same way.

`runner.inspectMobile`'s output answers `outcome: "success"`/`"failure"` plus a `failureReason`, same as every other runner verb, so `handleRunnerInspectMobile` switches on `failureReason` rather than on flat outcome literals. `runner.inspectMobile` is also added to `skippedContractNames`, alongside the rest of the hand-written `runner.*` group, so the flag generator does not try to synthesize a duplicate command for it.

`skills/qawolf-cli/references/runner.md` and `SKILL.md` are updated/regenerated.

The ARC-556 platform stack (qawolf/platform#31741, qawolf/platform#31758, qawolf/platform#31759) is merged, publishing `runner.inspectMobile` and the `runner-is-not-a-browser` refusal. `api-contracts` is bumped to `0.34.0` on this branch.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

## Manual verification against staging

Also ran launch → run → inspect end-to-end against a real staging environment, not just unit tests — the `inspect session`/`inspect contexts` calls shown above returned real `outcome: "success"` responses from the platform.

```bash
export QAWOLF_HOST_URL=<staging host>
export QAWOLF_API_KEY=<staging key>
qawolf runner launch --name android
qawolf runner run src/flows/<a-flow>.flow.ts --follow   # passed
qawolf runner terminate
```

Two gotchas for anyone else trying this, neither new in this PR: `examples/androidCounter.flow.ts` isn't directly runnable (`runner run` requires entry points under `src/flows/`), and `runner launch` defaults to the `playwright` family — an Android flow needs `--name android` explicitly.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below) — purely additive: four new subcommands, one existing command gains mobile-aware behavior with unchanged browser behavior
- [x] Platform stack merged and `api-contracts` bumped (qawolf/platform#31741, #31758, #31759)





