### PR TITLE
chore(runner): bump api-contracts to 0.32.0, handle mobile runner responses for inspect

### DIFF
--- a/.changeset/api-contracts-0-32-0.md
+++ b/.changeset/api-contracts-0-32-0.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+A run may now carry up to 200 environment variables, up from 100. The CLI checks the cap locally before any round trip, so it refused at 100 whatever the platform accepted.
+
+Upgrades `@qawolf/api-contracts` to `0.32.0`, which also adds two runner failure reasons. `qawolf runner inspect` against a mobile runner now says so instead of reporting an unknown answer, and `qawolf runner act` names the action when a touchscreen has no equivalent of it.

--- a/.changeset/api-contracts-0-32-0.md
+++ b/.changeset/api-contracts-0-32-0.md
@@ -4,4 +4,4 @@
 
 A run may now carry up to 200 environment variables, up from 100. The CLI checks the cap locally before any round trip, so it refused at 100 whatever the platform accepted.
 
-Upgrades `@qawolf/api-contracts` to `0.32.0`, which also adds two runner failure reasons. `qawolf runner inspect` against a mobile runner now says so instead of reporting an unknown answer, and `qawolf runner act` names the action when a touchscreen has no equivalent of it.
+Upgrades `@qawolf/api-contracts` to `0.32.0`, which also adds two runner failure reasons. `qawolf runner inspect` against a mobile runner now says so instead of reporting an unknown answer, and `qawolf runner act` says what a touchscreen does instead when it cannot perform the action as asked.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.30.0",
+        "@qawolf/api-contracts": "0.32.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.30.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-vrOPtkLaSS75jgk9FgQgBSaEXCFgdFgWRkkox8j9qQDt65nxXKLSTwqCRy1n+LTwfR7p0cD32gUy6zdYCqctKg=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.32.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-usCDNH6IjmATfxaymMOmMKwRgE5wH+yb0VDEbWYuI457w8zeY6PnDD6NsRWAp2iYwjnvkd4a0OlCxJ+uqcqZKQ=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.30.0",
+    "@qawolf/api-contracts": "0.32.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/src/core/interactiveRunner/runEnvironment.test.ts
+++ b/src/core/interactiveRunner/runEnvironment.test.ts
@@ -42,13 +42,21 @@ describe("buildRunEnvironment", () => {
     expect(buildRunEnvironment('QAWOLF_DEBUG="1"\n').ok).toBe(true);
   });
 
-  it("refuses more variables than a run may carry", () => {
-    const many = Array.from(
-      { length: 101 },
+  const variables = (count: number) =>
+    Array.from(
+      { length: count },
       (_unused, index) => `VAR_${String(index)}="x"`,
     ).join("\n");
 
-    expect(buildRunEnvironment(`${many}\n`).ok).toBe(false);
+  it("carries as many variables as a run may hold", () => {
+    expect(buildRunEnvironment(`${variables(200)}\n`).ok).toBe(true);
+  });
+
+  it("refuses more variables than a run may carry", () => {
+    const refused = buildRunEnvironment(`${variables(201)}\n`);
+
+    expect(refused.ok).toBe(false);
+    expect(refused.ok ? "" : refused.error).toContain("At most 200");
   });
 
   it("refuses a value over the published length", () => {

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -7,6 +7,8 @@ export const interactMessages = {
     "The runner could not be reached, which does not mean the action was not performed: it may have stopped answering mid-action. Take a screenshot before repeating it.",
   actionNotJson:
     'Stdin did not hold a JSON action. Pipe one object, for example \'{"type":"click","button":"left","x":480,"y":260}\'.',
+  actionNotSupportedOnMobile: (type: string) =>
+    `A mobile runner has a touchscreen, which has no equivalent of ${type}. It taps with click, swipes with drag, and types into whatever the last tap focused.`,
   actionPerformed: (type: string) => `Performed ${type}.`,
   actionAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,
@@ -16,6 +18,8 @@ export const interactMessages = {
     "This runner does not run a browser on a virtual desktop, so there is nothing about it to see or drive. Retrying will never help: launch a playwright runner instead.",
   runnerHasNoScreenToEvaluate:
     "The runner could not evaluate the snippet. This covers a runner that is still starting or busy, and also one with no live page to evaluate against: a freshly launched runner has no page until a run opens one, so run a flow on it with qawolf runner run first. If it is not a runner that runs a browser at all, this will never clear. It is not proof the snippet did not run, so do not resubmit one that mutates the page without reading qawolf runner events console first.",
+  inspectNeedsABrowserRunner:
+    "This runner is a mobile device, and element and page HTML are a browser's shapes. Retrying will never help. Launch a playwright runner to inspect one.",
   nothingToInspect: (errorMessage: string | undefined) =>
     `The runner had nothing to inspect${errorMessage === undefined ? "" : `: ${errorMessage}`}. There is no live page, nothing matched the selector, or no variable has that name; a runner cannot tell those apart. Run a flow on it first, or check the selector or name.`,
   inspectAnsweredUnknown: (failureReason: string) =>

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -8,7 +8,7 @@ export const interactMessages = {
   actionNotJson:
     'Stdin did not hold a JSON action. Pipe one object, for example \'{"type":"click","button":"left","x":480,"y":260}\'.',
   actionNotSupportedOnMobile: (type: string) =>
-    `A mobile runner has a touchscreen, which has no equivalent of ${type}. It taps with click, swipes with drag, and types into whatever the last tap focused.`,
+    `A mobile runner has a touchscreen, so it cannot perform ${type} as asked. It taps with a left-button click, swipes with drag, and types into whatever the last tap focused.`,
   actionPerformed: (type: string) => `Performed ${type}.`,
   actionAnsweredUnknown: (failureReason: string) =>
     `The runner answered "${failureReason}", which this version of the CLI does not know how to report. Upgrade with npm install -g @qawolf/cli.`,

--- a/src/domains/interactiveRunner/inspect.test.ts
+++ b/src/domains/interactiveRunner/inspect.test.ts
@@ -156,6 +156,25 @@ describe("handleRunnerInspect", () => {
     expect(result?.error).toContain("no live page");
   });
 
+  // Element and page HTML are a browser's shapes, so this never clears by
+  // retrying. The caller has to ask a different verb.
+  it("says a mobile runner has no browser HTML to inspect", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { failureReason: "runner-is-not-a-browser", outcome: "failure" },
+    });
+
+    const result = await handleRunnerInspect(
+      ctx,
+      { flags: noFlags, runner: "ci", what: "page-html" },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("mobile device");
+    expect(result?.exitCode).toBe(2);
+  });
+
   it("reads an unreachable runner as worth retrying", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue({

--- a/src/domains/interactiveRunner/inspect.ts
+++ b/src/domains/interactiveRunner/inspect.ts
@@ -76,6 +76,11 @@ export async function handleRunnerInspect(
           ),
           exitCode: exitCodes.invalidArgs,
         };
+      case "runner-is-not-a-browser":
+        return {
+          error: interactiveRunnerMessages.inspectNeedsABrowserRunner,
+          exitCode: exitCodes.invalidArgs,
+        };
       case "runner-unreachable":
         return {
           error: interactiveRunnerMessages.runnerUnreachable,

--- a/src/domains/interactiveRunner/performAction.outcomes.test.ts
+++ b/src/domains/interactiveRunner/performAction.outcomes.test.ts
@@ -35,6 +35,18 @@ describe("handleRunnerAct outcomes", () => {
     expect(outputs()[0]?.data).toMatchObject({ outcome: "success" });
   });
 
+  // A touchscreen has no equivalent, so retrying never helps and the message
+  // has to name the action the caller asked for.
+  it("names the action a touchscreen cannot perform", async () => {
+    const { result } = await actWith({
+      failureReason: "action-not-supported-on-mobile",
+      outcome: "failure",
+    });
+
+    expect(result?.error).toContain("click");
+    expect(result?.exitCode).toBe(2);
+  });
+
   // Attempted and did not take effect: an answer, not a fault on our side.
   it("reports what stopped an action that reached the runner", async () => {
     const { result } = await actWith({

--- a/src/domains/interactiveRunner/performAction.outcomes.test.ts
+++ b/src/domains/interactiveRunner/performAction.outcomes.test.ts
@@ -35,15 +35,26 @@ describe("handleRunnerAct outcomes", () => {
     expect(outputs()[0]?.data).toMatchObject({ outcome: "success" });
   });
 
-  // A touchscreen has no equivalent, so retrying never helps and the message
-  // has to name the action the caller asked for.
-  it("names the action a touchscreen cannot perform", async () => {
-    const { result } = await actWith({
-      failureReason: "action-not-supported-on-mobile",
-      outcome: "failure",
+  // The runner answers this for a click whose button is not left, so the message
+  // must not deny the one action a touchscreen does support.
+  it("names the action and the tap a touchscreen does support", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: {
+        failureReason: "action-not-supported-on-mobile",
+        outcome: "failure",
+      },
     });
 
-    expect(result?.error).toContain("click");
+    const result = await handleRunnerAct(
+      ctx,
+      { ...click, flags: { ...click.flags, button: "right" } },
+      makeTestDeps(),
+    );
+
+    expect(result?.error).toContain("cannot perform click");
+    expect(result?.error).toContain("left-button click");
     expect(result?.exitCode).toBe(2);
   });
 

--- a/src/domains/interactiveRunner/performAction.ts
+++ b/src/domains/interactiveRunner/performAction.ts
@@ -14,6 +14,7 @@ import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
+import { describePerformActionFailure } from "./performActionFailure.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
 
@@ -105,43 +106,8 @@ export async function handleRunnerAct(
     return undefined;
   }
 
-  const failure = result.value;
-  const { failureReason } = failure;
-  switch (failureReason) {
-    // Attempted and did not take effect, which is an answer rather than a fault.
-    case "action-failed":
-      return {
-        error: interactiveRunnerMessages.actionFailed(failure.errorMessage),
-        exitCode: exitCodes.testFailure,
-      };
-    case "screen-needs-a-run":
-      return {
-        error: interactiveRunnerMessages.screenNeedsARun,
-        exitCode: exitCodes.invalidArgs,
-      };
-    case "screen-not-ready":
-      return {
-        error: interactiveRunnerMessages.screenNotReady,
-        exitCode: exitCodes.network,
-      };
-    case "runner-has-no-screen":
-      return {
-        error: interactiveRunnerMessages.runnerHasNoScreen,
-        exitCode: exitCodes.invalidArgs,
-      };
-    // Alone among these verbs, this one may have taken effect before its answer
-    // was lost, so the message must not invite a bare repeat.
-    case "runner-unreachable":
-      return {
-        error: interactiveRunnerMessages.actionMayHaveHappened,
-        exitCode: exitCodes.network,
-      };
-    default: {
-      failureReason satisfies never;
-      return {
-        error: interactiveRunnerMessages.actionAnsweredUnknown(failureReason),
-        exitCode: exitCodes.network,
-      };
-    }
-  }
+  return describePerformActionFailure({
+    actionType: built.action.type,
+    failure: result.value,
+  });
 }

--- a/src/domains/interactiveRunner/performActionFailure.ts
+++ b/src/domains/interactiveRunner/performActionFailure.ts
@@ -1,0 +1,62 @@
+import type { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
+
+import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import type { CommandResult } from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+
+type PerformActionFailure = Extract<
+  z.output<typeof publicContractsV1.runner.performAction.output>,
+  { outcome: "failure" }
+>;
+
+/** Why an action was refused, and what the caller should do about it. */
+export function describePerformActionFailure(options: {
+  actionType: string;
+  failure: PerformActionFailure;
+}): Exclude<CommandResult, void> {
+  const { actionType, failure } = options;
+  const { failureReason } = failure;
+  switch (failureReason) {
+    // Attempted and did not take effect, which is an answer rather than a fault.
+    case "action-failed":
+      return {
+        error: interactiveRunnerMessages.actionFailed(failure.errorMessage),
+        exitCode: exitCodes.testFailure,
+      };
+    case "action-not-supported-on-mobile":
+      return {
+        error: interactiveRunnerMessages.actionNotSupportedOnMobile(actionType),
+        exitCode: exitCodes.invalidArgs,
+      };
+    case "screen-needs-a-run":
+      return {
+        error: interactiveRunnerMessages.screenNeedsARun,
+        exitCode: exitCodes.invalidArgs,
+      };
+    case "screen-not-ready":
+      return {
+        error: interactiveRunnerMessages.screenNotReady,
+        exitCode: exitCodes.network,
+      };
+    case "runner-has-no-screen":
+      return {
+        error: interactiveRunnerMessages.runnerHasNoScreen,
+        exitCode: exitCodes.invalidArgs,
+      };
+    // Alone among these verbs, this one may have taken effect before its answer
+    // was lost, so the message must not invite a bare repeat.
+    case "runner-unreachable":
+      return {
+        error: interactiveRunnerMessages.actionMayHaveHappened,
+        exitCode: exitCodes.network,
+      };
+    default: {
+      failureReason satisfies never;
+      return {
+        error: interactiveRunnerMessages.actionAnsweredUnknown(failureReason),
+        exitCode: exitCodes.network,
+      };
+    }
+  }
+}


### PR DESCRIPTION
# Overview of Changes

`@qawolf/api-contracts@0.32.0` raises the run environment variable cap from 100 to 200. The CLI checks that cap locally before any round trip, so it kept refusing at 100 whatever the platform accepted. The same version publishes the mobile dispatch contracts, which add a failure reason to `runner.inspect` and another to `runner.performAction`, and both handlers close on `failureReason satisfies never` so the bump does not compile without them.

- [x] Pin `@qawolf/api-contracts` to `0.32.0`, so `--env-file` accepts 200 variables and refuses 201
- [x] Report `runner-is-not-a-browser` on `qawolf runner inspect` as a mobile runner having no browser HTML to read, rather than an answer this CLI does not know
- [x] Report `action-not-supported-on-mobile` on `qawolf runner act` by naming the action a touchscreen has no equivalent of
- [x] Move `performAction`'s failure mapping into `performActionFailure.ts`, with no change to what it does
- [x] Keep both `satisfies never` guards, which are what turned this contracts bump into a compile error instead of a silent exit 0
- [x] Cover both new failure reasons, and move the environment cap test to 200 accepted and 201 refused

# Testing

```bash
bun run typecheck
bun run test
bun run lint:fix
bun run format
bun run knip
```

`bun test` gives `1834 pass  0 fail`. The other four give exit 0.

- Against the published `0.32.0`, `buildRunEnvironment` accepts 100 and 200 variables and refuses 201 with `At most 200 environment variables may be supplied.` On `0.30.0` the same check refused at 101.
- Removing either new `case` fails that reason's own test and nothing else.
- `qawolf runner inspect-mobile` does not exist on `main`, so the mobile inspect message names no command a caller cannot run.
