### PR TITLE
fix(runner): wait 90s for runner calls instead of 60s

### DIFF
--- a/.changeset/runner-call-timeout-headroom.md
+++ b/.changeset/runner-call-timeout-headroom.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Runner calls now wait 90 seconds instead of 60, so the first action on a fresh runner outlives the platform's browser-start wait instead of timing out client-side.

--- a/src/domains/interactiveRunner/runnerCallOptions.ts
+++ b/src/domains/interactiveRunner/runnerCallOptions.ts
@@ -3,8 +3,9 @@ import type { RequestOptions } from "~/shell/platform/createTrpcClient.js";
 /**
  * Runner endpoints are answered by a live runner doing the work — starting a
  * browser, evaluating a snippet, capturing a screen — not by the platform's
- * database, so the client's default timeout is too short for them. Sixty
- * seconds covers the slowest observed case, a first action that has to start
- * the browser before it can be performed.
+ * database, so the client's default timeout is too short for them. The slowest
+ * case is a first action that has to start the browser: the platform waits up
+ * to sixty seconds for that boot, and this timeout must outlive that wait or
+ * the client gives up first.
  */
-export const runnerCallOptions: RequestOptions = { timeoutMs: 60_000 };
+export const runnerCallOptions: RequestOptions = { timeoutMs: 90_000 };


### PR DESCRIPTION
Related to NOVA-1659

# Overview of Changes

The platform now waits up to 60 seconds for the browser to boot before serving the first action on a fresh runner (qawolf/platform#32206). The CLI's 60-second runner-call timeout would fire at the same moment, so the client gave up first. Runner calls now wait 90 seconds.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)