### PR TITLE
Version Packages

### DIFF
--- a/.changeset/runner-run-default-env.md
+++ b/.changeset/runner-run-default-env.md
@@ -1,7 +1,0 @@
----
-"@qawolf/cli": patch
----
-
-`qawolf runner run` now falls back to `QAWOLF_ENVIRONMENT` when neither `--env-id` nor `--env-file` is passed, so the one export that already sets a default for `qawolf flows` covers a runner run too. `--env-id` still wins over it, and `--env-file` suppresses it so a run reading a dotenv file is not handed a second environment on top.
-
-The run reports on stderr which environment it picked up. A run that was given none before is now given one, and those variables reach the flow's code, so it should never happen silently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @qawolf/cli
 
+## 1.17.1
+
+### Patch Changes
+
+- ff34821: `qawolf runner run` now falls back to `QAWOLF_ENVIRONMENT` when neither `--env-id` nor `--env-file` is passed, so the one export that already sets a default for `qawolf flows` covers a runner run too. `--env-id` still wins over it, and `--env-file` suppresses it so a run reading a dotenv file is not handed a second environment on top.
+
+  The run reports on stderr which environment it picked up. A run that was given none before is now given one, and those variables reach the flow's code, so it should never happen silently.
+
 ## 1.17.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",


### PR DESCRIPTION
This PR was opened by hand because the `Version PR` job still cannot open it.

The failure has moved on since #1531, so this is a third distinct problem in the same step rather than the one that PR described:

| When | Failure |
| --- | --- |
| before #1529 | `The 'client-id' ... input must be set to a non-empty string` — the job declared no environment |
| #1530's merge | `Invalid keyData` / `ERR_OSSL_ASN1_NOT_ENOUGH_DATA` — the private key did not parse |
| #1532's merge | the key parses, and GitHub answers `401 A JSON web token could not be decoded` |

So the PEM on `release-version` was repaired between yesterday and now, and it is no longer malformed. What is left is that the JWT it signs is rejected by GitHub on `GET /repos/qawolf/cli/installation`, which is what you get when the private key does not belong to the app named by `client-id`.

The `release` environment holds a pair that does work — `Publish` used it to ship `1.17.0` an hour ago. So the fix is to copy **both** `QA_WOLF_OPS_CLIENT_ID` and `QA_WOLF_OPS_PRIVATE_KEY` from `release` to `release-version` as a matched pair. Replacing only the key is what leaves it in this state. **This PR does not do that**, and the next merge carrying a changeset fails the same way until someone does.

The contents here are exactly what `changeset version` produces: the changeset consumed, `CHANGELOG.md` extended, and the version moved to `1.17.1`.

Merging this releases `1.17.1`. `has_changesets` becomes false, so the broken `Version PR` job is skipped entirely and `Publish` takes over from `main` using the `release` environment, which works.

# Releases

## @qawolf/cli@1.17.1

### Patch Changes

- `qawolf runner run` now falls back to `QAWOLF_ENVIRONMENT` when neither `--env-id` nor `--env-file` is passed, so the one export that already sets a default for `qawolf flows` covers a runner run too. `--env-id` still wins over it, and `--env-file` suppresses it so a run reading a dotenv file is not handed a second environment on top. The run reports on stderr which environment it picked up.
