### PR TITLE
feat(flows): run from the pulled env when unreachable

### DIFF
--- a/.changeset/offline-fallback-when-unreachable.md
+++ b/.changeset/offline-fallback-when-unreachable.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+`flows run --env` can now run from the pulled copy when the platform is not reachable. The fallback applies only when the platform did not answer — a connection failure or a timeout. An answer from the platform, for example an unknown environment or a rejected key, stops the run and shows that answer.
+
+A pulled environment resolves by its id, its slug, or its display name — every form the CLI can show.

--- a/src/commands/flows/run.register.ts
+++ b/src/commands/flows/run.register.ts
@@ -5,6 +5,7 @@ import { declareCommandKind } from "~/commands/commandKind.js";
 import { flowsMessages } from "~/core/messages/index.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { collectValue, parseInteger } from "~/domains/runner/runFlagParsers.js";
+import { findPulledEnv } from "~/shell/manifest/pulledEnv.js";
 import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
 
 import { addRunArtifactOptions } from "./runArtifactOptions.js";
@@ -93,6 +94,13 @@ export function registerFlowsRunCommand(
             {
               explicit: opts.env,
               requiredMessage: flowsMessages.run.requiresEnv,
+              // A run whose flows are already pulled does not need the
+              // platform, so an unreachable one should not stop it. The slug
+              // recorded at pull time means an alias resolves here too.
+              offlineFallback: async (explicit) =>
+                explicit === undefined
+                  ? undefined
+                  : (await findPulledEnv(explicit, process.cwd()))?.envId,
             },
             (ctx, env, identity) =>
               handleHybridFlowsRun(

--- a/src/commands/flows/withResolvedEnv.test.ts
+++ b/src/commands/flows/withResolvedEnv.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import { pulledEnvFallback } from "./withResolvedEnv.js";
+
+describe("pulledEnvFallback", () => {
+  it("consults the fallback when the platform never answered", async () => {
+    const offlineFallback = mock(() => Promise.resolve("env-abc"));
+
+    const pulled = await pulledEnvFallback(
+      { unreachable: true },
+      "staging",
+      offlineFallback,
+    );
+
+    expect(pulled).toBe("env-abc");
+    expect(offlineFallback).toHaveBeenCalledWith("staging");
+  });
+
+  // A 404 or a revoked key is the platform answering no. Running a stale
+  // pulled copy behind a "could not reach the platform" warning would be a
+  // false statement and the wrong action.
+  it("never consults the fallback when the platform answered", async () => {
+    const offlineFallback = mock(() => Promise.resolve("env-abc"));
+
+    const pulled = await pulledEnvFallback(
+      { unreachable: false },
+      "staging",
+      offlineFallback,
+    );
+
+    expect(pulled).toBeUndefined();
+    expect(offlineFallback).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the error when nothing is pulled", async () => {
+    const pulled = await pulledEnvFallback(
+      { unreachable: true },
+      "staging",
+      () => Promise.resolve(undefined),
+    );
+
+    expect(pulled).toBeUndefined();
+  });
+
+  it("is undefined when the command has no fallback", async () => {
+    const pulled = await pulledEnvFallback(
+      { unreachable: true },
+      "staging",
+      undefined,
+    );
+
+    expect(pulled).toBeUndefined();
+  });
+});

--- a/src/commands/flows/withResolvedEnv.ts
+++ b/src/commands/flows/withResolvedEnv.ts
@@ -16,7 +16,32 @@ type Args = {
   explicit: string | undefined;
   // Command-specific "an environment is required" text.
   requiredMessage: string;
+  /**
+   * Consulted only when resolution fails, for commands that can still work
+   * from a pulled copy. Returns the environment id to proceed with, or
+   * undefined to surface the resolution error as normal.
+   */
+  offlineFallback?: (
+    explicit: string | undefined,
+  ) => Promise<string | undefined>;
 };
+
+/**
+ * Decides whether a failed resolution may proceed from a pulled copy, and
+ * with which environment id.
+ *
+ * Only an unreachable platform qualifies: a platform that answered no
+ * (deleted environment, revoked key) must surface its answer, not run a stale
+ * pulled copy behind a false "could not reach" warning.
+ */
+export async function pulledEnvFallback(
+  outcome: { unreachable: boolean },
+  explicit: string | undefined,
+  offlineFallback: Args["offlineFallback"],
+): Promise<string | undefined> {
+  if (!outcome.unreachable) return undefined;
+  return offlineFallback?.(explicit);
+}
 
 /**
  * Wraps a platform command action with environment resolution: --env flag,
@@ -63,6 +88,18 @@ export function withResolvedEnv(
         return;
       }
       if (outcome.kind === "error") {
+        // Resolution needs the platform, so an unreachable one would otherwise
+        // block a command whose flows are already on disk. The fallback is a
+        // last resort: it runs only once resolution has already failed.
+        const pulled = await pulledEnvFallback(
+          outcome,
+          args.explicit,
+          args.offlineFallback,
+        );
+        if (pulled !== undefined) {
+          ctx.ui.warn(environmentsMessages.usingPulledEnv(pulled));
+          return fn(ctx, pulled, { slug: undefined, name: undefined });
+        }
         return failureFields(outcome);
       }
       return fn(ctx, outcome.env, {

--- a/src/core/messages/environments.ts
+++ b/src/core/messages/environments.ts
@@ -17,6 +17,8 @@ export const environmentsMessages = {
   couldNotResolve: (ref: string, detail: string) =>
     `Could not resolve environment ${ref}: ${detail} If ${ref} is an alias, note that aliases require a team API key.`,
   aborted: "Aborted; no environment selected.",
+  usingPulledEnv: (env: string) =>
+    `Could not reach the platform to resolve environment ${env}; using the copy pulled into .qawolf/${env}.`,
   tooManyPages: (pages: number) =>
     `Stopped listing environments after ${pages} pages. Pass --env explicitly.`,
 };

--- a/src/domains/environments/pickEnvironment.ts
+++ b/src/domains/environments/pickEnvironment.ts
@@ -24,11 +24,21 @@ export async function pickEnvironment(
   deps: ResolveEnvironmentDeps,
 ): Promise<ResolveEnvironmentOutcome> {
   const fetched = await fetchAllEnvironments(deps.platformClient);
-  if (!fetched.ok) return { ...failureFields(fetched), kind: "error" };
+  if (!fetched.ok) {
+    return {
+      ...failureFields(fetched),
+      kind: "error",
+      unreachable: fetched.unreachable === true,
+    };
+  }
 
   const environments = fetched.environments;
   if (environments.length === 0) {
-    return { kind: "error", error: environmentsMessages.noEnvironments };
+    return {
+      kind: "error",
+      error: environmentsMessages.noEnvironments,
+      unreachable: false,
+    };
   }
   const sole = environments.length === 1 ? environments[0] : undefined;
   if (sole) {

--- a/src/domains/environments/resolveEnvironment.errors.test.ts
+++ b/src/domains/environments/resolveEnvironment.errors.test.ts
@@ -18,6 +18,7 @@ describe("resolveEnvironment platform errors", () => {
       kind: "error",
       error:
         "Could not resolve environment staging: HTTP 400 If staging is an alias, note that aliases require a team API key.",
+      unreachable: false,
     });
   });
 
@@ -37,7 +38,26 @@ describe("resolveEnvironment platform errors", () => {
       error:
         "Could not resolve environment staging: HTTP 404 If staging is an alias, note that aliases require a team API key.",
       errorBody: "No environment named staging exists on this team.",
+      unreachable: false,
     });
+  });
+
+  // The unreachable flag is what lets `flows run --env` fall back to a pulled
+  // copy: it must be set only when the platform never answered, so a
+  // definitive refusal (404, revoked key) still surfaces as an error.
+  it("marks the outcome unreachable when the platform never answered", async () => {
+    const { deps } = makeDeps({
+      getError: "Could not reach the platform.",
+      getUnreachable: true,
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      ...opts,
+      explicit: "staging",
+    });
+
+    if (outcome.kind !== "error") throw new Error("expected an error");
+    expect(outcome.unreachable).toBe(true);
   });
 
   it("surfaces a platform error", async () => {
@@ -45,7 +65,11 @@ describe("resolveEnvironment platform errors", () => {
 
     const outcome = await resolveEnvironment(deps, opts);
 
-    expect(outcome).toEqual({ kind: "error", error: "HTTP 500" });
+    expect(outcome).toEqual({
+      kind: "error",
+      error: "HTTP 500",
+      unreachable: false,
+    });
   });
 
   it("carries the server's reason from the environment listing", async () => {
@@ -60,6 +84,7 @@ describe("resolveEnvironment platform errors", () => {
       kind: "error",
       error: "HTTP 403",
       errorBody: "This API key has no access to environments.",
+      unreachable: false,
     });
   });
 });

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -85,7 +85,11 @@ describe("resolveEnvironment", () => {
       requiredMessage: "req",
     });
 
-    expect(outcome).toEqual({ kind: "error", error: "req" });
+    expect(outcome).toEqual({
+      kind: "error",
+      error: "req",
+      unreachable: false,
+    });
   });
 
   it("errors with the required message in non-human modes", async () => {
@@ -97,7 +101,11 @@ describe("resolveEnvironment", () => {
         requiredMessage: "req",
       });
 
-      expect(outcome).toEqual({ kind: "error", error: "req" });
+      expect(outcome).toEqual({
+        kind: "error",
+        error: "req",
+        unreachable: false,
+      });
       expect(findEnvironments).not.toHaveBeenCalled();
       expect(getEnvironment).not.toHaveBeenCalled();
     }
@@ -115,6 +123,7 @@ describe("resolveEnvironment", () => {
       kind: "error",
       error:
         'No environments found on your team. Create one with "qawolf environment create".',
+      unreachable: false,
     });
   });
 
@@ -226,6 +235,7 @@ describe("resolveEnvironment", () => {
       kind: "error",
       error:
         "Stopped listing environments after 10 pages. Pass --env explicitly.",
+      unreachable: false,
     });
     expect(findEnvironments).toHaveBeenCalledTimes(10);
   });

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -27,6 +27,8 @@ export function makeDeps(args: {
   getEnv?: Page["environments"][number];
   getError?: string;
   getErrorBody?: string;
+  /** Marks the getError as a transport failure the platform never answered. */
+  getUnreachable?: boolean;
   selectAnswers?: string[];
   selectCancelled?: boolean;
 }) {
@@ -58,9 +60,14 @@ export function makeDeps(args: {
   const getEnvironment = mock(
     async (_input: unknown): Promise<PlatformResult<GetOutput>> => {
       if (args.getError !== undefined) {
-        return args.getErrorBody === undefined
-          ? { ok: false, error: args.getError }
-          : { ok: false, error: args.getError, errorBody: args.getErrorBody };
+        return {
+          ok: false,
+          error: args.getError,
+          ...(args.getErrorBody === undefined
+            ? {}
+            : { errorBody: args.getErrorBody }),
+          ...(args.getUnreachable ? { unreachable: true } : {}),
+        };
       }
       const value = args.getEnv;
       if (value === undefined)

--- a/src/domains/environments/resolveEnvironment.ts
+++ b/src/domains/environments/resolveEnvironment.ts
@@ -25,7 +25,17 @@ export type ResolveEnvironmentOutcome =
       name?: string | undefined;
     }
   | { kind: "cancelled" }
-  | { kind: "error"; error: string; errorBody?: string };
+  | {
+      kind: "error";
+      error: string;
+      errorBody?: string;
+      /**
+       * True when the platform never answered. A definitive refusal (unknown
+       * environment, revoked key) is not unreachable: falling back to a
+       * pulled copy would then run something the platform said no to.
+       */
+      unreachable: boolean;
+    };
 
 // The concrete instantiations of PlatformClient["callPublicApi"] this domain
 // needs. The real generic method is assignable to the overload set, and test
@@ -68,7 +78,7 @@ export async function resolveEnvironment(
   }
 
   if (deps.ui.mode !== "human") {
-    return { kind: "error", error: opts.requiredMessage };
+    return { kind: "error", error: opts.requiredMessage, unreachable: false };
   }
 
   return pickEnvironment(deps);
@@ -92,6 +102,7 @@ async function resolveRef(
       ...failureFields(result),
       kind: "error",
       error: environmentsMessages.couldNotResolve(ref, result.error),
+      unreachable: result.unreachable === true,
     };
   }
   if (result.value.id !== ref) {

--- a/src/shell/manifest/pulledEnv.test.ts
+++ b/src/shell/manifest/pulledEnv.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import type { Fs } from "~/shell/fs.js";
+import { manifestFilename } from "./io.js";
+import { findPulledEnv, listPulledEnvDirs } from "./pulledEnv.js";
+
+const cwd = "/proj";
+
+const manifestFor = (
+  envId: string,
+  envSlug?: string,
+  envName?: string,
+): string =>
+  JSON.stringify({
+    envId,
+    ...(envSlug === undefined ? {} : { envSlug }),
+    ...(envName === undefined ? {} : { envName }),
+    fetchedAt: "2026-09-01T12:00:00.000Z",
+    cliFlowsVersion: "0.1.4",
+    flows: [],
+  });
+
+async function fsWith(
+  envs: { dir: string; envId: string; envSlug?: string; envName?: string }[],
+): Promise<Fs> {
+  const fs = makeMemoryFs();
+  for (const e of envs) {
+    await fs.mkdir(`${cwd}/.qawolf/${e.dir}`, { recursive: true });
+    await fs.writeFile(
+      `${cwd}/.qawolf/${e.dir}/${manifestFilename}`,
+      manifestFor(e.envId, e.envSlug, e.envName),
+    );
+  }
+  return fs;
+}
+
+const staging = { dir: "env-abc", envId: "env-abc", envSlug: "staging" };
+const prod = { dir: "env-xyz", envId: "env-xyz", envSlug: "prod" };
+
+describe("findPulledEnv", () => {
+  it("matches the canonical id", async () => {
+    const fs = await fsWith([staging, prod]);
+    expect(await findPulledEnv("env-abc", cwd, fs)).toEqual({
+      dir: join(cwd, ".qawolf", "env-abc"),
+      envId: "env-abc",
+    });
+  });
+
+  // The point of recording the slug: an alias is resolvable without the API.
+  it("matches the slug recorded at pull time", async () => {
+    const fs = await fsWith([staging, prod]);
+    expect(await findPulledEnv("staging", cwd, fs)).toEqual({
+      dir: join(cwd, ".qawolf", "env-abc"),
+      envId: "env-abc",
+    });
+    expect(await findPulledEnv("prod", cwd, fs)).toEqual({
+      dir: join(cwd, ".qawolf", "env-xyz"),
+      envId: "env-xyz",
+    });
+  });
+
+  // Labels shown to the user fall back to the display name when there is no
+  // slug, so a name the CLI prints must also resolve.
+  it("matches the display name recorded at pull time", async () => {
+    const fs = await fsWith([
+      { dir: "env-abc", envId: "env-abc", envName: "Staging" },
+    ]);
+    expect(await findPulledEnv("Staging", cwd, fs)).toEqual({
+      dir: join(cwd, ".qawolf", "env-abc"),
+      envId: "env-abc",
+    });
+  });
+
+  it("returns the canonical id, not the slug, so the cache stays addressable", async () => {
+    const fs = await fsWith([
+      { dir: "env-abc", envId: "env-abc", envSlug: "staging" },
+    ]);
+    expect((await findPulledEnv("staging", cwd, fs))?.envId).toBe("env-abc");
+  });
+
+  it("is undefined for a name that matches nothing", async () => {
+    const fs = await fsWith([staging]);
+    expect(await findPulledEnv("nope", cwd, fs)).toBeUndefined();
+  });
+
+  it("is undefined when nothing has been pulled", async () => {
+    expect(await findPulledEnv("staging", cwd, makeMemoryFs())).toBeUndefined();
+  });
+
+  // Manifests written before slugs were recorded still match by id, so an
+  // older pulled env keeps working.
+  it("still matches by id when the manifest predates slugs", async () => {
+    const fs = await fsWith([{ dir: "env-abc", envId: "env-abc" }]);
+    expect(await findPulledEnv("env-abc", cwd, fs)).toEqual({
+      dir: join(cwd, ".qawolf", "env-abc"),
+      envId: "env-abc",
+    });
+    expect(await findPulledEnv("staging", cwd, fs)).toBeUndefined();
+  });
+
+  it("ignores a directory whose manifest is unreadable", async () => {
+    const fs = makeMemoryFs();
+    await fs.mkdir(`${cwd}/.qawolf/broken`, { recursive: true });
+    await fs.writeFile(
+      `${cwd}/.qawolf/broken/${manifestFilename}`,
+      "{not json",
+    );
+    expect(await findPulledEnv("broken", cwd, fs)).toBeUndefined();
+  });
+
+  // An unreadable .qawolf is not the same answer as an absent one; reporting
+  // "not found" would hide a permissions problem.
+  it("rethrows a filesystem error that is not a missing directory", async () => {
+    const fs = makeMemoryFs();
+    const failing: Fs = {
+      ...fs,
+      readdirWithTypes: () => Promise.reject(new Error("EACCES: denied")),
+    };
+
+    expect(findPulledEnv("staging", cwd, failing)).rejects.toThrow("EACCES");
+  });
+});
+
+describe("listPulledEnvDirs", () => {
+  it("lists every directory holding a usable manifest", async () => {
+    const fs = await fsWith([staging, prod]);
+    expect(await listPulledEnvDirs(cwd, fs)).toEqual([
+      join(cwd, ".qawolf", "env-abc"),
+      join(cwd, ".qawolf", "env-xyz"),
+    ]);
+  });
+
+  it("skips a directory whose manifest is unreadable", async () => {
+    const fs = await fsWith([staging]);
+    await fs.mkdir(`${cwd}/.qawolf/broken`, { recursive: true });
+    await fs.writeFile(
+      `${cwd}/.qawolf/broken/${manifestFilename}`,
+      "{not json",
+    );
+    expect(await listPulledEnvDirs(cwd, fs)).toEqual([
+      join(cwd, ".qawolf", "env-abc"),
+    ]);
+  });
+
+  it("is empty when nothing has been pulled", async () => {
+    expect(await listPulledEnvDirs(cwd, makeMemoryFs())).toEqual([]);
+  });
+});

--- a/src/shell/manifest/pulledEnv.ts
+++ b/src/shell/manifest/pulledEnv.ts
@@ -1,0 +1,74 @@
+import { join } from "node:path";
+
+import { isNoEntError } from "~/core/errors.js";
+import { makeDefaultFs, type Fs } from "~/shell/fs.js";
+import { readManifest } from "./io.js";
+
+export type PulledEnv = {
+  /** Absolute `.qawolf/<id>/` directory of the pulled environment. */
+  readonly dir: string;
+  /** Canonical environment id from the manifest, the cache's address. */
+  readonly envId: string;
+};
+
+/**
+ * Finds a pulled environment by id, or by the slug or display name recorded
+ * at pull time.
+ *
+ * Name is matched because labels shown to the user are built the same way
+ * (slug, else name, else id): everything the CLI can print as an environment
+ * must also be accepted back. The canonical id is returned with the directory
+ * so callers never derive one from the other. A slug or name can be renamed
+ * on the platform, which makes this a convenience for working offline rather
+ * than a substitute for resolving the environment when it can be reached.
+ */
+export async function findPulledEnv(
+  ref: string,
+  cwd: string,
+  fs: Fs = makeDefaultFs(),
+): Promise<PulledEnv | undefined> {
+  for (const envDir of await listPulledEnvDirs(cwd, fs)) {
+    const manifest = await readManifest(envDir, fs);
+    if (typeof manifest === "string") continue;
+    if (
+      manifest.envId === ref ||
+      manifest.envSlug === ref ||
+      manifest.envName === ref
+    ) {
+      return { dir: envDir, envId: manifest.envId };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Lists every pulled environment directory under `cwd/.qawolf`, as absolute
+ * paths. A directory without a usable manifest is not a pulled environment.
+ */
+export async function listPulledEnvDirs(
+  cwd: string,
+  fs: Fs = makeDefaultFs(),
+): Promise<string[]> {
+  const root = join(cwd, ".qawolf");
+
+  let entries: Awaited<ReturnType<Fs["readdirWithTypes"]>>;
+  try {
+    entries = await fs.readdirWithTypes(root);
+  } catch (err: unknown) {
+    // A missing .qawolf means nothing has been pulled here. EACCES and other
+    // I/O failures are a different answer, so they surface rather than
+    // becoming a wrong "environment not found".
+    if (isNoEntError(err)) return [];
+    throw err;
+  }
+
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const envDir = join(root, entry.name);
+    const manifest = await readManifest(envDir, fs);
+    if (typeof manifest === "string") continue;
+    dirs.push(envDir);
+  }
+  return dirs;
+}

--- a/src/shell/platform/requestWithRetry.test.ts
+++ b/src/shell/platform/requestWithRetry.test.ts
@@ -23,6 +23,7 @@ describe("requestWithRetry", () => {
       error: "failed",
       mayHaveArrived: true,
       ok: false,
+      unreachable: true,
     });
   });
 
@@ -48,6 +49,7 @@ describe("requestWithRetry", () => {
       error: "failed",
       mayHaveArrived: true,
       ok: false,
+      unreachable: true,
     });
   });
 });

--- a/src/shell/platform/requestWithRetry.ts
+++ b/src/shell/platform/requestWithRetry.ts
@@ -18,6 +18,12 @@ export type PlatformFailure = {
   errorBody?: string;
   exitCode?: number;
   mayHaveArrived?: boolean;
+  /**
+   * The platform never answered — the connection failed or the deadline
+   * passed. An HTTP error is the opposite: a definitive answer. Callers use
+   * this to decide whether an offline fallback is honest.
+   */
+  unreachable?: boolean;
 };
 
 export type PlatformResult<T> =
@@ -73,10 +79,15 @@ export async function requestWithRetry<T>(
       // after the request body was sent just as it covers one refused outright,
       // so it cannot prove the request never arrived either.
       const mayHaveArrived = result.error.kind !== "http";
+      // A parse error is the server answering, so only the two failures that
+      // never produced an answer count as unreachable.
+      const unreachable =
+        result.error.kind === "network" || result.error.kind === "timeout";
       return {
         ok: false,
         ...args.describe(result.error),
         ...(mayHaveArrived ? { mayHaveArrived } : {}),
+        ...(unreachable ? { unreachable } : {}),
       };
     }
     await sleep(backoff);


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

> Stacked on #1545. Review that one first. Split out of #1546 to keep each PR small.

# Overview of Changes

`flows run --env` resolves the environment through the platform. An unreachable platform stopped the run, even when the flows were already pulled and on disk.

This change adds an offline fallback. The fallback applies only when the platform did not answer. An answer from the platform, for example an unknown environment or a rejected key, stops the run and shows that answer. A stale local copy must not run against a "no" from the platform.

- **`src/shell/platform/requestWithRetry.ts`**: a failed result carries an `unreachable` flag. The flag is set only for a connection failure or a timeout. An HTTP error is an answer. A parse error means the server answered.
- **`src/domains/environments/resolveEnvironment.ts`, `pickEnvironment.ts`**: the error outcome carries a required `unreachable` field, so every construction site must decide it.
- **`src/commands/flows/withResolvedEnv.ts`**: consult the fallback only when the outcome is unreachable. The decision is in `pulledEnvFallback`, which has its own tests.
- **`src/shell/manifest/pulledEnv.ts`**: new file. Find a pulled environment by id, by slug, or by display name — every form the CLI can show also resolves. `listPulledEnvDirs` lists the pulled environments on disk. The CLI uses this only after resolution fails offline.
- **`src/commands/flows/run.register.ts`**: wire the fallback into `flows run --env`. The run gets the canonical env id, which addresses the `.qawolf/<id>/` cache.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- The `unreachable` flag is set for network and timeout failures, and not for HTTP or parse failures.
- The fallback runs only when the platform is unreachable. An HTTP error surfaces.
- Find an environment by id, by slug, and by name. Path expectations use host separators.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
