### PR TITLE
feat(cli): add run reattempt command via contracts 0.30.0

### DIFF
--- a/.changeset/run-reattempt-command.md
+++ b/.changeset/run-reattempt-command.md
@@ -5,3 +5,5 @@
 The new command `qawolf run reattempt` requests new attempts for a run's flows, in the same run. A flow is eligible when its result is failed or canceled, and QA Wolf completed its automatic retries. Omit `--flow-ids` to reattempt all of the eligible flows. A run that is fully investigated does not accept reattempts.
 
 The commands `qawolf environment find`, `qawolf tag list`, and `qawolf tag create` accept a new `--workspace-id` flag. Give the workspace when you authenticate with an organization key or a user key.
+
+`qawolf run create` now reports the flows that it left out of the run. Each entry in `excludedFlows` gives the flow and the reason: `deleted` if the flow was deleted, or `not-on-branch` if the flow has no file at the commit that the run was created from. Flows that you select with tags are not reported.

--- a/.changeset/run-reattempt-command.md
+++ b/.changeset/run-reattempt-command.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+The new command `qawolf run reattempt` requests new attempts for a run's flows, in the same run. A flow is eligible when its result is failed or canceled, and QA Wolf completed its automatic retries. Omit `--flow-ids` to reattempt all of the eligible flows. A run that is fully investigated does not accept reattempts.
+
+The commands `qawolf environment find`, `qawolf tag list`, and `qawolf tag create` accept a new `--workspace-id` flag. Give the workspace when you authenticate with an organization key or a user key.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.29.0",
+        "@qawolf/api-contracts": "0.30.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.29.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-VGRdG6qoVa/K4YV9P0I+avEJIS894/UC0+35f3mIMmeN+iEZUk6Ekc4sslA4uxTfSo0lLly3wAKjNKD86k5dZg=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.30.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-vrOPtkLaSS75jgk9FgQgBSaEXCFgdFgWRkkox8j9qQDt65nxXKLSTwqCRy1n+LTwfR7p0cD32gUy6zdYCqctKg=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.27.0",
+        "@qawolf/api-contracts": "0.29.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.27.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-LeAhmB1CGbj1UUdC/wkIhzktPTxOE5w+vcHhjEsYIWFXDpw+jM+l2BQmfxYloLEZTlvv1FPCDTU5fCMLx52epw=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.29.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-VGRdG6qoVa/K4YV9P0I+avEJIS894/UC0+35f3mIMmeN+iEZUk6Ekc4sslA4uxTfSo0lLly3wAKjNKD86k5dZg=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.27.0",
+    "@qawolf/api-contracts": "0.29.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.29.0",
+    "@qawolf/api-contracts": "0.30.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -118,7 +118,7 @@ current branch.
 | `qawolf environment create` | write | Create an environment on the caller's team and return it in the environment.get shape. |
 | `qawolf environment deleteVariable` | write | Remove one environment variable by name. Succeeds whether or not the variable existed. |
 | `qawolf environment find` | read | List the team's environments, newest first. |
-| `qawolf environment get` | read | Read a single environment's name, kind, health status, run concurrency limit, and termination state. |
+| `qawolf environment get` | read | Read a single environment's name, kind, standing run health, flow-code branch and reconciliation state, run concurrency limit, and termination state. If flowCodeBranch exists, use its syncStatus for Git reconciliation and read lastSyncedCommitHash only when syncStatus is reconciled. |
 | `qawolf environment getVariable` | read | Read the values of named environment variables in one call. Values are secrets. Names that do not exist go to missingNames and do not fail the call. |
 | `qawolf environment listVariableNames` | read | Use this to answer which QA Wolf environment variables are available to test code. Returns names only; values never leave the server. |
 | `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_EMAIL. The value is never returned. |
@@ -141,6 +141,7 @@ current branch.
 | `qawolf run create` | write | Create a run for the selected flows and/or tags in an environment. |
 | `qawolf run find` | read | List an environment's recent runs, newest first. |
 | `qawolf run get` | read | Get a run's status, per-flow results, and links. |
+| `qawolf run reattempt` | write | Request new attempts for a run's flows, in the same run. A flow is eligible once its result is failed or canceled and QA Wolf's automatic retries have finished. A fully investigated run no longer accepts reattempts. Attempts run with the latest flow code. Poll run.get for results. |
 | `qawolf runner act` | write | Perform one raw action on a runner's screen: click, double_click, scroll, move, drag, keypress, navigate or type. Use - to read a whole action as JSON from stdin |
 | `qawolf runner events` | read | Print a runner's journal, one entry per line. QA Wolf writes console, recorder, run-events, run-logs, run-status |
 | `qawolf runner exec` | write | Evaluate a snippet against a runner's live page. Use - to read the snippet from stdin |

--- a/src/shell/platform/callPublicApi.test.ts
+++ b/src/shell/platform/callPublicApi.test.ts
@@ -35,7 +35,7 @@ describe("callPublicApi", () => {
     const runId = "run-id";
     const url = "https://app.qawolf.com/runs/run-id";
     const fetchSpy = mock<typeof fetch>().mockResolvedValue(
-      jsonResponse(wrapped({ runId, url })),
+      jsonResponse(wrapped({ excludedFlows: [], runId, url })),
     );
     const trpc = createTrpcClient(apiKey, {
       baseUrl,
@@ -51,7 +51,10 @@ describe("callPublicApi", () => {
       `${baseUrl}/api/trpc/public.run.create`,
       expect.objectContaining({ method: "POST" }),
     );
-    expect(result).toEqual({ ok: true, data: { runId, url } });
+    expect(result).toEqual({
+      ok: true,
+      data: { excludedFlows: [], runId, url },
+    });
   });
 
   it("sends a read contract as a query", async () => {

--- a/src/shell/platform/createPlatformClient.callPublicApi.test.ts
+++ b/src/shell/platform/createPlatformClient.callPublicApi.test.ts
@@ -47,7 +47,7 @@ describe("callPublicApi", () => {
   it("sends a write contract as a mutation and returns the value", async () => {
     const runId = "run-id";
     const url = "https://app.qawolf.com/runs/run-id";
-    const f = mockFetch(json(trpcWrapped({ runId, url })));
+    const f = mockFetch(json(trpcWrapped({ excludedFlows: [], runId, url })));
 
     const result = await createPlatformClient(apiKey, {
       fetch: f,
@@ -61,7 +61,10 @@ describe("callPublicApi", () => {
     expect(req.url).toBe(`${baseUrl}/api/trpc/public.run.create`);
     expect(req.method).toBe("POST");
     expect(req.auth).toBe(`Bearer ${apiKey}`);
-    expect(result).toEqual({ ok: true, value: { runId, url } });
+    expect(result).toEqual({
+      ok: true,
+      value: { excludedFlows: [], runId, url },
+    });
   });
 
   it("sets the auth exit code when the server rejects the key with HTTP 401", async () => {


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

`@qawolf/api-contracts` 0.27.0 → 0.30.0. Most of the bump is declarative — `registerPublicApiCommands` builds commands from the contract tree, and `scripts/genSkillMd.ts` derives the agent-facing command table from the same source — so a new endpoint and new flags cost no hand-written wiring. The one exception is a required output field, covered below.

- **`package.json` / `bun.lock`**: `@qawolf/api-contracts` 0.27.0 → 0.30.0.
- **`skills/qawolf-cli/SKILL.md`**: regenerated via `bun run generate`. Adds the `qawolf run reattempt` row and picks up the reworded `environment get` description, which now covers the flow-code branch and reconciliation state and tells agents to read `lastSyncedCommitHash` only when `syncStatus` is `reconciled`.
- **`src/shell/platform/callPublicApi.test.ts`** and **`src/shell/platform/createPlatformClient.callPublicApi.test.ts`**: `run.create` output gained a required `excludedFlows` field, so the mocked server responses in these two tests were no longer valid `run.create` responses and failed the output parse. Both tests use the live `publicContractsV1.run.create` as a fixture rather than a local stub, which is what gives them real coverage of the parse path, so the fix is to make the fixtures faithful — return `excludedFlows: []` — rather than loosen the assertions.
- **`.changeset/run-reattempt-command.md`**: minor bump, covering the new command, the new flags, and the new output field.

What the contracts add, all generated:

- **`qawolf run reattempt`** (write, 0.29.0) — requests new attempts for a run's flows, in the same run. `--run-id` is required; `--flow-ids` is optional and defaults to every eligible flow. A flow becomes eligible once its result is failed or canceled and the automatic retries have finished; a fully investigated run rejects the request.
- **`--workspace-id`** on `qawolf environment find`, `qawolf tag list`, and `qawolf tag create` (0.29.0) — required when authenticating with an organization or user API key.
- **`excludedFlows` on `qawolf run create` output** (0.30.0) — explicitly requested flows that were left out of the run, each with a `deleted` or `not-on-branch` reason. Flows selected through tags are not reported. No flag change; the field appears in the printed response.
- Description-only edits (0.29.0 and 0.30.0) to `issue create`, `issue find`, `environment create`, `environment get`, and the environment `healthStatus` field. Several now say "organization or user API key" instead of "organization API key", and `healthStatus` clarifies that it describes standing run health, not Git reconciliation state.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- 1829 tests pass, 0 fail. The two fixture updates above are the only test changes; no new tests, since the added surface is generated from contract data and already covered by the generator's tests.
- Verified command registration by hand: `qawolf run reattempt --help` renders the description and both flags, `--workspace-id` appears on `environment find`, `tag list`, and `tag create`, and `qawolf run create --help` is unchanged, as expected for an output-only change.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
