### PR TITLE
Version Packages

### DIFF
--- a/.changeset/api-contracts-0-32-0.md
+++ b/.changeset/api-contracts-0-32-0.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": minor
----
-
-A run may now carry up to 200 environment variables, up from 100. The CLI checks the cap locally before any round trip, so it refused at 100 whatever the platform accepted.
-
-Upgrades `@qawolf/api-contracts` to `0.32.0`, which also adds two runner failure reasons. `qawolf runner inspect` against a mobile runner now says so instead of reporting an unknown answer, and `qawolf runner act` says what a touchscreen does instead when it cannot perform the action as asked.

--- a/.changeset/lines-file-unchanged-target.md
+++ b/.changeset/lines-file-unchanged-target.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": patch
----
-
-`qawolf runner run --lines <lines> --lines-file <path>` no longer fails when the named file has not changed since the last run on that runner.
-
-Delta shipping withholds a file whose content hash matches what the runner already holds, so an untouched page object was dropped from the payload and the platform refused the run with `A selection must name a file carried in files.` The selection's file now always travels in full, alongside the entry point and `package.json`.

--- a/.changeset/runner-call-timeout-headroom.md
+++ b/.changeset/runner-call-timeout-headroom.md
@@ -1,5 +1,0 @@
----
-"@qawolf/cli": patch
----
-
-Runner calls now wait 90 seconds instead of 60, so the first action on a fresh runner outlives the platform's browser-start wait instead of timing out client-side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @qawolf/cli
 
+## 1.16.0
+
+### Minor Changes
+
+- 20d56c3: A run may now carry up to 200 environment variables, up from 100. The CLI checks the cap locally before any round trip, so it refused at 100 whatever the platform accepted.
+
+  Upgrades `@qawolf/api-contracts` to `0.32.0`, which also adds two runner failure reasons. `qawolf runner inspect` against a mobile runner now says so instead of reporting an unknown answer, and `qawolf runner act` says what a touchscreen does instead when it cannot perform the action as asked.
+
+### Patch Changes
+
+- b278e7d: `qawolf runner run --lines <lines> --lines-file <path>` no longer fails when the named file has not changed since the last run on that runner.
+
+  Delta shipping withholds a file whose content hash matches what the runner already holds, so an untouched page object was dropped from the payload and the platform refused the run with `A selection must name a file carried in files.` The selection's file now always travels in full, alongside the entry point and `package.json`.
+
+- 7960eb0: Runner calls now wait 90 seconds instead of 60, so the first action on a fresh runner outlives the platform's browser-start wait instead of timing out client-side.
+
 ## 1.15.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",


### PR DESCRIPTION
This PR was opened by hand because the `Version PR` job cannot open it.

Since #1524 split the release job in two, `version` declares no environment while `QA_WOLF_OPS_CLIENT_ID` and `QA_WOLF_OPS_PRIVATE_KEY` exist only as `Release` environment secrets, so `Generate qa-wolf-ops token` fails with an empty `client-id`. Three merges carrying a changeset have failed that way: #1525, #1526 and #1527. The contents here are exactly what `changeset version` produces.

Merging this releases `1.16.0`. Only the `version` job is affected, so `publish` takes over from `main` as usual and carries the tag, binaries and GitHub Packages with it.

# Releases

## @qawolf/cli@1.16.0

### Minor Changes

- A run may now carry up to 200 environment variables, up from 100, and `@qawolf/api-contracts` moves to `0.32.0`.

### Patch Changes

- `qawolf runner run --lines <lines> --lines-file <path>` no longer fails when the named file has not changed since the last run.
- Runner calls now wait 90 seconds instead of 60.
