### PR TITLE
feat(flows): handle tags across several pulled environments

### DIFF
--- a/.changeset/run-tags-across-environments.md
+++ b/.changeset/run-tags-across-environments.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+`flows run --tag` and `flows list` now handle flows from more than one pulled environment. When a tag matches flows in several environments, an interactive run asks which environment to use, and `--all-envs` runs every match. The CLI warns when `--all-envs` has no effect: with `--env`, or without `--tag`.
+
+`flows list` shows the environment of each flow, and `flows list --env` filters to one pulled environment without a platform call. An unknown `--env` value lists the environments that are on disk.

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -213,6 +213,8 @@ Options:
   --tag <name>          Only run flows carrying this tag; repeat for several.
                         Without --env, matches against tags cached by the last
                         pull (default: [])
+  --all-envs            When a tag matches flows in several pulled environments,
+                        run every match instead of choosing one (default: false)
   -h, --help            display help for command
 
 Examples:
@@ -234,8 +236,8 @@ environment with --remote
 Options:
   --remote          List flows from the QA Wolf platform instead of the local
                     project (default: false)
-  --env <env>       Environment to list flows from (with --remote; defaults to
-                    QAWOLF_ENVIRONMENT, or an interactive picker)
+  --env <env>       Environment to list flows from: a QA Wolf environment with
+                    --remote, otherwise a pulled one by slug or id
   --include-drafts  Include draft flows in the listing (requires --remote)
                     (default: false)
   --tag <name>      Only list flows carrying this tag; repeat for several.
@@ -246,8 +248,9 @@ Options:
 Examples:
   $ qawolf flows list
   $ qawolf flows list "flows/checkout/**"
-  $ qawolf flows list --tag auth
   $ qawolf flows list --remote --env staging
+  $ qawolf flows list --tag auth
+  $ qawolf flows list --env staging --tag auth
   $ qawolf flows list --remote --env staging --tag auth --tag smoke
   $ qawolf flows list "**/checkout/**" --remote --env staging --include-drafts
 "

--- a/src/commands/flows/index.test.ts
+++ b/src/commands/flows/index.test.ts
@@ -53,17 +53,38 @@ describe("flows list flag combinations", () => {
     expect(output).toContain(flowsMessages.list.remoteRequiresEnv);
   });
 
-  it("rejects --env without --remote", async () => {
+  // --env without --remote names a pulled environment rather than a platform
+  // one, so it is answered from disk. This repo has nothing pulled.
+  it("accepts --env without --remote and answers it locally", async () => {
     const output = await runList(["--env", "staging"]);
 
-    expect(process.exitCode).toBe(1);
-    expect(output).toContain(flowsMessages.list.flagsRequireRemote);
+    expect(process.exitCode).toBe(2);
+    expect(output).toContain("No pulled environment named 'staging'");
   });
 
   it("rejects --include-drafts without --remote", async () => {
     const output = await runList(["--include-drafts"]);
 
     expect(process.exitCode).toBe(1);
-    expect(output).toContain(flowsMessages.list.flagsRequireRemote);
+    expect(output).toContain(flowsMessages.list.draftsRequireRemote);
+  });
+
+  // --tag works without --remote by reading the pull cache. This repo has no
+  // pulled env, so it reports that rather than silently matching nothing.
+  it("accepts --tag without --remote and reports when no tags are cached", async () => {
+    const output = await runList(["--tag", "auth"]);
+
+    expect(process.exitCode).toBe(4);
+    expect(output).toContain(flowsMessages.selectors.tagsNotCached);
+  });
+});
+
+describe("flows list --tag parsing", () => {
+  // A variadic --tag swallowed a following positional as another tag name,
+  // silently ignoring the pattern. Repeating the flag removes the ambiguity.
+  it("leaves a positional pattern alone when it follows --tag", async () => {
+    const output = await runList(["--tag", "auth", "src/flows/**"]);
+
+    expect(output).not.toContain("src/flows/**");
   });
 });

--- a/src/commands/flows/index.ts
+++ b/src/commands/flows/index.ts
@@ -6,7 +6,7 @@ import { flowsMessages } from "~/core/messages/index.js";
 import { collectValue } from "~/domains/runner/runFlagParsers.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
-import { handleFlowsList } from "~/domains/flows/list.js";
+import { handleFlowsList } from "~/domains/flows/listDefaults.js";
 import { flowsListRemote } from "~/domains/flows/listRemote.js";
 import { registerFlowsPullCommand } from "./pull.register.js";
 import { registerFlowsRunCommand } from "./run.register.js";
@@ -17,8 +17,9 @@ const listExamples = `
 Examples:
   $ qawolf flows list
   $ qawolf flows list "flows/checkout/**"
-  $ qawolf flows list --tag auth
   $ qawolf flows list --remote --env staging
+  $ qawolf flows list --tag auth
+  $ qawolf flows list --env staging --tag auth
   $ qawolf flows list --remote --env staging --tag auth --tag smoke
   $ qawolf flows list "**/checkout/**" --remote --env staging --include-drafts`;
 
@@ -53,7 +54,7 @@ export function registerFlowsCommand(
     )
     .option(
       "--env <env>",
-      "Environment to list flows from (with --remote; defaults to QAWOLF_ENVIRONMENT, or an interactive picker)",
+      "Environment to list flows from: a QA Wolf environment with --remote, otherwise a pulled one by slug or id",
     )
     .option(
       "--include-drafts",
@@ -73,6 +74,7 @@ export function registerFlowsCommand(
         opts: FlowsListOptions,
         command: Command,
       ) => {
+        const tags = opts.tag;
         if (opts.remote) {
           return withResolvedEnv(
             signals,
@@ -84,17 +86,21 @@ export function registerFlowsCommand(
               flowsListRemote(ctx, pattern, {
                 env,
                 includeDrafts: opts.includeDrafts,
-                tags: opts.tag,
+                tags,
               }),
           )(opts, command);
         }
-        if (opts.env !== undefined || opts.includeDrafts) {
+        // --include-drafts is a platform concept; --env is not, so without
+        // --remote it names a pulled environment and is answered from disk.
+        if (opts.includeDrafts) {
           return withContext(signals, async () => ({
-            error: flowsMessages.list.flagsRequireRemote,
+            error: flowsMessages.list.draftsRequireRemote,
           }))(opts, command);
         }
+        // Without --remote the tags come from the pull cache, so this works
+        // offline; it cannot validate names against the team's tag list.
         return withContext(signals, (ctx) =>
-          handleFlowsList(ctx, pattern, { tags: opts.tag }),
+          handleFlowsList(ctx, pattern, { tags, env: opts.env }),
         )(opts, command);
       },
     );

--- a/src/commands/flows/run.register.ts
+++ b/src/commands/flows/run.register.ts
@@ -1,17 +1,11 @@
 import type { Command } from "commander";
 
-import { withContext } from "~/commands/context.js";
 import { declareCommandKind } from "~/commands/commandKind.js";
-import { flowsMessages } from "~/core/messages/index.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { collectValue, parseInteger } from "~/domains/runner/runFlagParsers.js";
-import { findPulledEnv } from "~/shell/manifest/pulledEnv.js";
-import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
 
 import { addRunArtifactOptions } from "./runArtifactOptions.js";
-import { handleFlowsRun } from "./runDefaults.js";
-import { handleHybridFlowsRun } from "./hybridRunDefaults.js";
-import { withResolvedEnv } from "./withResolvedEnv.js";
+import { makeFlowsRunAction } from "./runAction.js";
 
 const runExamples = `
 Examples:
@@ -77,43 +71,11 @@ export function registerFlowsRunCommand(
       collectValue,
       [],
     )
+    .option(
+      "--all-envs",
+      "When a tag matches flows in several pulled environments, run every match instead of choosing one",
+      false,
+    )
     .addHelpText("after", runExamples)
-    .action(
-      (
-        pattern: string | undefined,
-        opts: FlowsRunFlags & { env?: string; tag: string[] },
-        command: Command,
-      ) => {
-        const selectors = { tags: opts.tag };
-        if (opts.env !== undefined) {
-          // Resolution turns an alias into the canonical id before the
-          // .qawolf/<env>/ cache lookup, so --env <alias> and --env <id>
-          // share one cache directory.
-          return withResolvedEnv(
-            signals,
-            {
-              explicit: opts.env,
-              requiredMessage: flowsMessages.run.requiresEnv,
-              // A run whose flows are already pulled does not need the
-              // platform, so an unreachable one should not stop it. The slug
-              // recorded at pull time means an alias resolves here too.
-              offlineFallback: async (explicit) =>
-                explicit === undefined
-                  ? undefined
-                  : (await findPulledEnv(explicit, process.cwd()))?.envId,
-            },
-            (ctx, env, identity) =>
-              handleHybridFlowsRun(
-                ctx,
-                pattern,
-                { ...opts, env },
-                { identity, selectors },
-              ),
-          )(opts, command);
-        }
-        return withContext(signals, (ctx) =>
-          handleFlowsRun(ctx, pattern, opts, undefined, selectors),
-        )(opts, command);
-      },
-    );
+    .action(makeFlowsRunAction(signals));
 }

--- a/src/commands/flows/runAction.ts
+++ b/src/commands/flows/runAction.ts
@@ -1,0 +1,73 @@
+import type { Command } from "commander";
+
+import { withContext } from "~/commands/context.js";
+import { allEnvsNoEffectWarning } from "~/domains/flows/allEnvsWarning.js";
+import { flowsMessages } from "~/core/messages/index.js";
+import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
+import { findPulledEnv } from "~/shell/manifest/pulledEnv.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { handleFlowsRun } from "./runDefaults.js";
+import { handleHybridFlowsRun } from "./hybridRunDefaults.js";
+import { withResolvedEnv } from "./withResolvedEnv.js";
+
+type Opts = FlowsRunFlags & {
+  env?: string;
+  tag: string[];
+  allEnvs?: boolean;
+};
+
+/** Dispatches `flows run` to the hybrid (--env) or the local handler. */
+export function makeFlowsRunAction(signals: SignalRegistry) {
+  return (
+    pattern: string | undefined,
+    opts: Opts,
+    command: Command,
+  ): Promise<void> => {
+    const selectors = { tags: opts.tag };
+    const allEnvsWarning = allEnvsNoEffectWarning({
+      allEnvs: opts.allEnvs ?? false,
+      env: opts.env,
+      tags: opts.tag,
+    });
+    if (opts.env !== undefined) {
+      // Resolution turns an alias into the canonical id before the
+      // .qawolf/<env>/ cache lookup, so --env <alias> and --env <id>
+      // share one cache directory.
+      return withResolvedEnv(
+        signals,
+        {
+          explicit: opts.env,
+          requiredMessage: flowsMessages.run.requiresEnv,
+          // A run whose flows are already pulled does not need the
+          // platform, so an unreachable one should not stop it. The slug
+          // recorded at pull time means an alias resolves here too.
+          offlineFallback: async (explicit) =>
+            explicit === undefined
+              ? undefined
+              : (await findPulledEnv(explicit, process.cwd()))?.envId,
+        },
+        (ctx, env, identity) => {
+          if (allEnvsWarning !== undefined) ctx.ui.warn(allEnvsWarning);
+          return handleHybridFlowsRun(
+            ctx,
+            pattern,
+            { ...opts, env },
+            { identity, selectors },
+          );
+        },
+      )(opts, command);
+    }
+    return withContext(signals, (ctx) => {
+      if (allEnvsWarning !== undefined) ctx.ui.warn(allEnvsWarning);
+      return handleFlowsRun(
+        ctx,
+        pattern,
+        opts,
+        undefined,
+        selectors,
+        opts.allEnvs,
+      );
+    })(opts, command);
+  };
+}

--- a/src/commands/flows/runDefaults.multiEnv.test.ts
+++ b/src/commands/flows/runDefaults.multiEnv.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { CommandContext } from "~/shell/commandContext.js";
+import { makeFakeUI } from "~/shell/commandContext.testUtils.js";
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import { makeNoopLogger } from "~/shell/logger.testUtils.js";
+import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
+import { manifestFilename } from "~/shell/manifest/io.js";
+import type { OutputMode } from "~/shell/ui/env.js";
+import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
+import { environmentsMessages } from "~/core/messages/index.js";
+
+import { handleFlowsRun, type HandleFlowsRunDeps } from "./runDefaults.js";
+
+const stagingFlow = "/proj/.qawolf/env-abc/src/flows/a.flow.ts";
+const prodFlow = "/proj/.qawolf/env-xyz/src/flows/b.flow.ts";
+
+const manifestFor = (envId: string, envSlug: string, path: string): string =>
+  JSON.stringify({
+    envId,
+    envSlug,
+    fetchedAt: "2026-09-01T12:00:00.000Z",
+    tagsFetchedAt: "2026-09-01T12:00:00.000Z",
+    cliFlowsVersion: "0.1.4",
+    flows: [{ path, contentHash: "h1", tags: ["auth"] }],
+  });
+
+async function makeCtx(
+  mode: OutputMode,
+  select?: CommandContext["ui"]["select"],
+): Promise<CommandContext> {
+  const fs = makeMemoryFs();
+  for (const [dir, envId, envSlug, path] of [
+    ["/proj/.qawolf/env-abc", "env-abc", "staging", "src/flows/a.flow.ts"],
+    ["/proj/.qawolf/env-xyz", "env-xyz", "prod", "src/flows/b.flow.ts"],
+  ] as const) {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      `${dir}/${manifestFilename}`,
+      manifestFor(envId, envSlug, path),
+    );
+  }
+  const ui = makeFakeUI(mode);
+  return {
+    configDir: "/mock/config",
+    apiBaseUrl: "https://app.qawolf.com",
+    outputMode: mode,
+    isInteractive: mode === "human",
+    signals: makeNoopSignals(),
+    fs,
+    log: () => makeNoopLogger(),
+    ui: select === undefined ? ui : { ...ui, select },
+  } as unknown as CommandContext;
+}
+
+const prepareRunDirMock = mock<HandleFlowsRunDeps["prepareRunDir"]>();
+
+function makeDeps(): HandleFlowsRunDeps {
+  prepareRunDirMock.mockClear();
+  prepareRunDirMock.mockImplementation(({ files }) =>
+    Promise.resolve({
+      files: [...files],
+      runDir: "/mock/run",
+      outerHop: { mode: "none" },
+      cleanup: async () => {},
+    }),
+  );
+  return {
+    expandPatterns: mock(() => Promise.resolve([stagingFlow, prodFlow])),
+    resolveDepsRoot: mock(() =>
+      Promise.resolve({
+        depsRoot: "/env",
+        source: "project" as const,
+        installed: false,
+      }),
+    ),
+    prepareRunDir: prepareRunDirMock,
+    configureTestkit: mock(() => Promise.resolve()),
+    flowsRun: mock(() => Promise.resolve(undefined)),
+    runWebFlowDeps: mock(() =>
+      Promise.resolve({}),
+    ) as unknown as HandleFlowsRunDeps["runWebFlowDeps"],
+    createFlowRuntimeDeps: mock(() => ({
+      fetchLatestEnvironmentVariables: async () => {},
+    })) as unknown as HandleFlowsRunDeps["createFlowRuntimeDeps"],
+  };
+}
+
+const flags: FlowsRunFlags = {
+  retries: 0,
+  bail: false,
+  workers: 1,
+  timeout: 30_000,
+  video: "off",
+  trace: "off",
+  har: "off",
+  harContent: "omit",
+  outputDir: "/tmp",
+  headed: false,
+  browserDeps: true,
+  allowNoMatch: false,
+};
+
+// A tag matching flows in two pulled environments is ambiguous: each env has
+// its own variables, so the copies are different runs, not duplicates.
+describe("handleFlowsRun across several pulled environments", () => {
+  it("runs every match when --all-envs is set", async () => {
+    const ctx = await makeCtx("json");
+
+    const result = await handleFlowsRun(
+      ctx,
+      undefined,
+      flags,
+      makeDeps(),
+      { tags: ["auth"] },
+      true,
+    );
+
+    expect(result).toBeUndefined();
+    expect(prepareRunDirMock).toHaveBeenCalledWith(
+      expect.objectContaining({ files: [stagingFlow, prodFlow] }),
+    );
+  });
+
+  it("errors with the environment labels when nobody can be asked", async () => {
+    const ctx = await makeCtx("json");
+    const deps = makeDeps();
+
+    const result = await handleFlowsRun(ctx, undefined, flags, deps, {
+      tags: ["auth"],
+    });
+
+    if (result === undefined) throw new Error("expected an error");
+    expect(result.error).toContain("staging");
+    expect(result.error).toContain("prod");
+    expect(result.exitCode).toBe(2);
+    expect(deps.flowsRun).not.toHaveBeenCalled();
+  });
+
+  it("aborts when the human cancels the environment prompt", async () => {
+    const ctx = await makeCtx("human");
+    const deps = makeDeps();
+
+    const result = await handleFlowsRun(ctx, undefined, flags, deps, {
+      tags: ["auth"],
+    });
+
+    expect(result).toBeUndefined();
+    expect(ctx.ui.info).toHaveBeenCalledWith(environmentsMessages.aborted);
+    expect(deps.flowsRun).not.toHaveBeenCalled();
+  });
+
+  it("runs only the chosen environment's flows", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "/proj/.qawolf/env-abc" }),
+    ) as unknown as CommandContext["ui"]["select"];
+    const ctx = await makeCtx("human", select);
+
+    const result = await handleFlowsRun(ctx, undefined, flags, makeDeps(), {
+      tags: ["auth"],
+    });
+
+    expect(result).toBeUndefined();
+    expect(prepareRunDirMock).toHaveBeenCalledWith(
+      expect.objectContaining({ files: [stagingFlow] }),
+    );
+  });
+});

--- a/src/commands/flows/runDefaults.ts
+++ b/src/commands/flows/runDefaults.ts
@@ -1,9 +1,12 @@
 import { buildPatternArgs } from "~/core/patternArgs.js";
 import type { FlowSelectors } from "~/core/flowSelectors.js";
-import { readCachedTags as defaultReadCachedTags } from "~/domains/flows/readCachedTags.js";
-import { runnerMessages } from "~/core/messages/index.js";
+import { environmentsMessages, runnerMessages } from "~/core/messages/index.js";
 import { pluralize } from "~/core/pluralize.js";
 import { expandPatterns as defaultExpandPatterns } from "~/domains/flows/expand.js";
+import { readCachedTags as defaultReadCachedTags } from "~/domains/flows/readCachedTags.js";
+import { readEnvLabel as defaultReadEnvLabel } from "~/domains/flows/readEnvLabel.js";
+import { resolveEnvChoice } from "~/domains/flows/resolveEnvChoice.js";
+import { exitCodes } from "~/shell/exit.js";
 import { flowsRun as defaultFlowsRun } from "~/domains/runner/run.js";
 import { noMatchResult } from "~/domains/runner/noMatch.js";
 import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
@@ -46,6 +49,7 @@ export async function handleFlowsRun(
   flags: FlowsRunFlags,
   deps?: HandleFlowsRunDeps,
   selectors: FlowSelectors = { tags: [] },
+  allEnvs = false,
 ): Promise<CommandResult> {
   const resolvedDeps = deps ?? makeDefaultDeps(ctx.fs);
   const cwd = process.cwd();
@@ -71,6 +75,7 @@ export async function handleFlowsRun(
     files: expandedFiles,
     selectors,
     readCachedTags: (files) => defaultReadCachedTags(files, ctx.fs),
+    chooseEnv: (files) => chooseEnv(ctx, files, allEnvs),
     noMatch: (error) =>
       noMatchResult(ctx, {
         allowNoMatch: flags.allowNoMatch,
@@ -86,4 +91,28 @@ export async function handleFlowsRun(
     flags,
     deps: resolvedDeps,
   });
+}
+
+/**
+ * Resolves which pulled environment a tag selection meant, prompting a human
+ * and reporting an error to everyone else.
+ */
+async function chooseEnv(
+  ctx: CommandContext,
+  files: string[],
+  allEnvs: boolean,
+): Promise<{ proceed: string[] } | { stop: CommandResult }> {
+  const choice = await resolveEnvChoice({
+    files,
+    allEnvs,
+    mode: ctx.ui.mode,
+    select: ctx.ui.select,
+    readLabel: (dir) => defaultReadEnvLabel(dir, ctx.fs),
+  });
+  if (choice.kind === "proceed") return { proceed: choice.files };
+  if (choice.kind === "cancelled") {
+    ctx.ui.info(environmentsMessages.aborted);
+    return { stop: undefined };
+  }
+  return { stop: { error: choice.error, exitCode: exitCodes.invalidArgs } };
 }

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -17,7 +17,7 @@ export const flowsMessages = {
   list: {
     remoteRequiresEnv:
       "--remote requires an environment. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
-    flagsRequireRemote: "--env and --include-drafts require --remote",
+    draftsRequireRemote: "--include-drafts requires --remote",
   },
   selectors: {
     tagsNotCached:
@@ -30,6 +30,28 @@ export const flowsMessages = {
       suggestion === undefined
         ? `No tag named '${name}' on this team. Run 'qawolf tag list' to see available tags.`
         : `No tag named '${name}' on this team. Did you mean '${suggestion}'?`,
+    unknownPulledEnv: (
+      name: string,
+      pulled: readonly string[],
+      suggestion: string | undefined,
+    ) => {
+      const known =
+        pulled.length === 0
+          ? "No environments have been pulled yet."
+          : `Pulled environments: ${pulled.join(", ")}.`;
+      const hint =
+        suggestion === undefined ? "" : ` Did you mean '${suggestion}'?`;
+      return `No pulled environment named '${name}'.${hint} ${known}`;
+    },
+    allEnvsWithEnv:
+      "--all-envs has no effect with --env: the run is already scoped to that environment.",
+    allEnvsWithoutTag:
+      "--all-envs has no effect without --tag: a pattern run already includes every environment.",
+    chooseEnv: "Which environment should these flows run against?",
+    ambiguousEnvs: (labels: readonly string[]) =>
+      `The selection matches flows in several pulled environments: ${labels.join(
+        ", ",
+      )}. Pass --env <name> to choose one, or --all-envs to run every match.`,
     noFlowsSelected: (selectors: {
       readonly tags: readonly string[];
     }): string => `No flows matched tags ${selectors.tags.join(", ")}.`,

--- a/src/domains/flows/allEnvsWarning.test.ts
+++ b/src/domains/flows/allEnvsWarning.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import { flowsMessages } from "~/core/messages/index.js";
+
+import { allEnvsNoEffectWarning } from "./allEnvsWarning.js";
+
+describe("allEnvsNoEffectWarning", () => {
+  it("is silent when --all-envs was not given", () => {
+    expect(
+      allEnvsNoEffectWarning({ allEnvs: false, env: "staging", tags: [] }),
+    ).toBeUndefined();
+  });
+
+  it("warns that --env already pins the run to one environment", () => {
+    expect(
+      allEnvsNoEffectWarning({ allEnvs: true, env: "staging", tags: ["auth"] }),
+    ).toBe(flowsMessages.selectors.allEnvsWithEnv);
+  });
+
+  it("warns that without --tag there is nothing to widen", () => {
+    expect(
+      allEnvsNoEffectWarning({ allEnvs: true, env: undefined, tags: [] }),
+    ).toBe(flowsMessages.selectors.allEnvsWithoutTag);
+  });
+
+  it("is silent when the flag has work to do", () => {
+    expect(
+      allEnvsNoEffectWarning({ allEnvs: true, env: undefined, tags: ["auth"] }),
+    ).toBeUndefined();
+  });
+});

--- a/src/domains/flows/allEnvsWarning.ts
+++ b/src/domains/flows/allEnvsWarning.ts
@@ -1,0 +1,19 @@
+import { flowsMessages } from "~/core/messages/index.js";
+
+/**
+ * The warning to show when --all-envs cannot affect the run, or undefined
+ * when the flag has work to do.
+ *
+ * With --env the run is already pinned to one environment; without --tag no
+ * selection can span several. Saying so beats silently ignoring the flag.
+ */
+export function allEnvsNoEffectWarning(args: {
+  readonly allEnvs: boolean;
+  readonly env: string | undefined;
+  readonly tags: readonly string[];
+}): string | undefined {
+  if (!args.allEnvs) return undefined;
+  if (args.env !== undefined) return flowsMessages.selectors.allEnvsWithEnv;
+  if (args.tags.length === 0) return flowsMessages.selectors.allEnvsWithoutTag;
+  return undefined;
+}

--- a/src/domains/flows/envLabels.ts
+++ b/src/domains/flows/envLabels.ts
@@ -1,0 +1,25 @@
+import { findPulledEnvDir } from "~/core/repoRelativePath.js";
+
+export function envLabelFor(
+  file: string,
+  labels: ReadonlyMap<string, string>,
+): string | undefined {
+  const dir = findPulledEnvDir(file);
+  return dir === undefined ? undefined : labels.get(dir);
+}
+
+/**
+ * Names the environment each flow was pulled from, resolving one label per
+ * environment rather than one per flow.
+ */
+export async function readEnvLabels(
+  files: readonly string[],
+  readEnvLabel: (envDir: string) => Promise<string>,
+): Promise<Map<string, string>> {
+  const dirs = new Set(
+    files.map(findPulledEnvDir).filter((dir) => dir !== undefined),
+  );
+  const labels = new Map<string, string>();
+  for (const dir of dirs) labels.set(dir, await readEnvLabel(dir));
+  return labels;
+}

--- a/src/domains/flows/list.agent.test.ts
+++ b/src/domains/flows/list.agent.test.ts
@@ -49,6 +49,15 @@ function makeDeps(overrides?: {
     readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
       Promise.resolve(new Map<string, readonly string[]>()),
     ),
+    readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+      Promise.resolve(dir),
+    ),
+    findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+      Promise.resolve([]),
+    ),
   };
 }
 

--- a/src/domains/flows/list.env.test.ts
+++ b/src/domains/flows/list.env.test.ts
@@ -1,0 +1,203 @@
+import { sep } from "node:path";
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import type { CommandContext } from "~/shell/commandContext.js";
+import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
+import type { OutputMode } from "~/shell/ui/env.js";
+import { makeNoopLogger } from "~/shell/logger.testUtils.js";
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+
+import { type FlowsListDeps, flowsList } from "./list.js";
+import { callsOf, makeFakeUI } from "~/shell/commandContext.testUtils.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+const cwd = "/proj";
+const projectFlow = "/proj/src/flows/checkout/login.flow.ts";
+
+function makeCtx(outputMode: OutputMode = "json"): CommandContext {
+  const ui = makeFakeUI();
+  return {
+    ui: { ...ui, mode: outputMode },
+    configDir: "/tmp/test-config",
+    outputMode,
+    isInteractive: false,
+    apiBaseUrl: "https://example.invalid",
+    signals: makeNoopSignals(),
+    log: () => makeNoopLogger(),
+    fs: makeMemoryFs(),
+  };
+}
+
+function makeDeps(
+  files: readonly string[],
+  tagsByFile: Record<string, readonly string[]> = {},
+): FlowsListDeps {
+  return {
+    cwd,
+    expandPatterns: mock<FlowsListDeps["expandPatterns"]>(() =>
+      Promise.resolve([...files]),
+    ),
+    peekFlowMeta: mock<FlowsListDeps["peekFlowMeta"]>(() =>
+      Promise.resolve({ name: undefined, target: undefined }),
+    ),
+    readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
+      Promise.resolve(new Map(Object.entries(tagsByFile))),
+    ),
+    readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+      Promise.resolve(dir),
+    ),
+    findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+      Promise.resolve([]),
+    ),
+  };
+}
+
+type Item = {
+  file: string;
+  group: string;
+  tags?: readonly string[];
+};
+
+const itemsFrom = (ui: CommandContext["ui"]): Item[] =>
+  (callsOf(ui.json)[0]?.[0] ?? []) as Item[];
+
+// `file` is built with node:path, so it carries win32 separators on Windows.
+// Compare on posix form rather than pinning one platform's spelling.
+const filesFrom = (ui: CommandContext["ui"]): string[] =>
+  itemsFrom(ui).map((i) => i.file.split(sep).join("/"));
+
+describe("flowsList env identity", () => {
+  const stagingFlow = "/proj/.qawolf/env-abc/src/flows/a.flow.ts";
+  const prodFlow = "/proj/.qawolf/env-xyz/src/flows/a.flow.ts";
+
+  function depsWithLabels(files: readonly string[]): FlowsListDeps {
+    return {
+      ...makeDeps(files),
+      readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+        Promise.resolve(dir.endsWith("env-abc") ? "staging" : "prod"),
+      ),
+    };
+  }
+
+  it("labels each flow with the environment it was pulled from", async () => {
+    const ctx = makeCtx();
+    await flowsList(ctx, undefined, depsWithLabels([stagingFlow, prodFlow]));
+
+    const items = itemsFrom(ctx.ui) as unknown as { env?: string }[];
+    expect(items.map((i) => i.env)).toEqual(["staging", "prod"]);
+  });
+
+  it("leaves env undefined for a flow outside any pulled env", async () => {
+    const ctx = makeCtx();
+    await flowsList(ctx, undefined, depsWithLabels([projectFlow]));
+
+    const items = itemsFrom(ctx.ui) as unknown as { env?: string }[];
+    expect(items[0]?.env).toBeUndefined();
+  });
+
+  // One read per environment, not one per flow.
+  it("reads each environment's label once", async () => {
+    const deps = depsWithLabels([stagingFlow, prodFlow, stagingFlow]);
+    await flowsList(makeCtx(), undefined, deps);
+
+    expect(deps.readEnvLabel).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("flowsList --env against a pulled environment", () => {
+  const stagingFlow = "/proj/.qawolf/env-abc/src/flows/a.flow.ts";
+  const prodFlow = "/proj/.qawolf/env-xyz/src/flows/b.flow.ts";
+
+  function envDeps(files: readonly string[]): FlowsListDeps {
+    return {
+      ...makeDeps(files),
+      readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+        Promise.resolve(dir.endsWith("env-abc") ? "staging" : "prod"),
+      ),
+      findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>((ref: string) =>
+        Promise.resolve(
+          ref === "staging" || ref === "env-abc"
+            ? { dir: "/proj/.qawolf/env-abc", envId: "env-abc" }
+            : undefined,
+        ),
+      ),
+      listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+        Promise.resolve(["/proj/.qawolf/env-abc", "/proj/.qawolf/env-xyz"]),
+      ),
+    };
+  }
+
+  it("keeps only flows from the named environment", async () => {
+    const ctx = makeCtx();
+    await flowsList(ctx, undefined, envDeps([stagingFlow, prodFlow]), {
+      tags: [],
+      env: "staging",
+    });
+
+    expect(filesFrom(ctx.ui)).toEqual([".qawolf/env-abc/src/flows/a.flow.ts"]);
+  });
+
+  it("accepts the canonical id as well as the slug", async () => {
+    const ctx = makeCtx();
+    await flowsList(ctx, undefined, envDeps([stagingFlow, prodFlow]), {
+      tags: [],
+      env: "env-abc",
+    });
+
+    expect(itemsFrom(ctx.ui)).toHaveLength(1);
+  });
+
+  // Purely local: an unknown name is answered from what is on disk, with no
+  // platform call, so the error lists what was actually pulled.
+  it("errors with the pulled environments when the name is unknown", async () => {
+    const result = await flowsList(
+      makeCtx(),
+      undefined,
+      envDeps([stagingFlow, prodFlow]),
+      { tags: [], env: "nope" },
+    );
+
+    if (result === undefined) throw new Error("expected an error");
+    expect(result.error).toContain("nope");
+    expect(result.error).toContain("staging");
+    expect(result.error).toContain("prod");
+    expect(result.exitCode).toBe(2);
+  });
+
+  // The pattern may match no pulled flows at all; the error must still name
+  // what is on disk instead of claiming nothing has been pulled.
+  it("lists the pulled environments even when the pattern matched none", async () => {
+    const result = await flowsList(makeCtx(), undefined, envDeps([]), {
+      tags: [],
+      env: "nope",
+    });
+
+    if (result === undefined) throw new Error("expected an error");
+    expect(result.error).toContain("staging");
+    expect(result.error).toContain("prod");
+    expect(result.error).not.toContain("No environments have been pulled");
+  });
+
+  it("combines with a tag selector", async () => {
+    const ctx = makeCtx();
+    const deps = {
+      ...envDeps([stagingFlow, prodFlow]),
+      readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
+        Promise.resolve(
+          new Map<string, readonly string[]>([[stagingFlow, ["auth"]]]),
+        ),
+      ),
+    };
+
+    await flowsList(ctx, undefined, deps, { tags: ["auth"], env: "staging" });
+
+    expect(itemsFrom(ctx.ui)).toHaveLength(1);
+  });
+});

--- a/src/domains/flows/list.json.test.ts
+++ b/src/domains/flows/list.json.test.ts
@@ -54,6 +54,15 @@ function makeDeps(overrides?: {
     readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
       Promise.resolve(new Map(Object.entries(cachedTags))),
     ),
+    readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+      Promise.resolve(dir),
+    ),
+    findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+      Promise.resolve([]),
+    ),
   };
 }
 

--- a/src/domains/flows/list.selectors.test.ts
+++ b/src/domains/flows/list.selectors.test.ts
@@ -48,11 +48,21 @@ function makeDeps(
     readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
       Promise.resolve(new Map(Object.entries(tagsByFile))),
     ),
+    readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+      Promise.resolve(dir),
+    ),
+    findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+      Promise.resolve([]),
+    ),
   };
 }
 
 type Item = {
   file: string;
+  group: string;
   tags?: readonly string[];
 };
 

--- a/src/domains/flows/list.test.ts
+++ b/src/domains/flows/list.test.ts
@@ -52,6 +52,15 @@ function makeDeps(overrides?: {
     readCachedTags: mock<FlowsListDeps["readCachedTags"]>(() =>
       Promise.resolve(new Map<string, readonly string[]>()),
     ),
+    readEnvLabel: mock<FlowsListDeps["readEnvLabel"]>((dir: string) =>
+      Promise.resolve(dir),
+    ),
+    findPulledEnv: mock<FlowsListDeps["findPulledEnv"]>(() =>
+      Promise.resolve(undefined),
+    ),
+    listPulledEnvDirs: mock<FlowsListDeps["listPulledEnvDirs"]>(() =>
+      Promise.resolve([]),
+    ),
   };
 }
 

--- a/src/domains/flows/list.ts
+++ b/src/domains/flows/list.ts
@@ -11,12 +11,9 @@ import {
   targetToBrowser,
   type PeekFlowMetaFn,
 } from "~/core/flowMeta.js";
-import {
-  expandPatterns as defaultExpandPatterns,
-  makePeekFlowMeta,
-} from "./expand.js";
+import { envLabelFor, readEnvLabels } from "./envLabels.js";
+import { selectPulledEnv } from "./selectPulledEnv.js";
 import { emptySelectionResult, tagsNotCachedResult } from "./selectorGuards.js";
-import { readCachedTags as defaultReadCachedTags } from "./readCachedTags.js";
 import { renderListTable } from "./renderListTable.js";
 
 export type FlowsListDeps = {
@@ -30,11 +27,22 @@ export type FlowsListDeps = {
   readonly readCachedTags: (
     files: readonly string[],
   ) => Promise<Map<string, readonly string[]>>;
+  /** Human label for a pulled env dir — its slug, name, or id. */
+  readonly readEnvLabel: (envDir: string) => Promise<string>;
+  /** Resolves an id, slug, or name to a pulled env, without the API. */
+  readonly findPulledEnv: (
+    ref: string,
+  ) => Promise<{ dir: string; envId: string } | undefined>;
+  /** Every pulled env dir on disk, for naming what --env could refer to. */
+  readonly listPulledEnvDirs: () => Promise<string[]>;
 };
 
 type FlowsListItem = {
   file: string;
   name: string;
+  // The pulled environment the flow came from. Undefined for project flows,
+  // which belong to no environment.
+  env: string | undefined;
   // Absent when the flow was never pulled, so its tags are unknown rather
   // than known to be empty.
   tags: readonly string[] | undefined;
@@ -46,11 +54,26 @@ export async function flowsList(
   ctx: CommandContext,
   pattern: string | undefined,
   deps: FlowsListDeps,
-  selectors: FlowSelectors = { tags: [] },
+  selectors: FlowSelectors & { env?: string | undefined } = { tags: [] },
 ): Promise<CommandResult> {
   const patterns = pattern ? [pattern] : [];
-  const files = await deps.expandPatterns(patterns, deps.cwd);
+  let files = await deps.expandPatterns(patterns, deps.cwd);
+
+  // --env without --remote names a pulled environment, so it is answered from
+  // disk: no auth, no network, and the error can list what is actually here.
+  if (selectors.env !== undefined) {
+    const selection = await selectPulledEnv({
+      files,
+      ref: selectors.env,
+      findPulledEnv: deps.findPulledEnv,
+      listPulledEnvDirs: deps.listPulledEnvDirs,
+      readEnvLabel: deps.readEnvLabel,
+    });
+    if (selection.kind === "unknown") return selection.result;
+    files = selection.files;
+  }
   const cachedTags = await deps.readCachedTags(files);
+  const envLabels = await readEnvLabels(files, deps.readEnvLabel);
 
   const notCached = tagsNotCachedResult(selectors, cachedTags);
   if (notCached !== undefined) return notCached;
@@ -64,6 +87,7 @@ export async function flowsList(
     all.push({
       file: path.relative(deps.cwd, file),
       name: meta.name ?? flowBasename(file),
+      env: envLabelFor(file, envLabels),
       tags: cachedTags.get(file),
       target: meta.target,
       browser: meta.target ? targetToBrowser(meta.target) : undefined,
@@ -86,6 +110,7 @@ export async function flowsList(
   const rows = items.map((it) => ({
     name: it.name,
     target: it.target ?? "",
+    env: it.env,
     tags: it.tags,
     file: it.file,
   }));
@@ -97,24 +122,4 @@ export async function flowsList(
   ctx.ui.intro(flowsMessages.title);
   ctx.ui.write(renderListTable(rows, true));
   ctx.ui.outro(flowsMessages.flowCount(items.length));
-}
-
-export function handleFlowsList(
-  ctx: CommandContext,
-  pattern: string | undefined,
-  selectors?: FlowSelectors,
-): Promise<CommandResult> {
-  const { fs } = ctx;
-  return flowsList(
-    ctx,
-    pattern,
-    {
-      cwd: process.cwd(),
-      expandPatterns: (patterns, cwd) =>
-        defaultExpandPatterns(patterns, cwd, undefined, fs),
-      peekFlowMeta: makePeekFlowMeta(fs),
-      readCachedTags: (files) => defaultReadCachedTags(files, fs),
-    },
-    selectors,
-  );
 }

--- a/src/domains/flows/listDefaults.ts
+++ b/src/domains/flows/listDefaults.ts
@@ -1,0 +1,37 @@
+import type { FlowSelectors } from "~/core/flowSelectors.js";
+import {
+  findPulledEnv as defaultFindPulledEnv,
+  listPulledEnvDirs as defaultListPulledEnvDirs,
+} from "~/shell/manifest/pulledEnv.js";
+import type { CommandContext, CommandResult } from "~/shell/commandContext.js";
+
+import {
+  expandPatterns as defaultExpandPatterns,
+  makePeekFlowMeta,
+} from "./expand.js";
+import { flowsList } from "./list.js";
+import { readCachedTags as defaultReadCachedTags } from "./readCachedTags.js";
+import { readEnvLabel as defaultReadEnvLabel } from "./readEnvLabel.js";
+
+export function handleFlowsList(
+  ctx: CommandContext,
+  pattern: string | undefined,
+  selectors?: FlowSelectors & { env?: string | undefined },
+): Promise<CommandResult> {
+  const { fs } = ctx;
+  return flowsList(
+    ctx,
+    pattern,
+    {
+      cwd: process.cwd(),
+      expandPatterns: (patterns, cwd) =>
+        defaultExpandPatterns(patterns, cwd, undefined, fs),
+      peekFlowMeta: makePeekFlowMeta(fs),
+      readCachedTags: (files) => defaultReadCachedTags(files, fs),
+      readEnvLabel: (envDir) => defaultReadEnvLabel(envDir, fs),
+      findPulledEnv: (ref) => defaultFindPulledEnv(ref, process.cwd(), fs),
+      listPulledEnvDirs: () => defaultListPulledEnvDirs(process.cwd(), fs),
+    },
+    selectors,
+  );
+}

--- a/src/domains/flows/listRemote.ts
+++ b/src/domains/flows/listRemote.ts
@@ -78,6 +78,9 @@ export async function flowsListRemote(
   const rows = items.map((it) => ({
     name: it.name,
     target: it.target,
+    // A remote listing is scoped to one environment by definition, so the env
+    // column would repeat the --env value on every row.
+    env: undefined,
     tags: it.tags,
     file: it.file,
   }));

--- a/src/domains/flows/renderListTable.test.ts
+++ b/src/domains/flows/renderListTable.test.ts
@@ -6,6 +6,7 @@ const row = (over: Partial<FlowsListRow> = {}): FlowsListRow => ({
   name: "Login",
   target: "Web - Chrome",
   file: "src/flows/login.flow.ts",
+  env: undefined,
   tags: undefined,
   ...over,
 });
@@ -61,5 +62,74 @@ describe("renderListTable", () => {
     expect(short?.indexOf("Web - Chrome")).toBeGreaterThan(
       "A much longer flow name".length,
     );
+  });
+});
+
+describe("renderListTable env column", () => {
+  // One pulled env puts the same value on every row, which tells you nothing.
+  it("omits the env column when every flow is from one environment", () => {
+    const out = renderListTable(
+      [row({ env: "staging" }), row({ env: "staging" })],
+      false,
+    );
+    expect(headerOf(out)).not.toContain("env");
+  });
+
+  it("omits the env column when no flow is from a pulled environment", () => {
+    const out = renderListTable([row(), row()], false);
+    expect(headerOf(out)).not.toContain("env");
+  });
+
+  // The same flow pulled into two environments is otherwise distinguishable
+  // only by the opaque id buried in its path.
+  it("adds the env column when flows span two environments", () => {
+    const out = renderListTable(
+      [row({ env: "staging" }), row({ env: "debugging-beats" })],
+      false,
+    );
+    expect(headerOf(out)).toContain("env");
+    expect(out).toContain("staging");
+    expect(out).toContain("debugging-beats");
+  });
+
+  it("leaves the cell blank for a flow outside any pulled environment", () => {
+    const out = renderListTable(
+      [
+        row({ name: "Pulled", env: "staging" }),
+        row({ name: "Other", env: "prod" }),
+        row({ name: "Local", env: undefined }),
+      ],
+      false,
+    );
+
+    const header = headerOf(out);
+    const envStart = header.indexOf("env");
+    const envWidth = header.slice(envStart).indexOf("file");
+    const localRow = out.split("\n").find((l) => l.startsWith("Local")) ?? "";
+    // The cell must be empty, not some other environment's name.
+    expect(localRow.slice(envStart, envStart + envWidth).trim()).toBe("");
+  });
+
+  it("places env between target and tags", () => {
+    const out = renderListTable(
+      [
+        row({ env: "staging", tags: ["auth"] }),
+        row({ env: "prod", tags: ["auth"] }),
+      ],
+      false,
+    );
+    const header = headerOf(out);
+    expect(header.indexOf("env")).toBeGreaterThan(header.indexOf("target"));
+    expect(header.indexOf("tags")).toBeGreaterThan(header.indexOf("env"));
+  });
+
+  // A project flow is its own source: without the column you cannot tell it
+  // from a pulled row.
+  it("adds the env column when local rows mix with one pulled environment", () => {
+    const out = renderListTable(
+      [row({ env: "staging" }), row({ env: undefined })],
+      false,
+    );
+    expect(headerOf(out)).toContain("env");
   });
 });

--- a/src/domains/flows/renderListTable.ts
+++ b/src/domains/flows/renderListTable.ts
@@ -4,6 +4,8 @@ export type FlowsListRow = {
   readonly name: string;
   readonly target: string;
   readonly file: string;
+  // The pulled environment a flow came from, undefined for project flows.
+  readonly env: string | undefined;
   // Undefined when the caller cannot determine the tags, as opposed to a flow
   // that is genuinely untagged.
   readonly tags: readonly string[] | undefined;
@@ -16,6 +18,10 @@ const nameColumn: TableColumn<FlowsListRow> = {
 const targetColumn: TableColumn<FlowsListRow> = {
   header: "target",
   value: (row) => row.target,
+};
+const envColumn: TableColumn<FlowsListRow> = {
+  header: "env",
+  value: (row) => row.env ?? "",
 };
 const tagsColumn: TableColumn<FlowsListRow> = {
   header: "tags",
@@ -34,9 +40,14 @@ export function renderListTable(
   // Tagging is sparse, and local flows that were never pulled have no tags to
   // report at all, so the column only appears once some row can fill it.
   const someTagged = rows.some((row) => (row.tags ?? []).length > 0);
+  // One source puts the same value on every row; the column only earns its
+  // place when it tells rows apart. A project flow counts as its own source,
+  // so a listing mixing local and pulled rows still shows it.
+  const severalEnvs = new Set(rows.map((row) => row.env)).size > 1;
   const columns = [
     nameColumn,
     targetColumn,
+    ...(severalEnvs ? [envColumn] : []),
     ...(someTagged ? [tagsColumn] : []),
     fileColumn,
   ];

--- a/src/domains/flows/resolveEnvChoice.test.ts
+++ b/src/domains/flows/resolveEnvChoice.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import { resolveEnvChoice } from "./resolveEnvChoice.js";
+
+const a1 = "/proj/.qawolf/env-abc/src/flows/login.flow.ts";
+const a2 = "/proj/.qawolf/env-abc/src/flows/signup.flow.ts";
+const b1 = "/proj/.qawolf/env-xyz/src/flows/login.flow.ts";
+const project = "/proj/src/flows/local.flow.ts";
+
+const labels: Record<string, string> = {
+  "/proj/.qawolf/env-abc": "staging",
+  "/proj/.qawolf/env-xyz": "prod",
+};
+
+function makeArgs(over: Partial<Parameters<typeof resolveEnvChoice>[0]> = {}) {
+  return {
+    files: [a1, b1],
+    allEnvs: false,
+    mode: "json" as const,
+    select: mock(() => Promise.resolve({ ok: true as const, value: "" })),
+    readLabel: mock((dir: string) => Promise.resolve(labels[dir] ?? dir)),
+    ...over,
+  };
+}
+
+describe("resolveEnvChoice when there is no ambiguity", () => {
+  it("proceeds when every match is in one pulled env", async () => {
+    const result = await resolveEnvChoice(makeArgs({ files: [a1, a2] }));
+
+    expect(result).toEqual({ kind: "proceed", files: [a1, a2] });
+  });
+
+  it("proceeds for project flows outside any pulled env", async () => {
+    const result = await resolveEnvChoice(makeArgs({ files: [project] }));
+
+    expect(result).toEqual({ kind: "proceed", files: [project] });
+  });
+
+  it("does not prompt when there is nothing to choose", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "" }),
+    );
+    await resolveEnvChoice(
+      makeArgs({ files: [a1, a2], mode: "human", select }),
+    );
+
+    expect(select).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveEnvChoice when matches span several envs", () => {
+  // Agents cannot answer a prompt, so the ambiguity has to arrive as an error
+  // naming the same choices a human would be offered.
+  it("errors in json mode, naming each environment", async () => {
+    const result = await resolveEnvChoice(makeArgs({ mode: "json" }));
+
+    if (result.kind !== "error") throw new Error("expected an error");
+    expect(result.error).toContain("staging");
+    expect(result.error).toContain("prod");
+    expect(result.error).toContain("--env");
+    expect(result.error).toContain("--all-envs");
+  });
+
+  it("errors in agent mode too", async () => {
+    const result = await resolveEnvChoice(makeArgs({ mode: "agent" }));
+
+    expect(result.kind).toBe("error");
+  });
+
+  it("prompts a human with each environment plus an all option", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "/proj/.qawolf/env-xyz" }),
+    );
+
+    const result = await resolveEnvChoice(makeArgs({ mode: "human", select }));
+
+    const options = (select.mock.calls[0] as unknown[] | undefined)?.[1] as
+      | { value: string; label: string }[]
+      | undefined;
+    expect(options?.map((o) => o.label)).toEqual(["staging", "prod", "All"]);
+    expect(result).toEqual({ kind: "proceed", files: [b1] });
+  });
+
+  it("runs every match when the human picks all", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "all" }),
+    );
+
+    const result = await resolveEnvChoice(makeArgs({ mode: "human", select }));
+
+    expect(result).toEqual({ kind: "proceed", files: [a1, b1] });
+  });
+
+  it("is cancelled when the human dismisses the prompt", async () => {
+    const select = mock(() => Promise.resolve({ ok: false as const }));
+
+    const result = await resolveEnvChoice(makeArgs({ mode: "human", select }));
+
+    expect(result).toEqual({ kind: "cancelled" });
+  });
+
+  // --all-envs is the non-interactive equivalent of picking All.
+  it("skips the question entirely when --all-envs is set", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "" }),
+    );
+
+    const result = await resolveEnvChoice(
+      makeArgs({ allEnvs: true, mode: "human", select }),
+    );
+
+    expect(select).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: "proceed", files: [a1, b1] });
+  });
+
+  // A project flow belongs to no environment, so it was never part of the
+  // ambiguity and must survive the choice.
+  it("keeps project flows when one environment is chosen", async () => {
+    const select = mock(() =>
+      Promise.resolve({ ok: true as const, value: "/proj/.qawolf/env-xyz" }),
+    );
+
+    const result = await resolveEnvChoice(
+      makeArgs({ files: [a1, b1, project], mode: "human", select }),
+    );
+
+    expect(result).toEqual({ kind: "proceed", files: [project, b1] });
+  });
+});

--- a/src/domains/flows/resolveEnvChoice.ts
+++ b/src/domains/flows/resolveEnvChoice.ts
@@ -1,0 +1,73 @@
+import { findPulledEnvDir } from "~/core/repoRelativePath.js";
+import { flowsMessages } from "~/core/messages/index.js";
+import type { OutputMode } from "~/shell/ui/env.js";
+import type { SelectFn } from "~/shell/ui/renderers/select.js";
+
+/** Sentinel for the "every environment" option, which is not an env dir. */
+const allValue = "all";
+
+export type EnvChoice =
+  | { kind: "proceed"; files: string[] }
+  | { kind: "error"; error: string }
+  | { kind: "cancelled" };
+
+type Args = {
+  readonly files: readonly string[];
+  /** Set by --all-envs: the non-interactive equivalent of choosing All. */
+  readonly allEnvs: boolean;
+  readonly mode: OutputMode;
+  readonly select: SelectFn;
+  /** Human label for a pulled env dir — its slug, name, or id. */
+  readonly readLabel: (envDir: string) => Promise<string>;
+};
+
+/**
+ * Decides which environment's copies to act on when a selection matches flows
+ * in more than one pulled environment.
+ *
+ * Each env has its own variables, so the copies are different runs of the same
+ * file rather than duplicates. Choosing silently would be a guess, so a human
+ * is asked and everyone else gets the same choices as an error.
+ */
+export async function resolveEnvChoice(args: Args): Promise<EnvChoice> {
+  const byEnv = new Map<string, string[]>();
+  for (const file of args.files) {
+    // Project flows share one bucket: they belong to no pulled env, so they
+    // never make a selection ambiguous.
+    const key = findPulledEnvDir(file) ?? "";
+    const group = byEnv.get(key);
+    if (group) group.push(file);
+    else byEnv.set(key, [file]);
+  }
+
+  const envDirs = [...byEnv.keys()].filter((key) => key !== "");
+  if (envDirs.length <= 1 || args.allEnvs) {
+    return { kind: "proceed", files: [...args.files] };
+  }
+
+  const labels = await Promise.all(
+    envDirs.map(async (dir) => ({ dir, label: await args.readLabel(dir) })),
+  );
+
+  if (args.mode !== "human") {
+    return {
+      kind: "error",
+      error: flowsMessages.selectors.ambiguousEnvs(labels.map((l) => l.label)),
+    };
+  }
+
+  const picked = await args.select(flowsMessages.selectors.chooseEnv, [
+    ...labels.map(({ dir, label }) => ({ value: dir, label })),
+    { value: allValue, label: "All" },
+  ]);
+  if (!picked.ok) return { kind: "cancelled" };
+  if (picked.value === allValue) {
+    return { kind: "proceed", files: [...args.files] };
+  }
+  // Project flows belong to no environment, so choosing one must not drop
+  // them: they were never part of the ambiguity.
+  return {
+    kind: "proceed",
+    files: [...(byEnv.get("") ?? []), ...(byEnv.get(picked.value) ?? [])],
+  };
+}

--- a/src/domains/flows/selectPulledEnv.ts
+++ b/src/domains/flows/selectPulledEnv.ts
@@ -1,0 +1,52 @@
+import { findPulledEnvDir } from "~/core/repoRelativePath.js";
+import { flowsMessages } from "~/core/messages/index.js";
+import { suggestNearMiss } from "~/core/suggestNearMiss.js";
+import type { CommandResult } from "~/shell/commandContext.js";
+import { exitCodes } from "~/shell/exit.js";
+
+export type PulledEnvSelection =
+  | { kind: "selected"; files: string[] }
+  | { kind: "unknown"; result: CommandResult };
+
+/**
+ * Narrows a listing to one pulled environment, named by id, slug, or name.
+ *
+ * Answered entirely from disk: `--env` without `--remote` refers to something
+ * already pulled, so it needs no auth and the error can name what is here.
+ */
+export async function selectPulledEnv(args: {
+  readonly files: readonly string[];
+  readonly ref: string;
+  readonly findPulledEnv: (
+    ref: string,
+  ) => Promise<{ dir: string; envId: string } | undefined>;
+  /** Every pulled env dir on disk, not just those the pattern matched. */
+  readonly listPulledEnvDirs: () => Promise<string[]>;
+  readonly readEnvLabel: (envDir: string) => Promise<string>;
+}): Promise<PulledEnvSelection> {
+  const found = await args.findPulledEnv(args.ref);
+  if (found !== undefined) {
+    return {
+      kind: "selected",
+      files: args.files.filter((file) => findPulledEnvDir(file) === found.dir),
+    };
+  }
+
+  // The pattern may have matched no files from a pulled env, so the error
+  // lists what is on disk rather than what happened to match.
+  const dirs = await args.listPulledEnvDirs();
+  const labels = (
+    await Promise.all(dirs.map((dir) => args.readEnvLabel(dir)))
+  ).sort();
+  return {
+    kind: "unknown",
+    result: {
+      error: flowsMessages.selectors.unknownPulledEnv(
+        args.ref,
+        labels,
+        suggestNearMiss(args.ref, labels),
+      ),
+      exitCode: exitCodes.invalidArgs,
+    },
+  };
+}

--- a/src/domains/flows/selectRunByTag.test.ts
+++ b/src/domains/flows/selectRunByTag.test.ts
@@ -11,12 +11,16 @@ const tagsFor = (
   mock(() => Promise.resolve(new Map(Object.entries(entries))));
 
 const noMatch = (error: string) => ({ error, exitCode: 2 });
+// The environment choice is the caller's concern; these tests pass the
+// selection straight through.
+const chooseEnv = (files: string[]) => Promise.resolve({ proceed: files });
 
 describe("selectRunByTag", () => {
   it("returns every file when no tag is given", async () => {
     const result = await selectRunByTag({
       files: [login, smoke],
       selectors: { tags: [] },
+      chooseEnv,
       readCachedTags: tagsFor({}),
       noMatch,
     });
@@ -28,6 +32,7 @@ describe("selectRunByTag", () => {
     const result = await selectRunByTag({
       files: [login, smoke],
       selectors: { tags: ["auth"] },
+      chooseEnv,
       readCachedTags: tagsFor({ [login]: ["auth"], [smoke]: ["smoke"] }),
       noMatch,
     });
@@ -41,6 +46,7 @@ describe("selectRunByTag", () => {
     const result = await selectRunByTag({
       files: [login],
       selectors: { tags: ["auth"] },
+      chooseEnv,
       readCachedTags: tagsFor({}),
       noMatch,
     });
@@ -52,6 +58,7 @@ describe("selectRunByTag", () => {
     const result = await selectRunByTag({
       files: [login],
       selectors: { tags: ["nope"] },
+      chooseEnv,
       readCachedTags: tagsFor({ [login]: ["auth"] }),
       noMatch,
     });
@@ -66,8 +73,34 @@ describe("selectRunByTag", () => {
     const result = await selectRunByTag({
       files: [login],
       selectors: { tags: ["nope"] },
+      chooseEnv,
       readCachedTags: tagsFor({ [login]: ["auth"] }),
       noMatch: () => undefined,
+    });
+
+    expect(result).toEqual({ ok: false, result: undefined });
+  });
+
+  // The caller decides which environment a multi-environment match meant.
+  it("returns whatever the environment choice resolved to", async () => {
+    const result = await selectRunByTag({
+      files: [login, smoke],
+      selectors: { tags: ["auth"] },
+      chooseEnv: () => Promise.resolve({ proceed: [smoke] }),
+      readCachedTags: tagsFor({ [login]: ["auth"], [smoke]: ["auth"] }),
+      noMatch,
+    });
+
+    expect(result).toEqual({ ok: true, files: [smoke] });
+  });
+
+  it("returns the caller's result when the choice stops the run", async () => {
+    const result = await selectRunByTag({
+      files: [login],
+      selectors: { tags: ["auth"] },
+      chooseEnv: () => Promise.resolve({ stop: undefined }),
+      readCachedTags: tagsFor({ [login]: ["auth"] }),
+      noMatch,
     });
 
     expect(result).toEqual({ ok: false, result: undefined });

--- a/src/domains/flows/selectRunByTag.ts
+++ b/src/domains/flows/selectRunByTag.ts
@@ -22,6 +22,13 @@ export type SelectRunByTagResult =
 export async function selectRunByTag(args: {
   files: string[];
   selectors: FlowSelectors;
+  /**
+   * Decides which environment to act on when a selection spans several.
+   * Returns the files to run, or the result the caller should return instead.
+   */
+  chooseEnv: (
+    files: string[],
+  ) => Promise<{ proceed: string[] } | { stop: CommandResult }>;
   readCachedTags: (
     files: readonly string[],
   ) => Promise<Map<string, readonly string[]>>;
@@ -43,5 +50,11 @@ export async function selectRunByTag(args: {
       result: args.noMatch(explainEmptySelection(args.selectors)),
     };
   }
-  return { ok: true, files: matched };
+
+  // Each pulled env has its own variables, so the same file pulled twice is
+  // two different runs; ask rather than guess which was meant.
+  const choice = await args.chooseEnv(matched);
+  return "proceed" in choice
+    ? { ok: true, files: choice.proceed }
+    : { ok: false, result: choice.stop };
 }


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

> Stacked on #1548. Review that one first.

# Overview of Changes

Flows belong to the team. An environment is a view of them at one commit. Thus the same flow is in each environment. If you pull two environments, every tag matches both copies.

Each environment has its own variables. The two copies are two different runs, not duplicates. The CLI must not select one of them without instructions.

- **`src/domains/flows/resolveEnvChoice.ts`**: if a selection includes more than one environment, show a list to a user. In `--json` and `--agent` modes, report an error with the same options.
- **`--all-envs`**: run all matches. This gives agents the same function as the "All" option. The CLI warns when the flag has no effect: with `--env`, or without `--tag`.
- **`src/domains/flows/selectPulledEnv.ts`**: `flows list --env <slug>` without `--remote` selects a pulled environment from disk. An unknown value lists the environments that are on disk, not only the ones the pattern matched.
- **`src/domains/flows/renderListTable.ts`**, **`envLabels.ts`**: add an `env` column. Show it only when the rows include more than one environment.
- **`src/commands/flows/runAction.ts`**, **`listDefaults.ts`**: new files. The source files were more than 150 lines.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- Show no list when there is one environment. Show an error in `json` and `agent` modes.
- Select one environment, or all of them. A cancel aborts the run.
- The `--all-envs` flag flows from the command line to the environment choice.
- Live test: the error named `debugging-beats, staging`. `--env staging` selected 2 flows. `--all-envs` selected 4.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
