### PR TITLE
hotfix(runner): default --env-id to `QAWOLF_ENVIRONMENT`

### DIFF
--- a/.changeset/runner-run-default-env.md
+++ b/.changeset/runner-run-default-env.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf runner run` now falls back to `QAWOLF_ENVIRONMENT` when neither `--env-id` nor `--env-file` is passed, so the one export that already sets a default for `qawolf flows` covers a runner run too. `--env-id` still wins over it, and `--env-file` suppresses it so a run reading a dotenv file is not handed a second environment on top.
+
+The run reports on stderr which environment it picked up. A run that was given none before is now given one, and those variables reach the flow's code, so it should never happen silently.

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -38,7 +38,9 @@ is set; otherwise select an id or alias from
 `qawolf --json environment find` and reuse it. Shell invocations may not share
 exported variables, so pass the selected environment explicitly instead of
 rediscovering it. Check the command's help for its environment flag: variable
-commands use `--environment-id`; `qawolf flows run` uses `--env`.
+commands use `--environment-id`; `qawolf flows run` uses `--env`; and
+`qawolf runner run` uses `--env-id`, which falls back to `QAWOLF_ENVIRONMENT`
+when neither it nor `--env-file` is passed.
 
 If multiple environments are returned and the task context does not identify
 the target, ask instead of guessing. Do not default to the newest environment.

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -312,6 +312,18 @@ qawolf runner run flows/checkout.flow.ts --env-id staging
 qawolf runner run flows/checkout.flow.ts --env-file .env
 ```
 
+**A run with neither flag falls back to `QAWOLF_ENVIRONMENT`**, the same
+variable `qawolf flows` reads, so one export covers both. The run says on
+stderr which environment it picked up, because those variables reach your flow's
+code and a run should never be given an environment silently. `--env-id` wins
+over it, and `--env-file` suppresses it, so a run reading a dotenv file is not
+handed a second environment on top.
+
+```sh
+export QAWOLF_ENVIRONMENT=staging
+qawolf runner run flows/checkout.flow.ts     # runs against staging
+```
+
 **Prefer `--env-id`.** QA Wolf reads and decrypts the environment itself, so the
 values never leave the server, nothing has to be pulled to disk first, and no
 size limit applies to them. It is the only way to run a flow whose environment

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -347,9 +347,9 @@ Options:
                        submission: the recorder is runner-wide, not run-scoped.
                        Implies --follow (default: false)
   --env-id <env>       QA Wolf environment whose variables the run is given, by
-                       id or alias. QA Wolf reads and decrypts them itself, so
-                       they never leave the server and no size limit applies to
-                       them
+                       id or alias. Defaults to QAWOLF_ENVIRONMENT. QA Wolf
+                       reads and decrypts them itself, so they never leave the
+                       server and no size limit applies to them
   --env-file <path>    Dotenv file on this machine whose variables the run is
                        given. Pass this or --env-id, not both
   --lines <start-end>  Run only these 1-indexed lines against the browser as it

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -38,7 +38,9 @@ is set; otherwise select an id or alias from
 `qawolf --json environment find` and reuse it. Shell invocations may not share
 exported variables, so pass the selected environment explicitly instead of
 rediscovering it. Check the command's help for its environment flag: variable
-commands use `--environment-id`; `qawolf flows run` uses `--env`.
+commands use `--environment-id`; `qawolf flows run` uses `--env`; and
+`qawolf runner run` uses `--env-id`, which falls back to `QAWOLF_ENVIRONMENT`
+when neither it nor `--env-file` is passed.
 
 If multiple environments are returned and the task context does not identify
 the target, ask instead of guessing. Do not default to the newest environment.

--- a/src/commands/runner/run.register.ts
+++ b/src/commands/runner/run.register.ts
@@ -62,7 +62,7 @@ export function registerRunCommand(
     )
     .option(
       "--env-id <env>",
-      "QA Wolf environment whose variables the run is given, by id or alias. QA Wolf reads and decrypts them itself, so they never leave the server and no size limit applies to them",
+      "QA Wolf environment whose variables the run is given, by id or alias. Defaults to QAWOLF_ENVIRONMENT. QA Wolf reads and decrypts them itself, so they never leave the server and no size limit applies to them",
     )
     .option(
       "--env-file <path>",

--- a/src/domains/interactiveRunner/deps.testUtils.ts
+++ b/src/domains/interactiveRunner/deps.testUtils.ts
@@ -25,6 +25,7 @@ export const testCwd = "/workspace";
 export function makeAuthCtx(mode: OutputMode = "human"): {
   callPublicApi: ReturnType<typeof makeCallPublicApiMock>;
   ctx: AuthCommandContext;
+  infos: () => string[];
   outputs: () => { data: unknown; humanMessage: string }[];
   streamed: () => string[];
   streamedData: () => unknown[];
@@ -39,6 +40,10 @@ export function makeAuthCtx(mode: OutputMode = "human"): {
       apiKeySource: "env",
       platformClient: makeMockPlatformClient({ callPublicApi }),
     },
+    infos: () =>
+      (base.ui.info as Mock<(message: string) => void>).mock.calls.map(
+        ([message]) => message,
+      ),
     outputs: () =>
       (
         base.ui.output as Mock<(data: unknown, humanMessage: string) => void>

--- a/src/domains/interactiveRunner/prepareRun.ts
+++ b/src/domains/interactiveRunner/prepareRun.ts
@@ -49,16 +49,21 @@ export async function prepareRun(
   },
   deps: InteractiveRunnerDeps,
 ): Promise<PreparedRun> {
-  const environmentId = options.envId?.trim();
-  if (environmentId !== undefined && options.envFile !== undefined) {
+  const explicitEnvId = options.envId?.trim();
+  if (explicitEnvId !== undefined && options.envFile !== undefined) {
     return refused(
       interactiveRunnerMessages.envIdWithEnvFile,
       exitCodes.invalidArgs,
     );
   }
-  if (environmentId === "") {
+  if (explicitEnvId === "") {
     return refused(interactiveRunnerMessages.envIdBlank, exitCodes.invalidArgs);
   }
+
+  const fromEnvVar = deps.env["QAWOLF_ENVIRONMENT"]?.trim();
+  const environmentId =
+    explicitEnvId ??
+    (options.envFile === undefined && fromEnvVar ? fromEnvVar : undefined);
 
   const linesFilePath =
     options.linesFile === undefined

--- a/src/domains/interactiveRunner/runFlow.environment.test.ts
+++ b/src/domains/interactiveRunner/runFlow.environment.test.ts
@@ -7,8 +7,9 @@ import { handleRunnerRun } from "./runFlow.js";
 const submitted = { outcome: "success" as const, runId: "run-a" };
 
 describe("handleRunnerRun with --env-file and --env-id", () => {
-  const envFileDeps = (content: string) =>
+  const envFileDeps = (content: string, env: Record<string, string> = {}) =>
     makeTestDeps({
+      env,
       collectRunFiles: async () => ({
         files: {
           "flow.ts": "export default {};",
@@ -24,14 +25,16 @@ describe("handleRunnerRun with --env-file and --env-id", () => {
 
   const run = async ({
     content = 'A="1"\n',
+    env,
     envFile,
     envId,
   }: {
     content?: string;
+    env?: Record<string, string>;
     envFile?: string;
     envId?: string;
   }) => {
-    const { callPublicApi, ctx } = makeAuthCtx();
+    const { callPublicApi, ctx, infos } = makeAuthCtx();
     callPublicApi.mockResolvedValue({ ok: true, value: submitted });
     const result = await handleRunnerRun(
       ctx,
@@ -48,9 +51,9 @@ describe("handleRunnerRun with --env-file and --env-id", () => {
         runner: "ci",
         timeout: undefined,
       },
-      envFileDeps(content),
+      envFileDeps(content, env),
     );
-    return { callPublicApi, result };
+    return { callPublicApi, infos, result };
   };
 
   const sentRequest = (callPublicApi: { mock: { calls: unknown[][] } }) =>
@@ -104,6 +107,52 @@ describe("handleRunnerRun with --env-file and --env-id", () => {
     expect(sentRequest(callPublicApi)).toMatchObject({
       environmentId: "staging",
     });
+  });
+
+  it("falls back to QAWOLF_ENVIRONMENT when neither flag is passed", async () => {
+    const { callPublicApi, infos, result } = await run({
+      env: { QAWOLF_ENVIRONMENT: "staging" },
+    });
+
+    expect(result).toBeUndefined();
+    expect(sentRequest(callPublicApi)).toMatchObject({
+      environmentId: "staging",
+    });
+    // Those variables reach the flow's code, so the run says where they came from.
+    expect(infos().join("\n")).toContain("QAWOLF_ENVIRONMENT");
+  });
+
+  it("prefers an explicit --env-id over QAWOLF_ENVIRONMENT", async () => {
+    const { callPublicApi, infos } = await run({
+      env: { QAWOLF_ENVIRONMENT: "staging" },
+      envId: "production",
+    });
+
+    expect(sentRequest(callPublicApi)).toMatchObject({
+      environmentId: "production",
+    });
+    expect(infos().join("\n")).not.toContain("QAWOLF_ENVIRONMENT");
+  });
+
+  // The file is the whole environment the caller asked for, so it is not given
+  // a second one on top.
+  it("ignores QAWOLF_ENVIRONMENT when --env-file is passed", async () => {
+    const { callPublicApi } = await run({
+      env: { QAWOLF_ENVIRONMENT: "staging" },
+      envFile: ".env",
+    });
+    const request = sentRequest(callPublicApi);
+
+    expect(request).toMatchObject({ env: { A: "1" } });
+    expect(Object.hasOwn(request, "environmentId")).toBe(false);
+  });
+
+  it("treats a blank QAWOLF_ENVIRONMENT as unset", async () => {
+    const { callPublicApi } = await run({ env: { QAWOLF_ENVIRONMENT: "  " } });
+
+    expect(Object.hasOwn(sentRequest(callPublicApi), "environmentId")).toBe(
+      false,
+    );
   });
 
   it("refuses an --env-id given nothing", async () => {

--- a/src/domains/interactiveRunner/runFlow.ts
+++ b/src/domains/interactiveRunner/runFlow.ts
@@ -1,6 +1,9 @@
 import { parseFollowTimeout } from "~/core/interactiveRunner/followTimeout.js";
 import { toCollectedPath } from "~/core/interactiveRunner/runFiles.js";
-import { interactiveRunnerMessages } from "~/core/messages/index.js";
+import {
+  environmentsMessages,
+  interactiveRunnerMessages,
+} from "~/core/messages/index.js";
 import type {
   AuthCommandContext,
   CommandResult,
@@ -53,6 +56,10 @@ export async function handleRunnerRun(
   );
   if (!prepared.ok) {
     return { error: prepared.error, exitCode: prepared.exitCode };
+  }
+
+  if (options.envId === undefined && prepared.environmentId !== undefined) {
+    ctx.ui.info(environmentsMessages.usingFromEnvVar(prepared.environmentId));
   }
 
   const resolved = await resolveRunner(


### PR DESCRIPTION
# Overview of Changes

A `qawolf runner run` that names no environment gets none. Anyone who already exports `QAWOLF_ENVIRONMENT`, the variable `qawolf flows` reads and the documented way to set a default, has to repeat it as `--env-id` on every run. In CI that is easy to miss, and the run executes against no environment rather than failing.

`qawolf runner run` now falls back to `QAWOLF_ENVIRONMENT` when neither `--env-id` nor `--env-file` is passed, so one export covers both commands.

- `--env-id` wins over it, and `--env-file` suppresses it, so a run reading a dotenv file is not handed a second environment on top. A blank or unset variable counts as absent rather than being sent as an empty id the server would reject.
- The run reports on stderr which environment it picked up, reusing the `usingFromEnvVar` message `qawolf flows` already prints. It fires only for the fallback, never for an explicit flag. Those variables reach your flow's code, so a run should not be given an environment silently.
- Both existing refusals are unchanged and still land before a runner is resolved: `--env-id` together with `--env-file`, and a blank `--env-id`.

This reverses a deliberate choice from #1530, which made `--env-id` explicit-only. That was right when `runner run` had no environment concept. Now that it has one, matching `qawolf flows` is the less surprising behaviour.

**Behaviour change on upgrade:** a run with no env flags, in a shell exporting `QAWOLF_ENVIRONMENT`, now sends that environment where 1.17.0 sent none.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
```

1856 tests pass. Four new cases in `runFlow.environment.test.ts`: the fallback applies and announces, `--env-id` beats the variable, `--env-file` suppresses it, and a blank variable is ignored. `makeTestDeps` already defaulted `env: {}`, so no existing test picks the variable up by accident.

The fallback case was checked against a revert rather than trusted because it passed: replacing the resolution with `const environmentId = explicitEnvId` makes that test fail, and restoring it makes it pass again. The other three pass either way by design, pinning the boundaries rather than the new behaviour.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
