### PR TITLE
feat(flows): cache flow tags at pull time and show them in list

### DIFF
--- a/.changeset/cache-flow-tags-at-pull-time.md
+++ b/.changeset/cache-flow-tags-at-pull-time.md
@@ -1,0 +1,9 @@
+---
+"@qawolf/cli": minor
+---
+
+`flows list` now shows the tags of each flow.
+
+`flows pull` gets the tags of an environment and writes them to the manifest. A failed tag request does not stop the pull, and it does not erase tags from an earlier pull.
+
+Local `flows list` no longer sends `tags: []` for a flow it did not pull. The `tags` key is absent when the tags are unknown, and `[]` only when the flow has none.

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -28,6 +28,7 @@ export const flowsMessages = {
       "An environment is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
     downloadingBundle: "Downloading flows bundle",
     fetchingEnvVars: "Fetching environment variables",
+    fetchingTags: "Fetching flow tags",
     downloadComplete: "Downloaded flows bundle and environment variables",
     needsYesError: "Re-run with --yes to overwrite locally-modified files",
     aborted: "Aborted; no changes.",

--- a/src/core/repoRelativePath.test.ts
+++ b/src/core/repoRelativePath.test.ts
@@ -44,6 +44,18 @@ describe("toRepoRelativePath", () => {
     ).toBe("src/flows/a/b.flow.ts");
   });
 
+  // The result is compared against paths the platform reports, which are
+  // posix. On win32 `relative` yields backslashes, so it must be normalized
+  // or every comparison misses.
+  it("always returns posix separators", () => {
+    const result = toRepoRelativePath(
+      "/repo/.qawolf/staging/src/flows/a/b.flow.ts",
+      "/repo",
+    );
+    expect(result).not.toContain("\\");
+    expect(result.split("/")).toEqual(["src", "flows", "a", "b.flow.ts"]);
+  });
+
   it("falls back to a path relative to cwd for a project flow", () => {
     expect(toRepoRelativePath("/repo/src/flows/a/b.flow.ts", "/repo")).toBe(
       "src/flows/a/b.flow.ts",

--- a/src/core/repoRelativePath.test.ts
+++ b/src/core/repoRelativePath.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { findPulledEnvDir, toRepoRelativePath } from "./repoRelativePath.js";
+
+describe("findPulledEnvDir", () => {
+  it("finds the env dir whose parent is .qawolf", () => {
+    expect(
+      findPulledEnvDir("/repo/.qawolf/staging/src/flows/a/b.flow.ts"),
+    ).toBe("/repo/.qawolf/staging");
+  });
+
+  it("finds it when the flow sits directly in the env dir", () => {
+    expect(findPulledEnvDir("/repo/.qawolf/staging/b.flow.ts")).toBe(
+      "/repo/.qawolf/staging",
+    );
+  });
+
+  it("returns undefined outside a pulled env tree", () => {
+    expect(findPulledEnvDir("/repo/src/flows/a/b.flow.ts")).toBeUndefined();
+  });
+
+  // `.qawolf` itself is not an env dir — the env is the directory beneath it.
+  it("returns undefined for a file directly inside .qawolf", () => {
+    expect(findPulledEnvDir("/repo/.qawolf/b.flow.ts")).toBeUndefined();
+  });
+});
+
+describe("toRepoRelativePath", () => {
+  it("strips the pulled env prefix so the path is repo-relative", () => {
+    expect(
+      toRepoRelativePath(
+        "/repo/.qawolf/staging/src/flows/a/b.flow.ts",
+        "/repo",
+      ),
+    ).toBe("src/flows/a/b.flow.ts");
+  });
+
+  it("ignores cwd for a pulled flow", () => {
+    expect(
+      toRepoRelativePath(
+        "/repo/.qawolf/staging/src/flows/a/b.flow.ts",
+        "/somewhere/else",
+      ),
+    ).toBe("src/flows/a/b.flow.ts");
+  });
+
+  it("falls back to a path relative to cwd for a project flow", () => {
+    expect(toRepoRelativePath("/repo/src/flows/a/b.flow.ts", "/repo")).toBe(
+      "src/flows/a/b.flow.ts",
+    );
+  });
+});

--- a/src/core/repoRelativePath.ts
+++ b/src/core/repoRelativePath.ts
@@ -1,0 +1,29 @@
+import { basename, dirname, relative } from "node:path";
+
+/**
+ * Resolves the `.qawolf/<env>/` directory a pulled flow lives under, or
+ * undefined when the flow is not part of a pulled env tree.
+ */
+export function findPulledEnvDir(flowAbsPath: string): string | undefined {
+  // Walk up from the flow file looking for an ancestor whose own parent is
+  // `.qawolf`; that ancestor is the env dir.
+  let current = dirname(flowAbsPath);
+  while (current !== dirname(current)) {
+    const parent = dirname(current);
+    if (basename(parent) === ".qawolf") return current;
+    current = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Converts a flow's absolute path to the repo-relative form the platform uses
+ * (e.g. `src/flows/checkout/login.flow.ts`).
+ *
+ * Pulled flows resolve against their env dir, so the `.qawolf/<env>/` prefix
+ * never leaks into the result; everything else resolves against `cwd`.
+ */
+export function toRepoRelativePath(flowAbsPath: string, cwd: string): string {
+  const envDir = findPulledEnvDir(flowAbsPath);
+  return relative(envDir ?? cwd, flowAbsPath);
+}

--- a/src/core/repoRelativePath.ts
+++ b/src/core/repoRelativePath.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, relative } from "node:path";
+import { basename, dirname, relative, sep } from "node:path";
 
 /**
  * Resolves the `.qawolf/<env>/` directory a pulled flow lives under, or
@@ -25,5 +25,9 @@ export function findPulledEnvDir(flowAbsPath: string): string | undefined {
  */
 export function toRepoRelativePath(flowAbsPath: string, cwd: string): string {
   const envDir = findPulledEnvDir(flowAbsPath);
-  return relative(envDir ?? cwd, flowAbsPath);
+  // Always posix. The result is compared against paths the platform reports,
+  // which are posix, so returning win32 separators would never match.
+  return relative(envDir ?? cwd, flowAbsPath)
+    .split(sep)
+    .join("/");
 }

--- a/src/core/repoRelativePath.ts
+++ b/src/core/repoRelativePath.ts
@@ -1,4 +1,14 @@
-import { basename, dirname, relative, sep } from "node:path";
+import { basename, dirname, relative } from "node:path";
+
+/**
+ * Rewrites a path to posix separators.
+ *
+ * Manifest paths and platform paths are both posix, so anything compared
+ * against them is normalized with this rather than with the host separator:
+ * splitting on `sep` is a no-op on posix and would leave a win32-written
+ * manifest unmatched.
+ */
+export const toPosix = (path: string): string => path.replaceAll("\\", "/");
 
 /**
  * Resolves the `.qawolf/<env>/` directory a pulled flow lives under, or
@@ -25,9 +35,5 @@ export function findPulledEnvDir(flowAbsPath: string): string | undefined {
  */
 export function toRepoRelativePath(flowAbsPath: string, cwd: string): string {
   const envDir = findPulledEnvDir(flowAbsPath);
-  // Always posix. The result is compared against paths the platform reports,
-  // which are posix, so returning win32 separators would never match.
-  return relative(envDir ?? cwd, flowAbsPath)
-    .split(sep)
-    .join("/");
+  return toPosix(relative(envDir ?? cwd, flowAbsPath));
 }

--- a/src/domains/flows/list.agent.test.ts
+++ b/src/domains/flows/list.agent.test.ts
@@ -46,6 +46,9 @@ function makeDeps(overrides?: {
         target: metaByFile[file]?.target,
       }),
     ),
+    readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
+      Promise.resolve(new Map<string, readonly string[]>()),
+    ),
   };
 }
 

--- a/src/domains/flows/list.json.test.ts
+++ b/src/domains/flows/list.json.test.ts
@@ -37,8 +37,9 @@ function makeCtx(
 function makeDeps(overrides?: {
   files?: readonly string[];
   metaByFile?: Record<string, { name?: string; target?: string }>;
+  cachedTags?: Record<string, readonly string[]>;
 }): FlowsListDeps {
-  const { files = [], metaByFile = {} } = overrides ?? {};
+  const { files = [], metaByFile = {}, cachedTags = {} } = overrides ?? {};
   return {
     cwd: fakeCwd,
     expandPatterns: mock<FlowsListDeps["expandPatterns"]>(() =>
@@ -51,7 +52,7 @@ function makeDeps(overrides?: {
       }),
     ),
     readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
-      Promise.resolve(new Map<string, readonly string[]>()),
+      Promise.resolve(new Map(Object.entries(cachedTags))),
     ),
   };
 }
@@ -155,5 +156,60 @@ describe("flowsList json mode output", () => {
         browser: undefined,
       },
     ]);
+  });
+  // A pulled flow known to carry no tags is not the same as a flow whose tags
+  // the CLI never fetched: one sends [], the other sends nothing.
+  it("emits an empty tag list for a pulled flow with no tags", async () => {
+    const ui = makeFakeUI();
+    const file = "/proj/.qawolf/staging/src/flows/login.flow.ts";
+    const deps = makeDeps({
+      files: [file],
+      metaByFile: { [file]: { name: "Login", target: "Web - Chrome" } },
+      cachedTags: { [file]: [] },
+    });
+
+    await flowsList(makeCtx(ui, "json"), undefined, deps);
+
+    const items = (ui.json as ReturnType<typeof mock>).mock.calls[0]?.[0] as {
+      tags?: readonly string[];
+    }[];
+    expect(items[0]?.tags).toEqual([]);
+  });
+
+  it("emits the cached tags for a pulled flow that has them", async () => {
+    const ui = makeFakeUI();
+    const file = "/proj/.qawolf/staging/src/flows/login.flow.ts";
+    const deps = makeDeps({
+      files: [file],
+      metaByFile: { [file]: { name: "Login", target: "Web - Chrome" } },
+      cachedTags: { [file]: ["auth", "smoke"] },
+    });
+
+    await flowsList(makeCtx(ui, "json"), undefined, deps);
+
+    const items = (ui.json as ReturnType<typeof mock>).mock.calls[0]?.[0] as {
+      tags?: readonly string[];
+    }[];
+    expect(items[0]?.tags).toEqual(["auth", "smoke"]);
+  });
+
+  it("omits tags entirely for a flow that was never pulled", async () => {
+    const ui = makeFakeUI();
+    const deps = makeDeps({
+      files: ["/proj/src/flows/local.flow.ts"],
+      metaByFile: {
+        "/proj/src/flows/local.flow.ts": {
+          name: "Local",
+          target: "Web - Chrome",
+        },
+      },
+    });
+
+    await flowsList(makeCtx(ui, "json"), undefined, deps);
+
+    const items = (ui.json as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as Record<string, unknown>[];
+    expect(items[0]).not.toHaveProperty("tags", []);
+    expect(items[0]?.["tags"]).toBeUndefined();
   });
 });

--- a/src/domains/flows/list.json.test.ts
+++ b/src/domains/flows/list.json.test.ts
@@ -50,6 +50,9 @@ function makeDeps(overrides?: {
         target: metaByFile[file]?.target,
       }),
     ),
+    readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
+      Promise.resolve(new Map<string, readonly string[]>()),
+    ),
   };
 }
 
@@ -72,7 +75,7 @@ describe("flowsList json mode output", () => {
       {
         file: join("src", "flows", "login.flow.ts"),
         name: "Login",
-        tags: [],
+        tags: undefined,
         target: "Web - Chrome",
         browser: "chromium",
       },
@@ -100,7 +103,7 @@ describe("flowsList json mode output", () => {
       {
         file: join("src", "flows", "checkout.flow.ts"),
         name: "checkout",
-        tags: [],
+        tags: undefined,
         target: "Web - Firefox",
         browser: "firefox",
       },
@@ -122,7 +125,7 @@ describe("flowsList json mode output", () => {
       {
         file: join("src", "flows", "legacy.flow.js"),
         name: "legacy",
-        tags: [],
+        tags: undefined,
         target: "Web - Chrome",
         browser: "chromium",
       },
@@ -147,7 +150,7 @@ describe("flowsList json mode output", () => {
       {
         file: join("src", "flows", "mobile.flow.ts"),
         name: "Mobile",
-        tags: [],
+        tags: undefined,
         target: "Android - Pixel",
         browser: undefined,
       },

--- a/src/domains/flows/list.test.ts
+++ b/src/domains/flows/list.test.ts
@@ -49,6 +49,9 @@ function makeDeps(overrides?: {
         target: metaByFile[file]?.target,
       }),
     ),
+    readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
+      Promise.resolve(new Map<string, readonly string[]>()),
+    ),
   };
 }
 

--- a/src/domains/flows/list.ts
+++ b/src/domains/flows/list.ts
@@ -14,6 +14,7 @@ import {
   expandPatterns as defaultExpandPatterns,
   makePeekFlowMeta,
 } from "./expand.js";
+import { readCachedTags as defaultReadCachedTags } from "./readCachedTags.js";
 import { renderListTable } from "./renderListTable.js";
 
 export type FlowsListDeps = {
@@ -23,12 +24,18 @@ export type FlowsListDeps = {
     cwd: string,
   ) => Promise<string[]>;
   readonly peekFlowMeta: PeekFlowMetaFn;
+  /** Tags cached at pull time, keyed by absolute flow path. */
+  readonly readCachedTags: (
+    files: readonly string[],
+  ) => Promise<Map<string, readonly string[]>>;
 };
 
 type FlowsListItem = {
   file: string;
   name: string;
-  tags: readonly string[];
+  // Absent when the flow was never pulled, so its tags are unknown rather
+  // than known to be empty.
+  tags: readonly string[] | undefined;
   target: string | undefined;
   browser: BrowserName | undefined;
 };
@@ -40,6 +47,7 @@ export async function flowsList(
 ): Promise<CommandResult> {
   const patterns = pattern ? [pattern] : [];
   const files = await deps.expandPatterns(patterns, deps.cwd);
+  const cachedTags = await deps.readCachedTags(files);
 
   const items: FlowsListItem[] = [];
   for await (const { file, ...meta } of batchMap(
@@ -50,7 +58,7 @@ export async function flowsList(
     items.push({
       file: path.relative(deps.cwd, file),
       name: meta.name ?? flowBasename(file),
-      tags: [],
+      tags: cachedTags.get(file),
       target: meta.target,
       browser: meta.target ? targetToBrowser(meta.target) : undefined,
     });
@@ -67,6 +75,7 @@ export async function flowsList(
   const rows = items.map((it) => ({
     name: it.name,
     target: it.target ?? "",
+    tags: it.tags,
     file: it.file,
   }));
   if (ctx.ui.mode === "agent") {
@@ -89,5 +98,6 @@ export function handleFlowsList(
     expandPatterns: (patterns, cwd) =>
       defaultExpandPatterns(patterns, cwd, undefined, fs),
     peekFlowMeta: makePeekFlowMeta(fs),
+    readCachedTags: (files) => defaultReadCachedTags(files, fs),
   });
 }

--- a/src/domains/flows/listRemote.test.ts
+++ b/src/domains/flows/listRemote.test.ts
@@ -103,7 +103,7 @@ describe("flowsListRemote wire call", () => {
 });
 
 describe("flowsListRemote success paths", () => {
-  it("renders a bolded header + name|target|file rows in human mode", async () => {
+  it("renders a bolded header + name|target|tags|file rows in human mode", async () => {
     const { ui } = await run({ mode: "human" });
 
     const output = callsOf(ui.write)
@@ -115,13 +115,13 @@ describe("flowsListRemote success paths", () => {
     expect(lines[0]).toMatch(/\[0m/);
     // oxlint-disable-next-line no-control-regex, @typescript-eslint/no-non-null-assertion
     expect(lines[0]!.replace(/\x1b[^m]*m/g, "")).toMatch(
-      /^name\s+target\s+file$/,
+      /^name\s+target\s+tags\s+file$/,
     );
     expect(stripAnsi(lines[1])).toMatch(
       /^Login\s+Web - Chrome\s+src\/flows\/login\.flow\.ts$/,
     );
     expect(stripAnsi(lines[2])).toMatch(
-      /^Checkout\s+Web - Firefox\s+src\/flows\/sub\/checkout\.flow\.ts$/,
+      /^Checkout\s+Web - Firefox\s+smoke\s+src\/flows\/sub\/checkout\.flow\.ts$/,
     );
     expect(ui.intro).toHaveBeenCalledWith("Remote Flows");
     expect(ui.outro).toHaveBeenCalledWith("2 flows");

--- a/src/domains/flows/listRemote.ts
+++ b/src/domains/flows/listRemote.ts
@@ -64,6 +64,7 @@ export async function flowsListRemote(
   const rows = items.map((it) => ({
     name: it.name,
     target: it.target,
+    tags: it.tags,
     file: it.file,
   }));
   if (ctx.ui.mode === "agent") {

--- a/src/domains/flows/pull/bundle.test.ts
+++ b/src/domains/flows/pull/bundle.test.ts
@@ -139,9 +139,10 @@ describe("buildManifest", () => {
 
     const manifest = await buildManifest(baseArgs());
 
+    // Manifest paths are written in posix form on every host.
     expect(manifest.flows.map((f) => f.path).sort()).toEqual([
       "a.flow.ts",
-      join("nested", "b.flow.js"),
+      "nested/b.flow.js",
     ]);
     expect(manifest.flows[0]?.contentHash).toMatch(/^[a-f0-9]{64}$/);
   });

--- a/src/domains/flows/pull/bundle.test.ts
+++ b/src/domains/flows/pull/bundle.test.ts
@@ -115,6 +115,7 @@ describe("buildManifest", () => {
     envVarsFetchedAt: Date | undefined;
     wrapperName: string | undefined;
     qawolfCommittedAt: string | undefined;
+    tags: undefined;
   } => ({
     envId: "env-x",
     bundleDir: workDir,
@@ -123,6 +124,7 @@ describe("buildManifest", () => {
     envVarsFetchedAt: undefined,
     wrapperName: undefined,
     qawolfCommittedAt: undefined,
+    tags: undefined,
   });
 
   it("walks .flow.ts and .flow.js files, ignores other extensions", async () => {

--- a/src/domains/flows/pull/bundle.ts
+++ b/src/domains/flows/pull/bundle.ts
@@ -1,4 +1,4 @@
-import { join, relative } from "node:path";
+import { join, relative, sep } from "node:path";
 
 import { hashFile } from "~/shell/manifest/io.js";
 import type { Manifest } from "~/shell/manifest/types.js";
@@ -48,6 +48,15 @@ function extractQawolfCommitSha(
 
 const flowExtensions = [".flow.ts", ".flow.js"];
 
+/**
+ * Tags fetched for an env at pull time, keyed by repo-relative flow path.
+ * Undefined when the fetch did not happen or failed.
+ */
+export type FetchedTags = {
+  fetchedAt: Date;
+  byPath: Map<string, string[]>;
+};
+
 export async function buildManifest(
   args: {
     envId: string;
@@ -57,6 +66,7 @@ export async function buildManifest(
     envVarsFetchedAt: Date | undefined;
     wrapperName: string | undefined;
     qawolfCommittedAt: string | undefined;
+    tags?: FetchedTags | undefined;
   },
   fs: Fs = makeDefaultFs(),
 ): Promise<Manifest> {
@@ -65,6 +75,10 @@ export async function buildManifest(
     flowPaths.map(async (rel) => ({
       path: rel,
       contentHash: await hashFile(join(args.bundleDir, rel), fs),
+      // The walk yields platform-specific separators; tag keys arrive as posix
+      // paths, so normalize before looking one up. Left unset when the fetch
+      // did not cover this file — unknown, not untagged.
+      tags: args.tags?.byPath.get(rel.split(sep).join("/")),
     })),
   );
 
@@ -76,6 +90,7 @@ export async function buildManifest(
     cliFlowsVersion: args.cliFlowsVersion,
     qawolfCommitSha: extractQawolfCommitSha(args.wrapperName),
     qawolfCommittedAt: args.qawolfCommittedAt,
+    tagsFetchedAt: args.tags?.fetchedAt.toISOString(),
     flows,
   };
 }

--- a/src/domains/flows/pull/bundle.ts
+++ b/src/domains/flows/pull/bundle.ts
@@ -1,4 +1,4 @@
-import { join, relative, sep } from "node:path";
+import { join, relative } from "node:path";
 
 import { hashFile } from "~/shell/manifest/io.js";
 import type { Manifest } from "~/shell/manifest/types.js";
@@ -46,6 +46,8 @@ function extractQawolfCommitSha(
   return /-([0-9a-f]{40})$/i.exec(wrapperName)?.[1];
 }
 
+const toPosix = (p: string): string => p.replaceAll("\\", "/");
+
 const flowExtensions = [".flow.ts", ".flow.js"];
 
 /**
@@ -66,19 +68,21 @@ export async function buildManifest(
     envVarsFetchedAt: Date | undefined;
     wrapperName: string | undefined;
     qawolfCommittedAt: string | undefined;
-    tags?: FetchedTags | undefined;
+    tags: FetchedTags | undefined;
   },
   fs: Fs = makeDefaultFs(),
 ): Promise<Manifest> {
   const flowPaths = await walkForFlows(args.bundleDir, fs);
   const flows = await Promise.all(
     flowPaths.map(async (rel) => ({
-      path: rel,
+      // Stored posix so a manifest written on one platform resolves on
+      // another. Every reader compares against this, so normalizing once
+      // here beats normalizing in each of them.
+      path: toPosix(rel),
       contentHash: await hashFile(join(args.bundleDir, rel), fs),
-      // The walk yields platform-specific separators; tag keys arrive as posix
-      // paths, so normalize before looking one up. Left unset when the fetch
-      // did not cover this file — unknown, not untagged.
-      tags: args.tags?.byPath.get(rel.split(sep).join("/")),
+      // Left unset when the fetch did not cover this file — unknown, not
+      // untagged.
+      tags: args.tags?.byPath.get(toPosix(rel)),
     })),
   );
 

--- a/src/domains/flows/pull/bundle.ts
+++ b/src/domains/flows/pull/bundle.ts
@@ -1,5 +1,7 @@
 import { join, relative } from "node:path";
 
+import { toPosix } from "~/core/repoRelativePath.js";
+
 import { hashFile } from "~/shell/manifest/io.js";
 import type { Manifest } from "~/shell/manifest/types.js";
 import { makeDefaultFs } from "~/shell/fs.js";
@@ -45,8 +47,6 @@ function extractQawolfCommitSha(
   if (!wrapperName) return undefined;
   return /-([0-9a-f]{40})$/i.exec(wrapperName)?.[1];
 }
-
-const toPosix = (p: string): string => p.replaceAll("\\", "/");
 
 const flowExtensions = [".flow.ts", ".flow.js"];
 

--- a/src/domains/flows/pull/bundleTags.test.ts
+++ b/src/domains/flows/pull/bundleTags.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
+import { readManifest } from "~/shell/manifest/io.js";
 import { buildManifest } from "./bundle.js";
+import { buildBundle } from "./pull.fixtures.js";
+import { stageBundle } from "./stage.js";
 
 let workDir = "";
 
@@ -31,6 +34,7 @@ const baseArgs = () => ({
   envVarsFetchedAt: undefined,
   wrapperName: undefined,
   qawolfCommittedAt: undefined,
+  tags: undefined,
 });
 
 const entryFor = (
@@ -92,5 +96,52 @@ describe("buildManifest tags", () => {
     expect(
       entryFor(manifest, join("src", "flows", "missing.flow.ts"))?.tags,
     ).toBeUndefined();
+  });
+});
+
+describe("stageBundle tag preservation", () => {
+  // A pull rebuilds the manifest from the bundle. Without carrying the
+  // previous tags forward, one failed tag fetch erases a good cache and every
+  // offline tag query silently stops working.
+  it("keeps the previous tags when the fetch failed", async () => {
+    const dest = join(workDir, "env");
+    const flows = [{ name: "src/flows/a.flow.ts", data: "// a" }];
+    const first = join(workDir, "first.tar.gz");
+    await buildBundle(first, { flows });
+
+    await stageBundle({
+      tmpArchive: first,
+      destAbs: dest,
+      assetsAbs: join(workDir, "assets"),
+      envId: "env-x",
+      cliFlowsVersion: "0.4.0",
+      now: new Date("2026-05-10T12:00:00.000Z"),
+      envVars: {},
+      envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: {
+        fetchedAt: new Date("2026-05-10T12:30:00.000Z"),
+        byPath: new Map([["src/flows/a.flow.ts", ["auth"]]]),
+      },
+    });
+
+    // Second pull, tag fetch failed.
+    const second = join(workDir, "second.tar.gz");
+    await buildBundle(second, { flows });
+    await stageBundle({
+      tmpArchive: second,
+      destAbs: dest,
+      assetsAbs: join(workDir, "assets"),
+      envId: "env-x",
+      cliFlowsVersion: "0.4.0",
+      now: new Date("2026-05-11T12:00:00.000Z"),
+      envVars: {},
+      envVarsFetchedAt: new Date("2026-05-11T12:00:00.000Z"),
+      tags: undefined,
+    });
+
+    const manifest = await readManifest(dest);
+    if (typeof manifest === "string") throw new Error(manifest);
+    expect(manifest.tagsFetchedAt).toBe("2026-05-10T12:30:00.000Z");
+    expect(manifest.flows[0]?.tags).toEqual(["auth"]);
   });
 });

--- a/src/domains/flows/pull/bundleTags.test.ts
+++ b/src/domains/flows/pull/bundleTags.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { buildManifest } from "./bundle.js";
+
+let workDir = "";
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "qawolf-bundle-tags-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function stage(names: string[]): Promise<void> {
+  for (const name of names) {
+    const p = join(workDir, name);
+    await mkdir(join(p, ".."), { recursive: true });
+    await writeFile(p, "// flow", "utf8");
+  }
+}
+
+const baseArgs = () => ({
+  envId: "env-x",
+  bundleDir: workDir,
+  cliFlowsVersion: "0.4.0",
+  now: new Date("2026-05-10T12:00:00.000Z"),
+  envVarsFetchedAt: undefined,
+  wrapperName: undefined,
+  qawolfCommittedAt: undefined,
+});
+
+const entryFor = (
+  manifest: Awaited<ReturnType<typeof buildManifest>>,
+  path: string,
+) => manifest.flows.find((f) => f.path === path);
+
+describe("buildManifest tags", () => {
+  it("leaves tags and tagsFetchedAt unset when no tags were fetched", async () => {
+    await stage(["src/flows/a.flow.ts"]);
+
+    const manifest = await buildManifest({ ...baseArgs(), tags: undefined });
+
+    expect(manifest.tagsFetchedAt).toBeUndefined();
+    expect(
+      entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags,
+    ).toBeUndefined();
+  });
+
+  it("records the fetched tags against each flow", async () => {
+    await stage(["src/flows/a.flow.ts", "src/flows/b.flow.ts"]);
+
+    const manifest = await buildManifest({
+      ...baseArgs(),
+      tags: {
+        fetchedAt: new Date("2026-05-10T12:30:00.000Z"),
+        byPath: new Map([
+          ["src/flows/a.flow.ts", ["auth"]],
+          ["src/flows/b.flow.ts", []],
+        ]),
+      },
+    });
+
+    expect(manifest.tagsFetchedAt).toBe("2026-05-10T12:30:00.000Z");
+    expect(entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags).toEqual(
+      ["auth"],
+    );
+    expect(entryFor(manifest, join("src", "flows", "b.flow.ts"))?.tags).toEqual(
+      [],
+    );
+  });
+
+  // A file in the bundle the tag fetch did not return has unknown tags. It must
+  // stay unset rather than defaulting to empty, which would claim it is untagged.
+  it("leaves a flow the fetch did not cover unset", async () => {
+    await stage(["src/flows/a.flow.ts", "src/flows/missing.flow.ts"]);
+
+    const manifest = await buildManifest({
+      ...baseArgs(),
+      tags: {
+        fetchedAt: new Date("2026-05-10T12:30:00.000Z"),
+        byPath: new Map([["src/flows/a.flow.ts", ["auth"]]]),
+      },
+    });
+
+    expect(entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags).toEqual(
+      ["auth"],
+    );
+    expect(
+      entryFor(manifest, join("src", "flows", "missing.flow.ts"))?.tags,
+    ).toBeUndefined();
+  });
+});

--- a/src/domains/flows/pull/bundleTags.test.ts
+++ b/src/domains/flows/pull/bundleTags.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { readManifest } from "~/shell/manifest/io.js";
+import { readManifest, writeManifest } from "~/shell/manifest/io.js";
 import { buildManifest } from "./bundle.js";
 import { buildBundle } from "./pull.fixtures.js";
 import { stageBundle } from "./stage.js";
@@ -142,6 +142,60 @@ describe("stageBundle tag preservation", () => {
     const manifest = await readManifest(dest);
     if (typeof manifest === "string") throw new Error(manifest);
     expect(manifest.tagsFetchedAt).toBe("2026-05-10T12:30:00.000Z");
+    expect(manifest.flows[0]?.tags).toEqual(["auth"]);
+  });
+
+  // A manifest written by an older CLI on win32 holds `\` paths. The rebuilt
+  // manifest looks entries up by posix path, so the carry must normalize or
+  // one failed fetch silently drops every tag while keeping tagsFetchedAt.
+  it("carries tags from a manifest that used backslash paths", async () => {
+    const dest = join(workDir, "env");
+    const flows = [{ name: "src/flows/a.flow.ts", data: "// a" }];
+    const first = join(workDir, "first.tar.gz");
+    await buildBundle(first, { flows });
+
+    await stageBundle({
+      tmpArchive: first,
+      destAbs: dest,
+      assetsAbs: join(workDir, "assets"),
+      envId: "env-x",
+      cliFlowsVersion: "0.4.0",
+      now: new Date("2026-05-10T12:00:00.000Z"),
+      envVars: {},
+      envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: {
+        fetchedAt: new Date("2026-05-10T12:30:00.000Z"),
+        byPath: new Map([["src/flows/a.flow.ts", ["auth"]]]),
+      },
+    });
+
+    const staged = await readManifest(dest);
+    if (typeof staged === "string") throw new Error(staged);
+    await writeManifest(dest, {
+      ...staged,
+      flows: staged.flows.map((flow) => ({
+        ...flow,
+        path: flow.path.replaceAll("/", "\\"),
+      })),
+    });
+
+    // Second pull, tag fetch failed.
+    const second = join(workDir, "second.tar.gz");
+    await buildBundle(second, { flows });
+    await stageBundle({
+      tmpArchive: second,
+      destAbs: dest,
+      assetsAbs: join(workDir, "assets"),
+      envId: "env-x",
+      cliFlowsVersion: "0.4.0",
+      now: new Date("2026-05-11T12:00:00.000Z"),
+      envVars: {},
+      envVarsFetchedAt: new Date("2026-05-11T12:00:00.000Z"),
+      tags: undefined,
+    });
+
+    const manifest = await readManifest(dest);
+    if (typeof manifest === "string") throw new Error(manifest);
     expect(manifest.flows[0]?.tags).toEqual(["auth"]);
   });
 });

--- a/src/domains/flows/pull/bundleTags.test.ts
+++ b/src/domains/flows/pull/bundleTags.test.ts
@@ -49,9 +49,7 @@ describe("buildManifest tags", () => {
     const manifest = await buildManifest({ ...baseArgs(), tags: undefined });
 
     expect(manifest.tagsFetchedAt).toBeUndefined();
-    expect(
-      entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags,
-    ).toBeUndefined();
+    expect(entryFor(manifest, "src/flows/a.flow.ts")?.tags).toBeUndefined();
   });
 
   it("records the fetched tags against each flow", async () => {
@@ -69,12 +67,8 @@ describe("buildManifest tags", () => {
     });
 
     expect(manifest.tagsFetchedAt).toBe("2026-05-10T12:30:00.000Z");
-    expect(entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags).toEqual(
-      ["auth"],
-    );
-    expect(entryFor(manifest, join("src", "flows", "b.flow.ts"))?.tags).toEqual(
-      [],
-    );
+    expect(entryFor(manifest, "src/flows/a.flow.ts")?.tags).toEqual(["auth"]);
+    expect(entryFor(manifest, "src/flows/b.flow.ts")?.tags).toEqual([]);
   });
 
   // A file in the bundle the tag fetch did not return has unknown tags. It must
@@ -90,11 +84,9 @@ describe("buildManifest tags", () => {
       },
     });
 
-    expect(entryFor(manifest, join("src", "flows", "a.flow.ts"))?.tags).toEqual(
-      ["auth"],
-    );
+    expect(entryFor(manifest, "src/flows/a.flow.ts")?.tags).toEqual(["auth"]);
     expect(
-      entryFor(manifest, join("src", "flows", "missing.flow.ts"))?.tags,
+      entryFor(manifest, "src/flows/missing.flow.ts")?.tags,
     ).toBeUndefined();
   });
 });

--- a/src/domains/flows/pull/fetchPhase.test.ts
+++ b/src/domains/flows/pull/fetchPhase.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+
+import type { AuthCommandContext } from "~/shell/commandContext.js";
+import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
+import { makeNoopLogger } from "~/shell/logger.testUtils.js";
+import { makeDefaultFs } from "~/shell/fs.js";
+import type { UI } from "~/shell/ui/index.js";
+import {
+  makeCallPublicApiMock,
+  makeMockPlatformClient,
+} from "~/shell/platform/createPlatformClient.testUtils.js";
+
+import { makeFakeUI } from "~/domains/runner/run.fixtures.js";
+import { fetchBundleAndEnvVars } from "./fetchPhase.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function makeUi(): UI {
+  const ui = makeFakeUI();
+  const withProgress = async (
+    steps: readonly {
+      task: (update: (message: string) => void) => Promise<unknown>;
+    }[],
+  ): Promise<unknown[]> => {
+    const results: unknown[] = [];
+    for (const step of steps) results.push(await step.task(() => undefined));
+    return results;
+  };
+  return {
+    ...ui,
+    mode: "json",
+    withProgress: withProgress as unknown as UI["withProgress"],
+  };
+}
+
+function makeCtx(callPublicApi: ReturnType<typeof makeCallPublicApiMock>) {
+  return {
+    ui: makeUi(),
+    configDir: "/tmp/test-config",
+    outputMode: "json",
+    isInteractive: false,
+    apiBaseUrl: "https://test.qawolf.com",
+    apiKeySource: "env",
+    signals: makeNoopSignals(),
+    log: () => makeNoopLogger(),
+    fs: makeDefaultFs(),
+    platformClient: makeMockPlatformClient({
+      downloadBundle: mock().mockResolvedValue({
+        ok: true,
+        value: { tmpArchive: "/tmp/bundle.tar.gz" },
+      }),
+      getEnvVars: mock().mockResolvedValue({ ok: true, value: {} }),
+      callPublicApi,
+    }),
+  } as unknown as AuthCommandContext;
+}
+
+const flowListOk = () =>
+  makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: {
+      flows: [
+        { flowId: "f1", path: "src/flows/a.flow.ts", tags: ["auth"] },
+        { flowId: "f2", path: "src/flows/b.flow.ts", tags: [] },
+      ],
+    },
+  });
+
+describe("fetchBundleAndEnvVars tags", () => {
+  it("fetches tags for the env including drafts", async () => {
+    const callPublicApi = flowListOk();
+
+    await fetchBundleAndEnvVars(makeCtx(callPublicApi), "env-1");
+
+    expect(callPublicApi).toHaveBeenCalledWith(publicContractsV1.flow.list, {
+      environmentId: "env-1",
+      includeDrafts: true,
+    });
+  });
+
+  it("returns the tags keyed by flow path", async () => {
+    const result = await fetchBundleAndEnvVars(makeCtx(flowListOk()), "env-1");
+
+    expect(result.tags?.byPath.get("src/flows/a.flow.ts")).toEqual(["auth"]);
+    expect(result.tags?.byPath.get("src/flows/b.flow.ts")).toEqual([]);
+    expect(result.tags?.fetchedAt).toBeInstanceOf(Date);
+  });
+
+  // Tags are an enhancement to the pull, never a precondition for it. A pull
+  // that cannot reach flow.list must still deliver the bundle.
+  it("still returns the bundle when the tag fetch fails", async () => {
+    const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+      ok: false,
+      error: "HTTP 500",
+    });
+
+    const result = await fetchBundleAndEnvVars(makeCtx(callPublicApi), "env-1");
+
+    expect(result.tmpArchive).toBe("/tmp/bundle.tar.gz");
+    expect(result.tags).toBeUndefined();
+  });
+
+  it("still returns the bundle when the tag fetch throws", async () => {
+    const callPublicApi = makeCallPublicApiMock().mockRejectedValue(
+      new Error("socket hang up"),
+    );
+
+    const result = await fetchBundleAndEnvVars(makeCtx(callPublicApi), "env-1");
+
+    expect(result.tmpArchive).toBe("/tmp/bundle.tar.gz");
+    expect(result.tags).toBeUndefined();
+  });
+});

--- a/src/domains/flows/pull/fetchPhase.test.ts
+++ b/src/domains/flows/pull/fetchPhase.test.ts
@@ -6,12 +6,12 @@ import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.j
 import { makeNoopLogger } from "~/shell/logger.testUtils.js";
 import { makeDefaultFs } from "~/shell/fs.js";
 import type { UI } from "~/shell/ui/index.js";
+import { makeFakeUI } from "~/shell/commandContext.testUtils.js";
 import {
   makeCallPublicApiMock,
   makeMockPlatformClient,
 } from "~/shell/platform/createPlatformClient.testUtils.js";
 
-import { makeFakeUI } from "~/domains/runner/run.fixtures.js";
 import { fetchBundleAndEnvVars } from "./fetchPhase.js";
 
 afterEach(() => {

--- a/src/domains/flows/pull/fetchPhase.ts
+++ b/src/domains/flows/pull/fetchPhase.ts
@@ -1,12 +1,40 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+
 import type { AuthCommandContext } from "~/shell/commandContext.js";
 import { flowsMessages } from "~/core/messages/index.js";
+
+import type { FetchedTags } from "./bundle.js";
 
 type FetchedBundle = {
   tmpArchive: string;
   bundleFetchedAt: Date;
   envVars: Record<string, string>;
   envVarsFetchedAt: Date;
+  // Undefined when the tag fetch did not succeed. Tags enrich a pull; they are
+  // never a precondition for one, so a failure here leaves the pull intact.
+  tags: FetchedTags | undefined;
 };
+
+// Drafts are included so the cache covers every flow the bundle can contain;
+// a flow missing from the response keeps unknown tags rather than empty ones.
+async function fetchTags(
+  ctx: AuthCommandContext,
+  envId: string,
+): Promise<FetchedTags | undefined> {
+  try {
+    const result = await ctx.platformClient.callPublicApi(
+      publicContractsV1.flow.list,
+      { environmentId: envId, includeDrafts: true },
+    );
+    if (!result.ok) return undefined;
+    return {
+      fetchedAt: new Date(),
+      byPath: new Map(result.value.flows.map((f) => [f.path, [...f.tags]])),
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 export async function fetchBundleAndEnvVars(
   ctx: AuthCommandContext,
@@ -17,6 +45,7 @@ export async function fetchBundleAndEnvVars(
   let bundleFetchedAt: Date | undefined;
   let envVars: Record<string, string> | undefined;
   let envVarsFetchedAt: Date | undefined;
+  let tags: FetchedTags | undefined;
 
   await ctx.ui.withProgress(
     [
@@ -38,6 +67,12 @@ export async function fetchBundleAndEnvVars(
           envVarsFetchedAt = new Date();
         },
       },
+      {
+        message: flowsMessages.pull.fetchingTags,
+        task: async () => {
+          tags = await fetchTags(ctx, envId);
+        },
+      },
     ],
     flowsMessages.pull.downloadComplete,
   );
@@ -53,5 +88,5 @@ export async function fetchBundleAndEnvVars(
         "This is a bug - please report it at https://github.com/qawolf/cli/issues",
     );
   }
-  return { tmpArchive, bundleFetchedAt, envVars, envVarsFetchedAt };
+  return { tmpArchive, bundleFetchedAt, envVars, envVarsFetchedAt, tags };
 }

--- a/src/domains/flows/pull/handler.ts
+++ b/src/domains/flows/pull/handler.ts
@@ -7,10 +7,10 @@ import {
   type AuthCommandContext,
   type CommandResult,
 } from "~/shell/commandContext.js";
-import { manifestFilename } from "~/shell/manifest/io.js";
 import { flowsMessages } from "~/core/messages/index.js";
 import { fetchBundleAndEnvVars } from "./fetchPhase.js";
 import { checkSafety, validateEnvId } from "./pull.js";
+import { reportPullResult } from "./reportPull.js";
 import { stageBundle } from "./stage.js";
 
 export type FlowsPullOptions = {
@@ -86,6 +86,7 @@ export async function handleFlowsPull(
                 now: fetched.bundleFetchedAt,
                 envVars: fetched.envVars,
                 envVarsFetchedAt: fetched.envVarsFetchedAt,
+                tags: fetched.tags,
               },
               resolvedDeps.fs,
             ),
@@ -122,24 +123,13 @@ export async function handleFlowsPull(
         ),
     );
 
-    if (ctx.ui.mode === "json") {
-      ctx.ui.output(
-        {
-          env: opts.env,
-          envDir: result.envDir,
-          assetsDir: assetsAbs,
-          fetchedAt: fetched.bundleFetchedAt.toISOString(),
-          flowCount: result.flowCount,
-          envVarCount: result.envVarCount,
-          flowsWithTeamStorageRefs: result.flowsWithTeamStorageRefs,
-          assetDownloadedCount: assetResult.downloadedCount,
-          assetReusedCount: assetResult.reusedCount,
-          assetSkippedCount: assetResult.skippedCount,
-          manifestPath: join(result.envDir, manifestFilename),
-        },
-        "",
-      );
-    }
+    reportPullResult(ctx.ui, {
+      env: opts.env,
+      assetsAbs,
+      fetchedAt: fetched.bundleFetchedAt,
+      stage: result,
+      assets: assetResult,
+    });
   } finally {
     if (archive !== undefined)
       await resolvedDeps.fs.unlink(archive).catch(() => {});

--- a/src/domains/flows/pull/pullSafety.test.ts
+++ b/src/domains/flows/pull/pullSafety.test.ts
@@ -35,6 +35,7 @@ describe("safety + staging integration", () => {
       cliFlowsVersion: "0.4.0",
       qawolfCommitSha: undefined,
       qawolfCommittedAt: undefined,
+      tagsFetchedAt: undefined,
       flows: [
         {
           path: "a.flow.ts",
@@ -66,6 +67,7 @@ describe("safety + staging integration", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: {},
       envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: undefined,
     });
 
     expect(await readFile(join(destDir, "a.flow.ts"), "utf8")).toBe("original");

--- a/src/domains/flows/pull/pullSafety.test.ts
+++ b/src/domains/flows/pull/pullSafety.test.ts
@@ -40,6 +40,7 @@ describe("safety + staging integration", () => {
         {
           path: "a.flow.ts",
           contentHash: await hashFile(join(destDir, "a.flow.ts")),
+          tags: undefined,
         },
       ],
     };

--- a/src/domains/flows/pull/reportPull.ts
+++ b/src/domains/flows/pull/reportPull.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+
+import { manifestFilename } from "~/shell/manifest/io.js";
+import type { UI } from "~/shell/ui/index.js";
+
+type StageResult = {
+  readonly envDir: string;
+  readonly flowCount: number;
+  readonly envVarCount: number;
+  readonly flowsWithTeamStorageRefs: string[];
+};
+
+type AssetResult = {
+  readonly downloadedCount: number;
+  readonly reusedCount: number;
+  readonly skippedCount: number;
+};
+
+/**
+ * Emits the machine-readable pull result. Human and agent modes already got
+ * the progress summary, so only JSON mode has anything left to say.
+ */
+export function reportPullResult(
+  ui: UI,
+  args: {
+    readonly env: string;
+    readonly assetsAbs: string;
+    readonly fetchedAt: Date;
+    readonly stage: StageResult;
+    readonly assets: AssetResult;
+  },
+): void {
+  if (ui.mode !== "json") return;
+  ui.output(
+    {
+      env: args.env,
+      envDir: args.stage.envDir,
+      assetsDir: args.assetsAbs,
+      fetchedAt: args.fetchedAt.toISOString(),
+      flowCount: args.stage.flowCount,
+      envVarCount: args.stage.envVarCount,
+      flowsWithTeamStorageRefs: args.stage.flowsWithTeamStorageRefs,
+      assetDownloadedCount: args.assets.downloadedCount,
+      assetReusedCount: args.assets.reusedCount,
+      assetSkippedCount: args.assets.skippedCount,
+      manifestPath: join(args.stage.envDir, manifestFilename),
+    },
+    "",
+  );
+}

--- a/src/domains/flows/pull/safety.test.ts
+++ b/src/domains/flows/pull/safety.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
 });
 
 const baseManifest = (
-  flows: { path: string; contentHash: string }[],
+  flows: { path: string; contentHash: string; tags: undefined }[],
 ): Manifest => ({
   envId: "env-abc",
   envSlug: undefined,
@@ -41,7 +41,7 @@ describe("detectLocalModifications", () => {
   it("returns [] when every file matches its manifest hash", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "hello", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     expect(await detectLocalModifications(workDir, manifest)).toEqual([]);
   });
@@ -49,7 +49,7 @@ describe("detectLocalModifications", () => {
   it("flags a file whose hash differs as 'modified'", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "edited", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     expect(await detectLocalModifications(workDir, manifest)).toEqual([
       { path: "a.flow.ts", reason: "modified" },
@@ -58,7 +58,7 @@ describe("detectLocalModifications", () => {
 
   it("flags a missing file as 'missing-from-disk'", async () => {
     const manifest = baseManifest([
-      { path: "gone.flow.ts", contentHash: helloHash },
+      { path: "gone.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     expect(await detectLocalModifications(workDir, manifest)).toEqual([
       { path: "gone.flow.ts", reason: "missing-from-disk" },
@@ -73,7 +73,7 @@ describe("detectLocalModifications", () => {
 
   it("rejects a manifest containing an absolute path entry", async () => {
     const manifest = baseManifest([
-      { path: "/etc/passwd", contentHash: helloHash },
+      { path: "/etc/passwd", contentHash: helloHash, tags: undefined },
     ]);
     let caught: unknown;
     try {
@@ -87,7 +87,7 @@ describe("detectLocalModifications", () => {
 
   it("rejects a manifest entry that escapes the env directory", async () => {
     const manifest = baseManifest([
-      { path: "../escape.flow.ts", contentHash: helloHash },
+      { path: "../escape.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     let caught: unknown;
     try {
@@ -120,7 +120,7 @@ describe("promptOverwriteIfModified", () => {
   it("proceeds without prompt when there are no modifications", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "hello", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     const confirm = makeFakeConfirm(false);
     const log = makeLog();
@@ -139,7 +139,7 @@ describe("promptOverwriteIfModified", () => {
 
   it("proceeds without prompt when only missing-from-disk entries exist", async () => {
     const manifest = baseManifest([
-      { path: "gone.flow.ts", contentHash: helloHash },
+      { path: "gone.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     const confirm = makeFakeConfirm(false);
     const log = makeLog();
@@ -159,7 +159,7 @@ describe("promptOverwriteIfModified", () => {
   it("proceeds without prompt and logs a notice when yes is true and mods exist", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "edited", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     const confirm = makeFakeConfirm(true);
     const log = makeLog();
@@ -181,7 +181,7 @@ describe("promptOverwriteIfModified", () => {
   it("prompts via confirm and proceeds when the user accepts", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "edited", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     const confirm = makeFakeConfirm(true);
     const log = makeLog();
@@ -202,7 +202,7 @@ describe("promptOverwriteIfModified", () => {
   it("aborts when the user declines the prompt", async () => {
     await writeFile(join(workDir, "a.flow.ts"), "edited", "utf8");
     const manifest = baseManifest([
-      { path: "a.flow.ts", contentHash: helloHash },
+      { path: "a.flow.ts", contentHash: helloHash, tags: undefined },
     ]);
     const confirm = makeFakeConfirm(false);
     const log = makeLog();

--- a/src/domains/flows/pull/safety.test.ts
+++ b/src/domains/flows/pull/safety.test.ts
@@ -29,6 +29,7 @@ const baseManifest = (
   cliFlowsVersion: "0.1.0",
   qawolfCommitSha: undefined,
   qawolfCommittedAt: undefined,
+  tagsFetchedAt: undefined,
   flows,
 });
 

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -58,9 +58,10 @@ describe("stageBundle", () => {
     if (manifest === "missing" || manifest === "malformed") {
       throw new Error("manifest should be present");
     }
+    // Manifest paths are written in posix form on every host.
     expect(manifest.flows.map((f) => f.path).sort()).toEqual([
       "checkout.flow.ts",
-      join("nested", "login.flow.ts"),
+      "nested/login.flow.ts",
     ]);
   });
 

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -41,6 +41,7 @@ describe("stageBundle", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: {},
       envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: undefined,
     });
 
     expect(result).toEqual({
@@ -78,6 +79,7 @@ describe("stageBundle", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: {},
       envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: undefined,
     });
 
     expect(result.flowCount).toBe(1);
@@ -103,6 +105,7 @@ describe("stageBundle", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: {},
       envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: undefined,
     });
 
     const manifest = await readManifest(destDir);
@@ -131,6 +134,7 @@ describe("stageBundle", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: { BASE_URL: "https://example.com", TOKEN: "abc" },
       envVarsFetchedAt: fetchedAt,
+      tags: undefined,
     });
 
     expect(result.envVarCount).toBe(3);
@@ -182,6 +186,7 @@ describe("stageBundle", () => {
       now: new Date("2026-05-10T12:00:00.000Z"),
       envVars: { TEAM_STORAGE_DIR: "/home/wolf/team-storage" },
       envVarsFetchedAt: new Date("2026-05-10T12:00:00.000Z"),
+      tags: undefined,
     });
 
     expect(stageResult.flowsWithTeamStorageRefs).toEqual([

--- a/src/domains/flows/pull/stage.ts
+++ b/src/domains/flows/pull/stage.ts
@@ -4,6 +4,7 @@ import {
   buildManifest,
   flattenSingleWrapper,
   sampleQawolfCommittedAt,
+  type FetchedTags,
 } from "./bundle.js";
 import { applyTeamStorageRewrite } from "./applyTeamStorageRewrite.js";
 import { writeEnvFile } from "./envVars.js";
@@ -23,6 +24,7 @@ type StageBundleArgs = {
   now: Date;
   envVars: Record<string, string>;
   envVarsFetchedAt: Date;
+  tags: FetchedTags | undefined;
 };
 
 type StageBundleResult = {
@@ -71,6 +73,7 @@ export async function stageBundle(
         envVarsFetchedAt: args.envVarsFetchedAt,
         wrapperName,
         qawolfCommittedAt,
+        tags: args.tags,
       },
       fs,
     );

--- a/src/domains/flows/pull/stage.ts
+++ b/src/domains/flows/pull/stage.ts
@@ -1,5 +1,5 @@
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
-import { writeManifest } from "~/shell/manifest/io.js";
+import { readManifest, writeManifest } from "~/shell/manifest/io.js";
 import {
   buildManifest,
   flattenSingleWrapper,
@@ -67,13 +67,13 @@ export async function stageBundle(
     const manifest = await buildManifest(
       {
         envId: args.envId,
+        tags: args.tags ?? (await carriedTags(args.destAbs, fs)),
         bundleDir: tmpDir,
         cliFlowsVersion: args.cliFlowsVersion,
         now: args.now,
         envVarsFetchedAt: args.envVarsFetchedAt,
         wrapperName,
         qawolfCommittedAt,
-        tags: args.tags,
       },
       fs,
     );
@@ -103,4 +103,26 @@ export async function stageBundle(
     await removeTempDir(tmpDir, registry, fs).catch(() => {});
     throw err;
   }
+}
+
+/**
+ * Tags kept from the previous pull of this environment.
+ *
+ * A pull rebuilds the manifest from the bundle, so a failed tag fetch would
+ * otherwise erase tags that were cached successfully earlier. Stale tags are
+ * reported as stale; losing them silently would break every offline query.
+ */
+async function carriedTags(
+  envDir: string,
+  fs: Fs,
+): Promise<FetchedTags | undefined> {
+  const previous = await readManifest(envDir, fs);
+  if (typeof previous === "string") return undefined;
+  if (previous.tagsFetchedAt === undefined) return undefined;
+
+  const byPath = new Map<string, string[]>();
+  for (const flow of previous.flows) {
+    if (flow.tags !== undefined) byPath.set(flow.path, [...flow.tags]);
+  }
+  return { fetchedAt: new Date(previous.tagsFetchedAt), byPath };
 }

--- a/src/domains/flows/pull/stage.ts
+++ b/src/domains/flows/pull/stage.ts
@@ -1,3 +1,4 @@
+import { toPosix } from "~/core/repoRelativePath.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import { readManifest, writeManifest } from "~/shell/manifest/io.js";
 import {
@@ -122,7 +123,10 @@ async function carriedTags(
 
   const byPath = new Map<string, string[]>();
   for (const flow of previous.flows) {
-    if (flow.tags !== undefined) byPath.set(flow.path, [...flow.tags]);
+    // A manifest written by an older CLI on win32 may hold `\` paths; the new
+    // manifest looks entries up by posix path, so normalize or the carried
+    // tags never match and vanish silently.
+    if (flow.tags !== undefined) byPath.set(toPosix(flow.path), [...flow.tags]);
   }
   return { fetchedAt: new Date(previous.tagsFetchedAt), byPath };
 }

--- a/src/domains/flows/readCachedTags.test.ts
+++ b/src/domains/flows/readCachedTags.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import type { Fs } from "~/shell/fs.js";
+import { manifestFilename } from "~/shell/manifest/io.js";
+import type { Manifest } from "~/shell/manifest/types.js";
+
+import { readCachedTags } from "./readCachedTags.js";
+
+const envDir = "/proj/.qawolf/staging";
+const flowA = `${envDir}/src/flows/a.flow.ts`;
+const flowB = `${envDir}/src/flows/b.flow.ts`;
+
+const manifest = (over: Partial<Manifest>): Manifest => ({
+  envId: "env-1",
+  envSlug: undefined,
+  fetchedAt: "2026-05-10T12:00:00.000Z",
+  envVarsFetchedAt: undefined,
+  cliFlowsVersion: "0.1.0",
+  qawolfCommitSha: undefined,
+  qawolfCommittedAt: undefined,
+  tagsFetchedAt: "2026-05-10T12:00:00.000Z",
+  flows: [],
+  ...over,
+});
+
+async function fsWith(m: Manifest): Promise<Fs> {
+  const fs = makeMemoryFs();
+  await fs.mkdir(envDir, { recursive: true });
+  await fs.writeFile(`${envDir}/${manifestFilename}`, JSON.stringify(m));
+  return fs;
+}
+
+describe("readCachedTags", () => {
+  it("returns nothing for flows outside a pulled env tree", async () => {
+    const fs = makeMemoryFs();
+    const result = await readCachedTags(["/proj/src/flows/a.flow.ts"], fs);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns the tags recorded for each flow", async () => {
+    const fs = await fsWith(
+      manifest({
+        flows: [
+          { path: "src/flows/a.flow.ts", contentHash: "h1", tags: ["auth"] },
+          { path: "src/flows/b.flow.ts", contentHash: "h2", tags: [] },
+        ],
+      }),
+    );
+
+    const result = await readCachedTags([flowA, flowB], fs);
+
+    expect(result.get(flowA)).toEqual(["auth"]);
+    expect(result.get(flowB)).toEqual([]);
+  });
+
+  // Without tagsFetchedAt the manifest predates tags entirely, so an empty
+  // entry means "never fetched", not "untagged".
+  it("returns nothing when the manifest never fetched tags", async () => {
+    const fs = await fsWith(
+      manifest({
+        tagsFetchedAt: undefined,
+        flows: [{ path: "src/flows/a.flow.ts", contentHash: "h1" }],
+      }),
+    );
+
+    const result = await readCachedTags([flowA], fs);
+
+    expect(result.size).toBe(0);
+  });
+
+  // A flow on disk the tag fetch did not return has unknown tags, which is
+  // not the same as being untagged.
+  it("omits a flow whose entry carries no tags", async () => {
+    const fs = await fsWith(
+      manifest({
+        flows: [
+          { path: "src/flows/a.flow.ts", contentHash: "h1", tags: ["auth"] },
+          { path: "src/flows/b.flow.ts", contentHash: "h2" },
+        ],
+      }),
+    );
+
+    const result = await readCachedTags([flowA, flowB], fs);
+
+    expect(result.has(flowA)).toBe(true);
+    expect(result.has(flowB)).toBe(false);
+  });
+
+  it("reads the manifest once no matter how many flows share the env", async () => {
+    const fs = await fsWith(
+      manifest({
+        flows: [
+          { path: "src/flows/a.flow.ts", contentHash: "h1", tags: ["auth"] },
+          { path: "src/flows/b.flow.ts", contentHash: "h2", tags: ["smoke"] },
+        ],
+      }),
+    );
+    let reads = 0;
+    const counting: Fs = {
+      ...fs,
+      readFile: (p: string) => {
+        reads += 1;
+        return fs.readFile(p);
+      },
+    };
+
+    await readCachedTags([flowA, flowB], counting);
+
+    expect(reads).toBe(1);
+  });
+});

--- a/src/domains/flows/readCachedTags.test.ts
+++ b/src/domains/flows/readCachedTags.test.ts
@@ -60,7 +60,9 @@ describe("readCachedTags", () => {
     const fs = await fsWith(
       manifest({
         tagsFetchedAt: undefined,
-        flows: [{ path: "src/flows/a.flow.ts", contentHash: "h1" }],
+        flows: [
+          { path: "src/flows/a.flow.ts", contentHash: "h1", tags: undefined },
+        ],
       }),
     );
 
@@ -76,7 +78,7 @@ describe("readCachedTags", () => {
       manifest({
         flows: [
           { path: "src/flows/a.flow.ts", contentHash: "h1", tags: ["auth"] },
-          { path: "src/flows/b.flow.ts", contentHash: "h2" },
+          { path: "src/flows/b.flow.ts", contentHash: "h2", tags: undefined },
         ],
       }),
     );

--- a/src/domains/flows/readCachedTags.test.ts
+++ b/src/domains/flows/readCachedTags.test.ts
@@ -109,4 +109,25 @@ describe("readCachedTags", () => {
 
     expect(reads).toBe(1);
   });
+
+  // A manifest written on Windows stores win32 separators. Splitting on the
+  // host separator would be a no-op here and the lookup would miss, so the
+  // flow's tags would wrongly read as unknown.
+  it("matches a manifest written with windows separators", async () => {
+    const fs = await fsWith(
+      manifest({
+        flows: [
+          {
+            path: "src\\flows\\a.flow.ts",
+            contentHash: "h1",
+            tags: ["auth"],
+          },
+        ],
+      }),
+    );
+
+    const result = await readCachedTags([flowA], fs);
+
+    expect(result.get(flowA)).toEqual(["auth"]);
+  });
 });

--- a/src/domains/flows/readCachedTags.ts
+++ b/src/domains/flows/readCachedTags.ts
@@ -1,4 +1,4 @@
-import { relative, sep } from "node:path";
+import { relative } from "node:path";
 
 import { findPulledEnvDir } from "~/core/repoRelativePath.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
@@ -33,9 +33,11 @@ export async function readCachedTags(
     // No fetch ever happened for this env, so every entry is unknown.
     if (manifest.tagsFetchedAt === undefined) continue;
 
-    // Manifest paths are compared on posix form: a manifest written on one
-    // platform must still resolve on another.
-    const toPosix = (p: string): string => p.split(sep).join("/");
+    // Manifest paths are compared on posix form so a manifest written on one
+    // platform resolves on another. Replace backslashes explicitly rather
+    // than splitting on the host separator: on posix that would be a no-op
+    // and a win32-written manifest would never match.
+    const toPosix = (p: string): string => p.replaceAll("\\", "/");
     const entryByPath = new Map(
       manifest.flows.map((f) => [toPosix(f.path), f]),
     );

--- a/src/domains/flows/readCachedTags.ts
+++ b/src/domains/flows/readCachedTags.ts
@@ -1,4 +1,4 @@
-import { relative } from "node:path";
+import { relative, sep } from "node:path";
 
 import { findPulledEnvDir } from "~/core/repoRelativePath.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
@@ -33,9 +33,14 @@ export async function readCachedTags(
     // No fetch ever happened for this env, so every entry is unknown.
     if (manifest.tagsFetchedAt === undefined) continue;
 
-    const entryByPath = new Map(manifest.flows.map((f) => [f.path, f]));
+    // Manifest paths are compared on posix form: a manifest written on one
+    // platform must still resolve on another.
+    const toPosix = (p: string): string => p.split(sep).join("/");
+    const entryByPath = new Map(
+      manifest.flows.map((f) => [toPosix(f.path), f]),
+    );
     for (const file of envFiles) {
-      const tags = entryByPath.get(relative(envDir, file))?.tags;
+      const tags = entryByPath.get(toPosix(relative(envDir, file)))?.tags;
       if (tags !== undefined) tagsByFile.set(file, tags);
     }
   }

--- a/src/domains/flows/readCachedTags.ts
+++ b/src/domains/flows/readCachedTags.ts
@@ -1,5 +1,7 @@
 import { relative } from "node:path";
 
+import { toPosix } from "~/core/repoRelativePath.js";
+
 import { findPulledEnvDir } from "~/core/repoRelativePath.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import { readManifest } from "~/shell/manifest/io.js";
@@ -33,11 +35,6 @@ export async function readCachedTags(
     // No fetch ever happened for this env, so every entry is unknown.
     if (manifest.tagsFetchedAt === undefined) continue;
 
-    // Manifest paths are compared on posix form so a manifest written on one
-    // platform resolves on another. Replace backslashes explicitly rather
-    // than splitting on the host separator: on posix that would be a no-op
-    // and a win32-written manifest would never match.
-    const toPosix = (p: string): string => p.replaceAll("\\", "/");
     const entryByPath = new Map(
       manifest.flows.map((f) => [toPosix(f.path), f]),
     );

--- a/src/domains/flows/readCachedTags.ts
+++ b/src/domains/flows/readCachedTags.ts
@@ -1,0 +1,43 @@
+import { relative } from "node:path";
+
+import { findPulledEnvDir } from "~/core/repoRelativePath.js";
+import { makeDefaultFs, type Fs } from "~/shell/fs.js";
+import { readManifest } from "~/shell/manifest/io.js";
+
+/**
+ * Reads the tags cached at pull time for each flow, keyed by absolute path.
+ *
+ * A flow is absent from the result whenever its tags are unknown — it was
+ * never pulled, its manifest predates tags, or the tag fetch did not cover it.
+ * Absence therefore means "unknown", never "untagged".
+ */
+export async function readCachedTags(
+  files: readonly string[],
+  fs: Fs = makeDefaultFs(),
+): Promise<Map<string, readonly string[]>> {
+  // Group by env dir so a listing of many flows reads each manifest once
+  // rather than once per flow.
+  const filesByEnvDir = new Map<string, string[]>();
+  for (const file of files) {
+    const envDir = findPulledEnvDir(file);
+    if (envDir === undefined) continue;
+    const group = filesByEnvDir.get(envDir);
+    if (group) group.push(file);
+    else filesByEnvDir.set(envDir, [file]);
+  }
+
+  const tagsByFile = new Map<string, readonly string[]>();
+  for (const [envDir, envFiles] of filesByEnvDir) {
+    const manifest = await readManifest(envDir, fs);
+    if (typeof manifest === "string") continue;
+    // No fetch ever happened for this env, so every entry is unknown.
+    if (manifest.tagsFetchedAt === undefined) continue;
+
+    const entryByPath = new Map(manifest.flows.map((f) => [f.path, f]));
+    for (const file of envFiles) {
+      const tags = entryByPath.get(relative(envDir, file))?.tags;
+      if (tags !== undefined) tagsByFile.set(file, tags);
+    }
+  }
+  return tagsByFile;
+}

--- a/src/domains/flows/renderListTable.test.ts
+++ b/src/domains/flows/renderListTable.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+
+import { renderListTable, type FlowsListRow } from "./renderListTable.js";
+
+const row = (over: Partial<FlowsListRow> = {}): FlowsListRow => ({
+  name: "Login",
+  target: "Web - Chrome",
+  file: "src/flows/login.flow.ts",
+  tags: undefined,
+  ...over,
+});
+
+const headerOf = (out: string): string => out.split("\n")[0] ?? "";
+
+describe("renderListTable", () => {
+  it("renders only name, target and file when there is nothing else to show", () => {
+    const out = renderListTable([row()], false);
+    expect(headerOf(out).split(/\s{2,}/)).toEqual(["name", "target", "file"]);
+  });
+
+  // Tagging is sparse, so most listings should not gain a tags column.
+  it("omits the tags column when no flow is tagged", () => {
+    const out = renderListTable(
+      [row({ tags: [] }), row({ tags: undefined })],
+      false,
+    );
+    expect(headerOf(out)).not.toContain("tags");
+  });
+
+  it("adds the tags column and joins tags when some flow is tagged", () => {
+    const out = renderListTable(
+      [row({ tags: ["auth", "smoke"] }), row({ tags: [] })],
+      false,
+    );
+    expect(headerOf(out)).toContain("tags");
+    expect(out).toContain("auth, smoke");
+  });
+
+  it("keeps file last when every column is shown", () => {
+    const out = renderListTable([row({ tags: ["auth"] })], false);
+    const header = headerOf(out);
+    expect(header.indexOf("tags")).toBeGreaterThan(header.indexOf("target"));
+    expect(header.indexOf("file")).toBeGreaterThan(header.indexOf("tags"));
+  });
+
+  it("bolds the header when asked", () => {
+    const out = renderListTable([row()], true);
+    expect(headerOf(out)).toStartWith("\x1b[1m");
+    expect(headerOf(out)).toEndWith("\x1b[0m");
+  });
+
+  it("pads columns so every row starts its target at the same column", () => {
+    const out = renderListTable(
+      [row({ name: "A" }), row({ name: "A much longer flow name" })],
+      false,
+    );
+    const [, short, long] = out.split("\n");
+    expect(short?.indexOf("Web - Chrome")).toBe(
+      long?.indexOf("Web - Chrome") ?? -1,
+    );
+    expect(short?.indexOf("Web - Chrome")).toBeGreaterThan(
+      "A much longer flow name".length,
+    );
+  });
+});

--- a/src/domains/flows/renderListTable.ts
+++ b/src/domains/flows/renderListTable.ts
@@ -4,17 +4,41 @@ export type FlowsListRow = {
   readonly name: string;
   readonly target: string;
   readonly file: string;
+  // Undefined when the caller cannot determine the tags, as opposed to a flow
+  // that is genuinely untagged.
+  readonly tags: readonly string[] | undefined;
 };
 
-const columns: readonly TableColumn<FlowsListRow>[] = [
-  { header: "name", value: (row) => row.name },
-  { header: "target", value: (row) => row.target },
-  { header: "file", value: (row) => row.file },
-];
+const nameColumn: TableColumn<FlowsListRow> = {
+  header: "name",
+  value: (row) => row.name,
+};
+const targetColumn: TableColumn<FlowsListRow> = {
+  header: "target",
+  value: (row) => row.target,
+};
+const tagsColumn: TableColumn<FlowsListRow> = {
+  header: "tags",
+  value: (row) => (row.tags ?? []).join(", "),
+};
+// Last, because it holds the widest cell.
+const fileColumn: TableColumn<FlowsListRow> = {
+  header: "file",
+  value: (row) => row.file,
+};
 
 export function renderListTable(
   rows: readonly FlowsListRow[],
   boldHeader: boolean,
 ): string {
+  // Tagging is sparse, and local flows that were never pulled have no tags to
+  // report at all, so the column only appears once some row can fill it.
+  const someTagged = rows.some((row) => (row.tags ?? []).length > 0);
+  const columns = [
+    nameColumn,
+    targetColumn,
+    ...(someTagged ? [tagsColumn] : []),
+    fileColumn,
+  ];
   return renderTable({ boldHeader, columns, rows });
 }

--- a/src/domains/runner/run.manifestStamp.test.ts
+++ b/src/domains/runner/run.manifestStamp.test.ts
@@ -33,7 +33,9 @@ const sampleManifest = (): Manifest => ({
   qawolfCommittedAt: undefined,
   tagsFetchedAt: undefined,
   envVarsFetchedAt: undefined,
-  flows: [{ path: "login.flow.ts", contentHash: "hash-login" }],
+  flows: [
+    { path: "login.flow.ts", contentHash: "hash-login", tags: undefined },
+  ],
 });
 
 describe("dispatchFlow manifest stamping", () => {

--- a/src/domains/runner/run.manifestStamp.test.ts
+++ b/src/domains/runner/run.manifestStamp.test.ts
@@ -31,6 +31,7 @@ const sampleManifest = (): Manifest => ({
   cliFlowsVersion: "0.1.0",
   qawolfCommitSha: undefined,
   qawolfCommittedAt: undefined,
+  tagsFetchedAt: undefined,
   envVarsFetchedAt: undefined,
   flows: [{ path: "login.flow.ts", contentHash: "hash-login" }],
 });

--- a/src/shell/manifest/io.test.ts
+++ b/src/shell/manifest/io.test.ts
@@ -24,7 +24,9 @@ const sample: Manifest = {
   qawolfCommittedAt: "2026-05-09T10:00:00.000Z",
   tagsFetchedAt: undefined,
   envVarsFetchedAt: "2026-05-10T12:30:00.000Z",
-  flows: [{ path: "src/checkout.flow.ts", contentHash: "deadbeef" }],
+  flows: [
+    { path: "src/checkout.flow.ts", contentHash: "deadbeef", tags: undefined },
+  ],
 };
 
 describe("readManifest", () => {
@@ -72,7 +74,13 @@ describe("readManifest", () => {
         envId: "env-abc",
         fetchedAt: "2026-05-10T12:00:00.000Z",
         cliFlowsVersion: "0.1.0",
-        flows: [{ path: "src/checkout.flow.ts", contentHash: "deadbeef" }],
+        flows: [
+          {
+            path: "src/checkout.flow.ts",
+            contentHash: "deadbeef",
+            tags: undefined,
+          },
+        ],
       }),
     );
 

--- a/src/shell/manifest/io.test.ts
+++ b/src/shell/manifest/io.test.ts
@@ -22,6 +22,7 @@ const sample: Manifest = {
   cliFlowsVersion: "0.1.0",
   qawolfCommitSha: "c67b5b6ff48766ca3cd72ceb4037e95c49633725",
   qawolfCommittedAt: "2026-05-09T10:00:00.000Z",
+  tagsFetchedAt: undefined,
   envVarsFetchedAt: "2026-05-10T12:30:00.000Z",
   flows: [{ path: "src/checkout.flow.ts", contentHash: "deadbeef" }],
 };
@@ -59,6 +60,49 @@ describe("readManifest", () => {
     const result = await readManifest(envDir, memFs);
     expect(result).toBe("malformed");
   });
+
+  // Manifests written before tags existed must keep parsing: a hard failure
+  // here would break `flows run` against any env pulled by an older CLI.
+  it("parses a manifest written before tags existed", async () => {
+    const memFs = makeMemoryFs();
+    await memFs.mkdir(envDir, { recursive: true });
+    await memFs.writeFile(
+      join(envDir, manifestFilename),
+      JSON.stringify({
+        envId: "env-abc",
+        fetchedAt: "2026-05-10T12:00:00.000Z",
+        cliFlowsVersion: "0.1.0",
+        flows: [{ path: "src/checkout.flow.ts", contentHash: "deadbeef" }],
+      }),
+    );
+
+    const result = await readManifest(envDir, memFs);
+    if (typeof result === "string")
+      throw new Error(`expected a manifest, got ${result}`);
+    expect(result.tagsFetchedAt).toBeUndefined();
+    expect(result.flows[0]?.tags).toBeUndefined();
+  });
+
+  it("round-trips tags and tagsFetchedAt", async () => {
+    const memFs = makeMemoryFs();
+    await memFs.mkdir(envDir, { recursive: true });
+    const tagged: Manifest = {
+      ...sample,
+      tagsFetchedAt: "2026-05-10T12:45:00.000Z",
+      flows: [
+        {
+          path: "src/checkout.flow.ts",
+          contentHash: "deadbeef",
+          tags: ["smoke", "auth"],
+        },
+        { path: "src/untagged.flow.ts", contentHash: "cafe", tags: [] },
+      ],
+    };
+
+    await writeManifest(envDir, tagged, memFs);
+
+    expect(await readManifest(envDir, memFs)).toEqual(tagged);
+  });
 });
 
 describe("writeManifest", () => {
@@ -81,6 +125,7 @@ describe("writeManifest", () => {
       cliFlowsVersion: "0.1.0",
       qawolfCommitSha: undefined,
       qawolfCommittedAt: undefined,
+      tagsFetchedAt: undefined,
       envVarsFetchedAt: undefined,
       flows: [],
     };

--- a/src/shell/manifest/io.ts
+++ b/src/shell/manifest/io.ts
@@ -12,6 +12,9 @@ export const manifestFilename = ".manifest.json";
 const flowEntrySchema = z.object({
   path: z.string(),
   contentHash: z.string(),
+  // Absent on manifests written before tags existed, and on flows the tag
+  // fetch did not return. Both optional so an older manifest still parses.
+  tags: z.array(z.string()).optional(),
 });
 
 const manifestSchema = z.object({
@@ -22,6 +25,7 @@ const manifestSchema = z.object({
   cliFlowsVersion: z.string(),
   qawolfCommitSha: z.string().optional(),
   qawolfCommittedAt: z.string().optional(),
+  tagsFetchedAt: z.string().optional(),
   flows: z.array(flowEntrySchema),
 });
 
@@ -59,6 +63,7 @@ export async function readManifest(
     cliFlowsVersion: result.data.cliFlowsVersion,
     qawolfCommitSha: result.data.qawolfCommitSha,
     qawolfCommittedAt: result.data.qawolfCommittedAt,
+    tagsFetchedAt: result.data.tagsFetchedAt,
     flows: result.data.flows,
   };
 }

--- a/src/shell/manifest/io.ts
+++ b/src/shell/manifest/io.ts
@@ -64,7 +64,11 @@ export async function readManifest(
     qawolfCommitSha: result.data.qawolfCommitSha,
     qawolfCommittedAt: result.data.qawolfCommittedAt,
     tagsFetchedAt: result.data.tagsFetchedAt,
-    flows: result.data.flows,
+    flows: result.data.flows.map((flow) => ({
+      path: flow.path,
+      contentHash: flow.contentHash,
+      tags: flow.tags,
+    })),
   };
 }
 

--- a/src/shell/manifest/lookup.test.ts
+++ b/src/shell/manifest/lookup.test.ts
@@ -43,8 +43,12 @@ const sampleManifest: Manifest = {
   tagsFetchedAt: undefined,
   envVarsFetchedAt: undefined,
   flows: [
-    { path: join("src", "login.flow.ts"), contentHash: "hash-login" },
-    { path: "checkout.flow.ts", contentHash: "hash-checkout" },
+    {
+      path: join("src", "login.flow.ts"),
+      contentHash: "hash-login",
+      tags: undefined,
+    },
+    { path: "checkout.flow.ts", contentHash: "hash-checkout", tags: undefined },
   ],
 };
 

--- a/src/shell/manifest/lookup.test.ts
+++ b/src/shell/manifest/lookup.test.ts
@@ -40,6 +40,7 @@ const sampleManifest: Manifest = {
   cliFlowsVersion: "0.1.0",
   qawolfCommitSha: undefined,
   qawolfCommittedAt: undefined,
+  tagsFetchedAt: undefined,
   envVarsFetchedAt: undefined,
   flows: [
     { path: join("src", "login.flow.ts"), contentHash: "hash-login" },

--- a/src/shell/manifest/lookup.ts
+++ b/src/shell/manifest/lookup.ts
@@ -1,24 +1,14 @@
-import { basename, dirname, relative } from "node:path";
+import { relative } from "node:path";
 
+import { findPulledEnvDir } from "~/core/repoRelativePath.js";
 import { readManifest } from "./io.js";
 import type { FlowStamp } from "./types.js";
 
 export async function findFlowStamp(
   flowAbsPath: string,
 ): Promise<FlowStamp | undefined> {
-  // Walk up from the flow file looking for an ancestor `<envDir>` whose own
-  // parent is `.qawolf`. If we never find one, the flow isn't under a pulled
-  // env tree and has no stamp.
-  let envDir: string | undefined;
-  let current = dirname(flowAbsPath);
-  while (current !== dirname(current)) {
-    const parent = dirname(current);
-    if (basename(parent) === ".qawolf") {
-      envDir = current;
-      break;
-    }
-    current = parent;
-  }
+  // No env dir means the flow isn't under a pulled env tree and has no stamp.
+  const envDir = findPulledEnvDir(flowAbsPath);
   if (!envDir) return undefined;
 
   const manifest = await readManifest(envDir);

--- a/src/shell/manifest/lookup.ts
+++ b/src/shell/manifest/lookup.ts
@@ -1,5 +1,7 @@
 import { relative } from "node:path";
 
+import { toPosix } from "~/core/repoRelativePath.js";
+
 import { findPulledEnvDir } from "~/core/repoRelativePath.js";
 import { readManifest } from "./io.js";
 import type { FlowStamp } from "./types.js";
@@ -14,8 +16,10 @@ export async function findFlowStamp(
   const manifest = await readManifest(envDir);
   if (typeof manifest === "string") return undefined;
 
-  const relPath = relative(envDir, flowAbsPath);
-  const entry = manifest.flows.find((f) => f.path === relPath);
+  // Manifests are written posix, but one written by an older CLI on win32
+  // holds native separators, so both sides are normalized before comparing.
+  const relPath = toPosix(relative(envDir, flowAbsPath));
+  const entry = manifest.flows.find((f) => toPosix(f.path) === relPath);
   if (!entry) return undefined;
 
   return {

--- a/src/shell/manifest/types.ts
+++ b/src/shell/manifest/types.ts
@@ -1,6 +1,10 @@
 type ManifestFlowEntry = {
   path: string;
   contentHash: string;
+  // Tags carried by the flow at the time of the pull. Optional because it is
+  // absent both on pre-tags manifests and on flows the tag fetch skipped —
+  // `Manifest.tagsFetchedAt` distinguishes those from a genuinely untagged flow.
+  tags?: string[] | undefined;
 };
 
 // Identifies a flow run against a pulled env: derived by walking the
@@ -34,5 +38,9 @@ export type Manifest = {
   // qawolfCommitSha undefined.
   qawolfCommitSha: string | undefined;
   qawolfCommittedAt: string | undefined;
+  // When the tag fetch last succeeded for this env. Undefined means tags were
+  // never fetched, so tag queries cannot be answered from this manifest at all
+  // — distinct from a fetch that succeeded and found no tags on a flow.
+  tagsFetchedAt: string | undefined;
   flows: ManifestFlowEntry[];
 };

--- a/src/shell/manifest/types.ts
+++ b/src/shell/manifest/types.ts
@@ -4,7 +4,7 @@ type ManifestFlowEntry = {
   // Tags carried by the flow at the time of the pull. Optional because it is
   // absent both on pre-tags manifests and on flows the tag fetch skipped —
   // `Manifest.tagsFetchedAt` distinguishes those from a genuinely untagged flow.
-  tags?: string[] | undefined;
+  tags: string[] | undefined;
 };
 
 // Identifies a flow run against a pulled env: derived by walking the


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

`flows list --remote` received tags from the API but did not show them. Local `flows list` always sent `tags: []`. That value was wrong. The CLI cannot know the tags of a flow it did not pull.

This change stores tags in the pull manifest and shows them in both lists.

- **`src/shell/manifest/types.ts`, `io.ts`**: add `tags` to each flow entry and `tagsFetchedAt` to the manifest. The `tags` field is required in the type, and its value can be undefined. Older manifests still parse.
- **`src/domains/flows/pull/fetchPhase.ts`**: get the tags with the bundle. If the request fails, the pull continues without new tags.
- **`src/domains/flows/pull/stage.ts`**: if the tag request fails, keep the tags from the last pull. A failed request does not erase them.
- **`src/domains/flows/pull/bundle.ts`**: write the tags to each entry. Write each path in posix form, so every reader gets one format. If the fetch did not include a flow, its tags stay unset.
- **`src/core/repoRelativePath.ts`**: new home for `toPosix` and the `.qawolf/<env>/` search. `lookup.ts` normalizes both sides of each comparison, so a manifest with `\` paths still matches.
- **`src/domains/flows/readCachedTags.ts`**: read cached tags. Read each manifest one time.
- **`src/domains/flows/renderListTable.ts`**: show the `tags` column only when a flow has tags.
- **`src/domains/flows/pull/reportPull.ts`**: new file. `handler.ts` was more than 150 lines.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- A manifest from an older CLI parses.
- If the tag request fails, the pull completes and keeps the old tags.
- A manifest with `\` paths still matches.
- Unset tags, empty tags and applied tags stay different.
- Live test: 10 flows pulled, all tags correct.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes — local `flows list --json` no longer sends `tags: []`. The key is absent when the tags are unknown.
