### PR TITLE
build(cli): gate release approval on publish job only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 2 # HEAD^ for the version-bump comparison
           persist-credentials: false
 
       - name: Detect pending changesets and unpublished version
@@ -32,13 +33,17 @@ jobs:
             fi
           done
 
-          # Publish only when the current version has no tag yet. Without this
-          # check every docs-only merge finds no changesets, reads that as
-          # "publish time", and parks a run on the approval gate. The repo is
+          # Publish only when this push bumped the version and that version has
+          # no tag yet. The bump check stops a merge that lands while a publish
+          # waits for approval from raising a second prompt. The tag check stops
+          # a re-run after a successful publish from publishing twice. An
+          # unreadable parent leaves the tag check to decide. The repo is
           # public, so the anonymous ls-remote needs no token.
+          version=$(jq -r .version package.json)
+          previous=$(git show HEAD^:package.json 2>/dev/null | jq -r .version || true)
+
           needs_publish=false
-          if [[ "$has_changesets" == "false" ]]; then
-            version=$(jq -r .version package.json)
+          if [[ "$has_changesets" == "false" && "$version" != "$previous" ]]; then
             if [[ -z "$(git ls-remote --tags origin "refs/tags/v${version}")" ]]; then
               needs_publish=true
             fi
@@ -80,6 +85,8 @@ jobs:
         with:
           client-id: ${{ secrets.QA_WOLF_OPS_CLIENT_ID }}
           private-key: ${{ secrets.QA_WOLF_OPS_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create or update Version Packages PR
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
@@ -126,6 +133,7 @@ jobs:
         with:
           client-id: ${{ secrets.QA_WOLF_OPS_CLIENT_ID }}
           private-key: ${{ secrets.QA_WOLF_OPS_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Publish to npm
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,103 @@ on:
   push:
     branches: [main]
 
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release:
-    name: Release
-    environment: release
+  # GitHub applies environment protection when a job starts, not when a step
+  # runs, so a gated job can only be avoided by never creating it.
+  mode:
+    name: Detect release mode
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has_changesets: ${{ steps.detect.outputs.has_changesets }}
+      needs_publish: ${{ steps.detect.outputs.needs_publish }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Detect pending changesets and unpublished version
+        id: detect
+        run: |
+          shopt -s nullglob
+          has_changesets=false
+          for f in .changeset/*.md; do
+            if [[ "$(basename "$f")" != "README.md" ]]; then
+              has_changesets=true
+              break
+            fi
+          done
+
+          # Publish only when the current version has no tag yet. Without this
+          # check every docs-only merge finds no changesets, reads that as
+          # "publish time", and parks a run on the approval gate. The repo is
+          # public, so the anonymous ls-remote needs no token.
+          needs_publish=false
+          if [[ "$has_changesets" == "false" ]]; then
+            version=$(jq -r .version package.json)
+            if [[ -z "$(git ls-remote --tags origin "refs/tags/v${version}")" ]]; then
+              needs_publish=true
+            fi
+          fi
+
+          echo "has_changesets=$has_changesets" >> "$GITHUB_OUTPUT"
+          echo "needs_publish=$needs_publish" >> "$GITHUB_OUTPUT"
+          echo "has_changesets=\`$has_changesets\` needs_publish=\`$needs_publish\`" >> "$GITHUB_STEP_SUMMARY"
+
+  version:
+    name: Version PR
+    needs: mode
+    if: needs.mode.outputs.has_changesets == 'true'
+    runs-on: ubuntu-latest
+    # Two version runs would race on force-pushing changeset-release/main.
+    concurrency:
+      group: release-version-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: package.json
+
+      # No build: version-packages only runs `changeset version` and oxfmt.
+      - run: bun install --frozen-lockfile
+
+      # GITHUB_TOKEN can't create PRs under org policy, and PRs it opens don't
+      # trigger CI; the App token does both.
+      - name: Generate qa-wolf-ops token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.QA_WOLF_OPS_CLIENT_ID }}
+          private-key: ${{ secrets.QA_WOLF_OPS_PRIVATE_KEY }}
+
+      - name: Create or update Version Packages PR
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        with:
+          version: bun run version-packages
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  publish:
+    name: Publish
+    needs: mode
+    if: needs.mode.outputs.needs_publish == 'true'
+    environment: release
+    runs-on: ubuntu-latest
+    # Two publish runs would race on pushing the same tag.
+    concurrency:
+      group: release-publish-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      id-token: write # OIDC for npm provenance
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       tag: ${{ steps.tag.outputs.tag }}
@@ -34,8 +118,8 @@ jobs:
 
       - run: bun run build
 
-      # GITHUB_TOKEN can't create PRs under org policy, and PRs it opens don't
-      # trigger CI; the App token does both.
+      # The App token creates the GitHub Release, so release-binaries picks it
+      # up: a release created by GITHUB_TOKEN triggers no workflow.
       - name: Generate qa-wolf-ops token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -43,18 +127,16 @@ jobs:
           client-id: ${{ secrets.QA_WOLF_OPS_CLIENT_ID }}
           private-key: ${{ secrets.QA_WOLF_OPS_PRIVATE_KEY }}
 
-      - name: Create Release PR or Publish
+      - name: Publish to npm
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          version: bun run version-packages
           publish: bunx changeset publish
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      # Only set when a publish actually happened; safe on version-mode runs.
       - name: Resolve release tag
         id: tag
         if: steps.changesets.outputs.published == 'true'
@@ -86,36 +168,39 @@ jobs:
 
   binaries:
     name: Binaries
-    needs: release
-    if: needs.release.outputs.published == 'true'
+    needs: publish
+    if: needs.publish.outputs.published == 'true'
     permissions:
       contents: write
     uses: ./.github/workflows/release-binaries.yml
     with:
-      tag: ${{ needs.release.outputs.tag }}
+      tag: ${{ needs.publish.outputs.tag }}
 
-  # A sibling of binaries rather than a step in release: a registry failure must
+  # A sibling of binaries rather than a step in publish: a registry failure must
   # not skip the binary build, and changeset publish only knows one registry.
   github-packages:
     name: GitHub Packages
-    needs: release
-    if: needs.release.outputs.published == 'true'
+    needs: publish
+    if: needs.publish.outputs.published == 'true'
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/publish-github-packages.yml
     with:
-      tag: ${{ needs.release.outputs.tag }}
+      tag: ${{ needs.publish.outputs.tag }}
 
   notify-binaries:
     name: Notify Slack of binaries
-    needs: [release, binaries]
+    needs: [publish, binaries]
     # always(): the binaries matrix runs with fail-fast off, so report partial
     # failures too. Skips when nothing was published or the publish-time Slack
     # message did not post (no ts to update).
-    if: always() && needs.release.outputs.published == 'true' && needs.release.outputs.slack_ts != ''
+    if: always() && needs.publish.outputs.published == 'true' && needs.publish.outputs.slack_ts != ''
     environment: release-notify
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-notify-${{ needs.publish.outputs.tag }}
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -135,8 +220,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
-          RELEASE_TAG: ${{ needs.release.outputs.tag }}
-          SLACK_TS: ${{ needs.release.outputs.slack_ts }}
+          RELEASE_TAG: ${{ needs.publish.outputs.tag }}
+          SLACK_TS: ${{ needs.publish.outputs.slack_ts }}
         run: |
           payload=$(gh release view "$RELEASE_TAG" --json body,url,tagName,assets \
             | bun scripts/slackReleaseMessage.ts --phase binaries --channel "$SLACK_CHANNEL_ID" --ts "$SLACK_TS")

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,9 +27,9 @@ PRs that do not affect the published package (CI config, internal tooling, docs)
 ## Release flow
 
 1. One or more PRs with changeset files merge to `main`.
-2. The [Release workflow](../.github/workflows/release.yml) detects the pending changesets and creates (or updates) a **"Version Packages"** PR. This PR bumps `package.json` version and updates `CHANGELOG.md`.
+2. The [Release workflow](../.github/workflows/release.yml) finds the pending changesets. Its `Version PR` job creates or updates a **"Version Packages"** PR. That PR bumps the `package.json` version and updates `CHANGELOG.md`. The job needs no approval.
 3. Review the Version Packages PR and merge it when ready to ship.
-4. The Release workflow runs again. It detects no pending changesets, builds the package, and runs:
+4. The workflow runs again and starts its `Publish` job. That job waits for approval of the `release` environment. To approve it, go to Actions → the run → "Review deployments". The job then builds the package and runs:
 
    ```bash
    bunx changeset publish
@@ -38,6 +38,8 @@ PRs that do not affect the published package (CI config, internal tooling, docs)
    `changeset publish` publishes to npm and creates a git tag for the new version. The changesets action pushes that tag and creates a GitHub Release from it, which triggers the binary build pipeline. npm [provenance](https://docs.npmjs.com/generating-provenance-statements) is enabled via the `NPM_CONFIG_PROVENANCE: true` env var on the publish step.
 
 5. Two jobs then run in parallel from the new tag. The first job builds the binaries. The second job publishes to [GitHub Packages](#github-packages).
+
+Approval applies to the `Publish` job only. The `Detect release mode` job examines each merge first. If the merge has no pending changesets, and the version in `package.json` already has a tag, the workflow starts neither the `Version PR` job nor the `Publish` job. Merges of docs and CI changes are of this type, and they ask for no approval.
 
 ## GitHub Packages
 
@@ -70,6 +72,8 @@ npm view @qawolf/cli version --@qawolf:registry=https://npm.pkg.github.com
 
 ## Re-running a failed publish
 
-If the publish step fails (e.g. network issue after the version PR was merged), re-run the Release workflow from the GitHub Actions UI (Actions → Release → Re-run jobs). If the version was already partially published, npm will return an error indicating the version exists — in that case, cut a patch release with a new changeset rather than attempting to re-publish the same version.
+If the publish step fails (e.g. network issue after the version PR was merged), re-run the Release workflow from the GitHub Actions UI (Actions → Release → Re-run jobs). The `Publish` job asks for approval again. Use "Re-run failed jobs" to keep the result of the `Detect release mode` job. If the version was already partially published, npm will return an error indicating the version exists — in that case, cut a patch release with a new changeset rather than attempting to re-publish the same version.
+
+Do this before you merge more changesets. A new changeset starts a new version bump, and the version that failed then gets no publish.
 
 If only the GitHub Packages job failed, run that job again. The job makes no change to npmjs, and a second run is safe.


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

`environment: release` sits on the single `release` job, which runs on every push to `main`. So every merge asks for a deployment approval, whether or not it publishes. All six of the last release runs needed a click; two of them published.

The gate cannot move to a step — GitHub applies environment protection when a job starts. So the job itself has to become conditional.

- **`.github/workflows/release.yml`**: splits `release` into `mode`, `version`, and `publish`. `mode` is ungated and reports whether changesets are pending and whether the current version is still untagged. `version` opens the Version Packages PR, ungated. `publish` carries `environment: release` alone and runs only when a publish is due. `binaries`, `github-packages`, and `notify-binaries` follow `needs: publish`, unchanged otherwise. Per-job concurrency groups replace the workflow-level one.
- **`docs/releasing.md`**: names the job behind each step and records which one asks for approval.

Only the merge of a Version Packages PR now requests approval. The `Release` environment needs no settings change. Supersedes #1395. No changeset — CI-only.

# Testing

```bash
actionlint .github/workflows/release.yml
bun run lint --max-warnings 0
bun run format:check
bun run typecheck
bun run knip
```

- `actionlint` clean; `environment: release` appears on `publish` only.
- Ran the `mode` script against real repository state: version tagged with no changesets → both jobs skip; changeset present → `version` only; version untagged → `publish` only.
- Publish steps are unchanged from `main` apart from dropping the `version:` input, so npm, provenance, tagging, the GitHub Release, binaries, GitHub Packages, and Slack all follow the paths already in production.
- The approval prompt itself only proves out on the first merges after this lands.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
