### PR TITLE
build(cli): read release app credentials in the version job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
     name: Version PR
     needs: mode
     if: needs.mode.outputs.has_changesets == 'true'
+    # The qa-wolf-ops credentials are environment secrets. This environment
+    # holds a copy with no reviewers, so the job reads them without a prompt.
+    environment: release-version
     runs-on: ubuntu-latest
     # Two version runs would race on force-pushing changeset-release/main.
     concurrency:


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

#1524 moved the deployment approval onto the `publish` job, so `version` runs without an environment. So a required key is empty in `version` and `create-github-app-token` fails with "The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string" error. 

- **`.github/workflows/release.yml`**: puts the `version` job on a `release-version` environment. 

# Testing

```bash
actionlint .github/workflows/release.yml
bun run lint --max-warnings 0
bun run format:check
bun run typecheck
bun run knip
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
