### PR TITLE
fix(runner): also send unchanged --lines-file target with the run

### DIFF
--- a/.changeset/lines-file-unchanged-target.md
+++ b/.changeset/lines-file-unchanged-target.md
@@ -2,6 +2,6 @@
 "@qawolf/cli": patch
 ---
 
-`qawolf runner run --lines --lines-file <path>` no longer fails when the named file has not changed since the last run on that runner.
+`qawolf runner run --lines <lines> --lines-file <path>` no longer fails when the named file has not changed since the last run on that runner.
 
 Delta shipping withholds a file whose content hash matches what the runner already holds, so an untouched page object was dropped from the payload and the platform refused the run with `A selection must name a file carried in files.` The selection's file now always travels in full, alongside the entry point and `package.json`.

--- a/.changeset/lines-file-unchanged-target.md
+++ b/.changeset/lines-file-unchanged-target.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf runner run --lines --lines-file <path>` no longer fails when the named file has not changed since the last run on that runner.
+
+Delta shipping withholds a file whose content hash matches what the runner already holds, so an untouched page object was dropped from the payload and the platform refused the run with `A selection must name a file carried in files.` The selection's file now always travels in full, alongside the entry point and `package.json`.

--- a/src/core/interactiveRunner/fileDelta.test.ts
+++ b/src/core/interactiveRunner/fileDelta.test.ts
@@ -19,7 +19,14 @@ const manifestFor = (from: Record<string, string>, runnerId = "ci") =>
 const delta = (
   held: ReturnType<typeof manifestFor> | undefined,
   runnerId = "ci",
-) => buildRunFileDelta({ entryPointPath: flowPath, files, held, runnerId });
+) =>
+  buildRunFileDelta({
+    entryPointPath: flowPath,
+    files,
+    held,
+    runnerId,
+    selectionPath: undefined,
+  });
 
 describe("hashRunFile", () => {
   it("hashes content, not the path it came from", () => {
@@ -60,6 +67,25 @@ describe("buildRunFileDelta", () => {
     ]);
     expect(built.unchangedFiles).toEqual({
       "src/pages/login.ts": hashRunFile(files["src/pages/login.ts"]),
+    });
+  });
+
+  it("keeps a selection's file in full even when unchanged", () => {
+    const withHelper = {
+      ...files,
+      "src/pages/cart.ts": "export const cart = 1;",
+    };
+    const built = buildRunFileDelta({
+      entryPointPath: flowPath,
+      files: withHelper,
+      held: manifestFor(withHelper),
+      runnerId: "ci",
+      selectionPath: "src/pages/login.ts",
+    });
+
+    expect(built.files["src/pages/login.ts"]).toBe(files["src/pages/login.ts"]);
+    expect(built.unchangedFiles).toEqual({
+      "src/pages/cart.ts": hashRunFile(withHelper["src/pages/cart.ts"]),
     });
   });
 

--- a/src/core/interactiveRunner/fileDelta.ts
+++ b/src/core/interactiveRunner/fileDelta.ts
@@ -33,15 +33,17 @@ export function toRunFilesManifest(options: {
 }
 
 /**
- * The entry point and `package.json` always travel in full. The server reads an
- * execution target from one and dependencies from the other, and neither can be
- * satisfied from a hash.
+ * The entry point, `package.json` and a selection's file always travel in full.
+ * The server reads an execution target from the first and dependencies from the
+ * second, and it refuses a selection naming a file the request left out. None of
+ * the three can be satisfied from a hash.
  */
 export function buildRunFileDelta(options: {
   entryPointPath: string;
   files: RunFiles;
   held: RunFilesManifest | undefined;
   runnerId: string;
+  selectionPath: string | undefined;
 }): RunFileDelta {
   const { held } = options;
   if (held === undefined || held.runnerId !== options.runnerId) {
@@ -52,6 +54,9 @@ export function buildRunFileDelta(options: {
     held.files.map((entry) => [entry.path, entry.contentHash]),
   );
   const alwaysSent = new Set([options.entryPointPath, runPackageJsonPath]);
+  if (options.selectionPath !== undefined) {
+    alwaysSent.add(options.selectionPath);
+  }
 
   const files: RunFiles = {};
   const unchangedFiles: Record<string, string> = {};

--- a/src/domains/interactiveRunner/runFlow.selection.test.ts
+++ b/src/domains/interactiveRunner/runFlow.selection.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from "bun:test";
 
+import { toRunFilesManifest } from "~/core/interactiveRunner/fileDelta.js";
+
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 import { handleRunnerRun } from "./runFlow.js";
 
 const submitted = { outcome: "success" as const, runId: "run-a" };
+const files = {
+  "flow.ts": "export default {};",
+  "package.json": "{}",
+  "pages/login.ts": "export const login = () => {};",
+};
 
 async function runWith(options: {
   bootstrappedRunner?: boolean | undefined;
   entryPoint?: string;
+  heldByRunner?: Record<string, string>;
   lines?: string;
   linesFile?: string;
 }) {
@@ -19,6 +27,14 @@ async function runWith(options: {
         ? submitted
         : { ...submitted, bootstrappedRunner: options.bootstrappedRunner },
   });
+  const deps = makeTestDeps({
+    collectRunFiles: async () => ({ files, unresolvedImports: [] }),
+  });
+  if (options.heldByRunner !== undefined) {
+    await deps.runFilesManifest.write(
+      toRunFilesManifest({ files: options.heldByRunner, runnerId: "ci" }),
+    );
+  }
   const result = await handleRunnerRun(
     ctx,
     {
@@ -33,26 +49,30 @@ async function runWith(options: {
       runner: "ci",
       timeout: undefined,
     },
-    makeTestDeps({
-      collectRunFiles: async () => ({
-        files: {
-          "flow.ts": "export default {};",
-          "package.json": "{}",
-          "pages/login.ts": "export const login = () => {};",
-        },
-        unresolvedImports: [],
-      }),
-    }),
+    deps,
   );
   return { callPublicApi, ctx, result };
+}
+
+function requestField(options: {
+  callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"];
+  field: string;
+}): unknown {
+  const [request] = options.callPublicApi.mock.calls[0]?.slice(1) ?? [];
+  if (request === null || typeof request !== "object") return undefined;
+  return Reflect.get(request, options.field);
 }
 
 function selectionOf(
   callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"],
 ): unknown {
-  const [request] = callPublicApi.mock.calls[0]?.slice(1) ?? [];
-  if (request === null || typeof request !== "object") return undefined;
-  return Reflect.get(request, "selection");
+  return requestField({ callPublicApi, field: "selection" });
+}
+
+function filesOf(
+  callPublicApi: ReturnType<typeof makeAuthCtx>["callPublicApi"],
+): unknown {
+  return requestField({ callPublicApi, field: "files" });
 }
 
 describe("handleRunnerRun with --lines", () => {
@@ -75,6 +95,18 @@ describe("handleRunnerRun with --lines", () => {
 
     expect(selectionOf(callPublicApi)).toMatchObject({
       path: "pages/login.ts",
+    });
+  });
+
+  it("sends the lines-file even when the runner already holds it unchanged", async () => {
+    const { callPublicApi } = await runWith({
+      heldByRunner: files,
+      lines: "4-9",
+      linesFile: "pages/login.ts",
+    });
+
+    expect(filesOf(callPublicApi)).toMatchObject({
+      "pages/login.ts": files["pages/login.ts"],
     });
   });
 

--- a/src/domains/interactiveRunner/submitRun.ts
+++ b/src/domains/interactiveRunner/submitRun.ts
@@ -48,6 +48,7 @@ export async function submitRun(
     files: options.files,
     held,
     runnerId: options.resolved.runnerId,
+    selectionPath: options.selection?.path,
   });
 
   const first = await sendRunFlowRequest(ctx, options, delta);


### PR DESCRIPTION
# Overview of Changes

Delta shipping withholds any file whose content hash matches what the runner already holds. A page object named by `--lines-file` that has not changed since the last run hashes equal, so it was dropped from the payload and the platform refused the run with `A selection must name a file carried in files.`

- [x] Always send the file a selection names, alongside the entry point and `package.json`, so an unchanged `--lines-file` target still travels with the run
- [x] Cover `buildRunFileDelta` keeping a selection's file while still withholding an ordinary unchanged one
- [x] Cover `handleRunnerRun` sending the `--lines-file` target against a runner that already holds it

# Testing

```bash
bun run typecheck
bun run test
bun run lint:fix
bun run format
bun run knip
```

`bun test` gives `1831 pass  0 fail`. The other four give exit 0.

- Reverting the `alwaysSent` addition fails the `buildRunFileDelta` test, and reverting the `selectionPath` wiring in `submitRun.ts` fails the `handleRunnerRun` test.
