### PR TITLE
Version Packages

### DIFF
--- a/.changeset/api-contracts-0-34-0.md
+++ b/.changeset/api-contracts-0-34-0.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": minor
----
-
-An environment variable a run sends with `--env-file` may now be up to 16 KiB, up from 8 KiB. The CLI checks the cap locally before any round trip, so it refused at 8 KiB whatever the platform accepted.
-
-Upgrades `@qawolf/api-contracts` to `0.34.0`, which carries the raised cap and the `environmentId` field `--env-id` sends.

--- a/.changeset/runner-highlight-and-promote.md
+++ b/.changeset/runner-highlight-and-promote.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": minor
----
-
-`qawolf runner highlight-selector [selector]` draws on a runner's live page so the next screenshot shows what a selector matches. Omit the selector to clear it. A selector the page read but that matched nothing exits `0` and reports the count, while one the page could not read at all exits `2`, so a bad locator is told apart from a locator pointing at nothing.
-
-`qawolf runner promote-snapshot --screenshot <path> --baseline <path>` accepts a run's screenshot as the new baseline for an image diff, on the runner that produced it. Both paths are the ones the diff reported on the `run-events` journal stream.

--- a/.changeset/runner-run-env-id.md
+++ b/.changeset/runner-run-env-id.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": minor
----
-
-`qawolf runner run --env-id <id-or-alias>` gives a run the variables of a QA Wolf environment. QA Wolf reads and decrypts them itself, so the values never leave the server, nothing has to be pulled to disk first, and the caps that bound `--env-file` do not apply to them. That makes it the only way to run a flow whose environment holds something large, such as a session cookie.
-
-`--env-id` and `--env-file` each give the run its whole environment, so passing both is refused before a runner is addressed rather than one silently winning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @qawolf/cli
 
+## 1.17.0
+
+### Minor Changes
+
+- 1ae524c: An environment variable a run sends with `--env-file` may now be up to 16 KiB, up from 8 KiB. The CLI checks the cap locally before any round trip, so it refused at 8 KiB whatever the platform accepted.
+
+  Upgrades `@qawolf/api-contracts` to `0.34.0`, which carries the raised cap and the `environmentId` field `--env-id` sends.
+
+- 1ae524c: `qawolf runner highlight-selector [selector]` draws on a runner's live page so the next screenshot shows what a selector matches. Omit the selector to clear it. A selector the page read but that matched nothing exits `0` and reports the count, while one the page could not read at all exits `2`, so a bad locator is told apart from a locator pointing at nothing.
+
+  `qawolf runner promote-snapshot --screenshot <path> --baseline <path>` accepts a run's screenshot as the new baseline for an image diff, on the runner that produced it. Both paths are the ones the diff reported on the `run-events` journal stream.
+
+- 54b5912: `qawolf runner run --env-id <id-or-alias>` gives a run the variables of a QA Wolf environment. QA Wolf reads and decrypts them itself, so the values never leave the server, nothing has to be pulled to disk first, and the caps that bound `--env-file` do not apply to them. That makes it the only way to run a flow whose environment holds something large, such as a session cookie.
+
+  `--env-id` and `--env-file` each give the run its whole environment, so passing both is refused before a runner is addressed rather than one silently winning.
+
 ## 1.16.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",


### PR DESCRIPTION
This PR was opened by hand because the `Version PR` job cannot open it.

This is a **different** failure from the one #1528 worked around. That one was an empty `client-id`: the `version` job declared no environment while the `qa-wolf-ops` secrets existed only on `Release`. #1529 fixed it by adding `environment: release-version`, but the run that merged #1529 carried no changesets, so `Version PR` was skipped and the fix was never exercised.

The merge of #1530 is the first run to reach the step. It gets past `client-id` and fails on the key instead:

```
Failed to create token for "qawolf/cli" (attempt 1): Invalid keyData
DOMException [DataError]: Invalid keyData
  [cause]: Error: error:0680008E:asn1 encoding routines::not enough data
    code: 'ERR_OSSL_ASN1_NOT_ENOUGH_DATA'
```

So `QA_WOLF_OPS_PRIVATE_KEY` on the `release-version` environment is either malformed (truncated PEM, missing header or newlines) or absent — an absent secret resolves to an empty string and produces the same "not enough data". Secret values are not readable, so which one it is has to be checked in the environment's settings. **This PR does not fix that**, and the next merge carrying a changeset will fail the same way until someone does.

The contents here are exactly what `changeset version` produces: the three changesets consumed, `CHANGELOG.md` extended, and the version moved to `1.17.0`.

Merging this releases `1.17.0`. `has_changesets` becomes false, so the broken `Version PR` job is skipped entirely and `Publish` takes over from `main`. `Publish` reads the `release` environment, a separate copy of the same secret pair, and that copy works — it published `1.16.0` and carried the tag, binaries and GitHub Packages with it after #1528 merged.

# Releases

## @qawolf/cli@1.17.0

### Minor Changes

- `qawolf runner run --env-id <id-or-alias>` gives a run the variables of a QA Wolf environment. QA Wolf reads and decrypts them itself, so the values never leave the server and the caps that bound `--env-file` do not apply to them. Passing both `--env-id` and `--env-file` is refused before a runner is addressed.
- `qawolf runner highlight-selector [selector]` draws on a runner's live page so the next screenshot shows what a selector matches. Omit the selector to clear it.
- `qawolf runner promote-snapshot --screenshot <path> --baseline <path>` accepts a run's screenshot as the new baseline for an image diff, on the runner that produced it.
- An environment variable a run sends with `--env-file` may now be up to 16 KiB, up from 8 KiB, and `@qawolf/api-contracts` moves to `0.34.0`.
