### PR TITLE
fix(runner): stop reading a spend-limit refusal as retryable

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -11,6 +11,7 @@ CI consumers depend on consistent exit codes. The CLI commits to the following c
 | `4`  | `network`     | Apex unreachable, GCS download failure, registry unreachable, or a runner that could not serve the request now (unreachable, or its screen not yet up).                                                                                                                                            |
 | `5`  | `config`      | `qawolf.config.ts` invalid, file collision during `init`, or a run file that could not be read.                                                                                                                                                                                                    |
 | `6`  | `timeout`     | A `--follow` reached its `--timeout`: `runner run` before its run settled (the run may still be going), or `runner events`.                                                                                                                                                                        |
+| `7`  | `payment`     | The QA Wolf API refused the request with HTTP 402: billing prevented it — the organization is over its monthly spend limit or has no valid payment method.                                                                                                                                         |
 
 ## Using the helper
 

--- a/src/core/messages/auth.ts
+++ b/src/core/messages/auth.ts
@@ -44,6 +44,8 @@ export const authMessages = {
     request: {
       rejected401: (noun: string | undefined) =>
         `QA Wolf API rejected the${noun ? ` ${noun}` : ""} request (HTTP 401). Check your API key.`,
+      rejected402: (noun: string | undefined) =>
+        `QA Wolf API refused the${noun ? ` ${noun}` : ""} request (HTTP 402): billing prevented it.`,
       rejected403: (noun: string | undefined) =>
         `QA Wolf API rejected the${noun ? ` ${noun}` : ""} request (HTTP 403). Check that your API key has access to this environment.`,
       notFound404: (noun: string | undefined) =>

--- a/src/domains/interactiveRunner/evaluateSnippet.spendLimit.test.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.spendLimit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+
+import { handleRunnerExec } from "./evaluateSnippet.js";
+import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
+
+describe("handleRunnerExec spend limit", () => {
+  it("keeps the payment exit code on a spend-limit refusal", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      error:
+        "QA Wolf API refused the runner.evaluateSnippet request (HTTP 402): billing prevented it.",
+      errorBody:
+        "You have reached your monthly limit of $50.00 for runner usage.",
+      exitCode: 7,
+      ok: false,
+    });
+
+    const result = await handleRunnerExec(
+      ctx,
+      { contextFile: undefined, runner: "ci", source: "flow.ts" },
+      makeTestDeps(),
+    );
+
+    expect(result?.errorBody).toContain("monthly limit");
+    expect(result?.exitCode).toBe(7);
+  });
+});

--- a/src/domains/interactiveRunner/evaluateSnippet.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.ts
@@ -111,7 +111,10 @@ export async function handleRunnerExec(
     runnerCallOptions,
   );
   if (!result.ok) {
-    return { ...failureFields(result), exitCode: exitCodes.network };
+    return {
+      ...failureFields(result),
+      exitCode: result.exitCode ?? exitCodes.network,
+    };
   }
 
   if (result.value.outcome === "failure") {

--- a/src/domains/interactiveRunner/importPackage.test.ts
+++ b/src/domains/interactiveRunner/importPackage.test.ts
@@ -149,4 +149,25 @@ describe("handleRunnerImportPackage", () => {
     expect(result?.error).toContain("Retry");
     expect(result?.exitCode).toBe(4);
   });
+
+  it("keeps the payment exit code on a spend-limit refusal", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      error:
+        "QA Wolf API refused the runner.importPackage request (HTTP 402): billing prevented it.",
+      errorBody:
+        "You have reached your monthly limit of $50.00 for runner usage.",
+      exitCode: 7,
+      ok: false,
+    });
+
+    const result = await handleRunnerImportPackage(
+      ctx,
+      { name: "dayjs", runner: "ci", version: undefined },
+      depsWithManifest(),
+    );
+
+    expect(result?.errorBody).toContain("monthly limit");
+    expect(result?.exitCode).toBe(7);
+  });
 });

--- a/src/domains/interactiveRunner/importPackage.ts
+++ b/src/domains/interactiveRunner/importPackage.ts
@@ -81,7 +81,10 @@ export async function handleRunnerImportPackage(
     runnerCallOptions,
   );
   if (!result.ok) {
-    return { ...failureFields(result), exitCode: exitCodes.network };
+    return {
+      ...failureFields(result),
+      exitCode: result.exitCode ?? exitCodes.network,
+    };
   }
 
   if (result.value.outcome === "failure") {

--- a/src/domains/interactiveRunner/launchAndRemember.ts
+++ b/src/domains/interactiveRunner/launchAndRemember.ts
@@ -36,7 +36,7 @@ async function launchRunner(
   if (!result.ok) {
     return {
       ...failureFields(result),
-      exitCode: exitCodes.network,
+      exitCode: result.exitCode ?? exitCodes.network,
       mayHaveArrived: result.mayHaveArrived ?? false,
       ok: false,
     };

--- a/src/domains/interactiveRunner/sendRunFlowRequest.ts
+++ b/src/domains/interactiveRunner/sendRunFlowRequest.ts
@@ -60,7 +60,10 @@ export async function sendRunFlowRequest(
   );
   if (!result.ok) {
     return {
-      failure: { ...failureFields(result), exitCode: exitCodes.network },
+      failure: {
+        ...failureFields(result),
+        exitCode: result.exitCode ?? exitCodes.network,
+      },
       type: "failed",
     };
   }

--- a/src/shell/exit.test.ts
+++ b/src/shell/exit.test.ts
@@ -59,6 +59,7 @@ describe("exit", () => {
       network: 4,
       config: 5,
       timeout: 6,
+      payment: 7,
     });
   });
 });

--- a/src/shell/exit.ts
+++ b/src/shell/exit.ts
@@ -6,6 +6,7 @@ export const exitCodes = {
   network: 4,
   config: 5,
   timeout: 6,
+  payment: 7,
 } as const;
 
 type ExitCode = (typeof exitCodes)[keyof typeof exitCodes];

--- a/src/shell/platform/describeErrors.test.ts
+++ b/src/shell/platform/describeErrors.test.ts
@@ -18,7 +18,7 @@ const envelope = (message: string) =>
   JSON.stringify({ error: { json: { message } } });
 
 describe("describeRequestError", () => {
-  it.each([401, 403, 404, 500])(
+  it.each([401, 402, 403, 404, 500])(
     "carries the server's reason on HTTP %i",
     (status) => {
       const described = describeRequestError(
@@ -32,7 +32,7 @@ describe("describeRequestError", () => {
     },
   );
 
-  it.each([401, 403, 404, 500])(
+  it.each([401, 402, 403, 404, 500])(
     "omits the body entirely when HTTP %i carries no reason",
     (status) => {
       const described = describeRequestError(
@@ -53,6 +53,16 @@ describe("describeRequestError", () => {
     );
 
     expect(described.exitCode).toBe(exitCodes.auth);
+  });
+
+  it("maps HTTP 402 to the payment exit code", () => {
+    const described = describeRequestError(
+      httpError(402),
+      baseUrl,
+      "run.create",
+    );
+
+    expect(described.exitCode).toBe(exitCodes.payment);
   });
 
   it.each([403, 404, 500])(

--- a/src/shell/platform/describeErrors.ts
+++ b/src/shell/platform/describeErrors.ts
@@ -55,6 +55,12 @@ export function describeRequestError(
         exitCode: exitCodes.auth,
         ...body,
       };
+    if (err.status === 402)
+      return {
+        error: m.request.rejected402(noun),
+        exitCode: exitCodes.payment,
+        ...body,
+      };
     if (err.status === 403)
       return { error: m.request.rejected403(noun), ...body };
     if (err.status === 404)


### PR DESCRIPTION
# Overview of Changes

Today the four runner handlers rebuild every platform failure with exit code 4, documented as "Apex unreachable" - so an agent driving the CLI reads a spend-limit refusal as transient and retries forever. 402 now gets its own documented exit code, 7 `payment`, assigned in `describeRequestError` next to the existing 401 → 3 mapping, and the handlers keep an exit code the platform layer already set instead of overwriting it with 4.

The server's own reason ("You have reached your monthly limit of …") already travels in the error body and still does.

Also: the same overwrite was clobbering the 401 → 3 mapping on these four verbs, a 401 on `runner run` exited 4. It exits 3 now.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All green locally. New cases: `describeErrors.test.ts` covers the 402 mapping, `evaluateSnippet.spendLimit.test.ts` and `importPackage.test.ts` prove the exit code survives the handlers' rebuild.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)


