### PR TITLE
fix(runner): warn when a freshly launched runner is shadowed by QAWOLF_RUNNER_ID (ARC-661)

### DIFF
--- a/.changeset/runner-launch-env-shadow-warning.md
+++ b/.changeset/runner-launch-env-shadow-warning.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf runner launch` now warns when `QAWOLF_RUNNER_ID` is set to a different runner than the one just launched, since that variable outranks the directory default and would otherwise send runner-less commands to the stale runner without any indication why.

--- a/src/core/messages/interactiveRunner/lifecycle.ts
+++ b/src/core/messages/interactiveRunner/lifecycle.ts
@@ -7,6 +7,8 @@ export const lifecycleMessages = {
     `Runner ${id} could not be written to .qawolf as this directory's default, so later commands will not find it on their own. Pass --runner ${id}, or set QAWOLF_RUNNER_ID=${id}.`,
   defaultNotForgotten: (id: string) =>
     `Runner ${id} was terminated, but it could not be removed from .qawolf as this directory's default, so later commands will still be sent to it. Pass --runner, or launch a new runner.`,
+  envRunnerIdShadowsLaunch: (launchedId: string, envId: string) =>
+    `QAWOLF_RUNNER_ID=${envId} is still set, so commands that omit --runner will keep targeting it instead of the runner just launched. Pass --runner ${launchedId}, or export QAWOLF_RUNNER_ID=${launchedId}.`,
   keptAlive: (id: string) =>
     `Runner ${id} is alive, and its inactivity clock has been reset.`,
   launchFailed: (id: string, error: string) =>

--- a/src/domains/interactiveRunner/launch.test.ts
+++ b/src/domains/interactiveRunner/launch.test.ts
@@ -74,6 +74,36 @@ describe("handleRunnerLaunch", () => {
     expect(outputs()[0]?.humanMessage).toContain("already running");
   });
 
+  // QAWOLF_RUNNER_ID outranks the directory default a launch just wrote (resolveRunner.ts).
+  it("warns when QAWOLF_RUNNER_ID names a different runner than the one just launched", async () => {
+    const { callPublicApi, ctx, warnings } = makeAuthCtx();
+    const value = { ...launched, id: "ci", runnerName: "android" as const };
+    callPublicApi.mockResolvedValue({ ok: true, value });
+
+    await handleRunnerLaunch(
+      ctx,
+      { id: "ci", name: "android" },
+      makeTestDeps({ env: { QAWOLF_RUNNER_ID: "old-default" } }),
+    );
+
+    expect(warnings()).toHaveLength(1);
+    expect(warnings()[0]).toContain("QAWOLF_RUNNER_ID=old-default");
+    expect(warnings()[0]).toContain("--runner ci");
+  });
+
+  it("does not warn when QAWOLF_RUNNER_ID already names the launched runner, or is unset", async () => {
+    const { callPublicApi, ctx, warnings } = makeAuthCtx();
+    callPublicApi.mockResolvedValue({
+      ok: true,
+      value: { ...launched, id: "ci" },
+    });
+    const opts = { id: "ci", name: undefined };
+    for (const env of [{ QAWOLF_RUNNER_ID: "ci" }, {}]) {
+      await handleRunnerLaunch(ctx, opts, makeTestDeps({ env }));
+    }
+    expect(warnings()).toEqual([]);
+  });
+
   it("refuses an id the published schema does not admit, without a request", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
 

--- a/src/domains/interactiveRunner/launch.ts
+++ b/src/domains/interactiveRunner/launch.ts
@@ -8,6 +8,7 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { launchAndRemember } from "./launchAndRemember.js";
+import { runnerIdEnvironmentVariable } from "./resolveRunner.js";
 import { parseRunnerId, parseRunnerName } from "./runnerIds.js";
 
 export async function handleRunnerLaunch(
@@ -35,6 +36,20 @@ export async function handleRunnerLaunch(
   );
   if (!launched.ok) {
     return { ...failureFields(launched), exitCode: launched.exitCode };
+  }
+
+  // The directory default this launch just wrote is only what a runner-less
+  // command reaches for; QAWOLF_RUNNER_ID outranks it (see resolveRunner.ts),
+  // so a stale value there would silently keep sending those commands
+  // elsewhere. Say so now, while it's this launch's id that's fresh in mind.
+  const envRunnerId = deps.env[runnerIdEnvironmentVariable]?.trim();
+  if (envRunnerId && envRunnerId !== launched.value.id) {
+    ctx.ui.warn(
+      interactiveRunnerMessages.envRunnerIdShadowsLaunch(
+        launched.value.id,
+        envRunnerId,
+      ),
+    );
   }
 
   ctx.ui.output(


### PR DESCRIPTION
## Overview of Problem

`qawolf runner launch` remembers the runner it just started as this directory's `.qawolf`-stored default, but `QAWOLF_RUNNER_ID` outranks that default when resolving a runner-less command. A stale `QAWOLF_RUNNER_ID` — inherited from a harness, or exported earlier in the same shell for a different runner — silently keeps every later command targeting the old runner instead. Surfaced during mobile dogfooding: launching an Android runner while `QAWOLF_RUNNER_ID` still named the session's default Playwright runner cost several debug cycles before the cause was found, since nothing errored.

## Overview of Changes

- `runner launch`: warn on stderr when it succeeds but `QAWOLF_RUNNER_ID` names a different id than the one just launched, naming both ids and the fix (`--runner <new>` or re-export `QAWOLF_RUNNER_ID=<new>`)
- No change to runner resolution order — considered making the directory default outrank env instead, but that would regress Tester's multi-runner "slot" feature (every `runner launch` for an additional slot overwrites the directory default; Tester relies on env staying authoritative to route back to its main runner)

### Verify it works

Added 2 unit tests covering: warns when `QAWOLF_RUNNER_ID` differs from the launched id; does not warn when it already matches or is unset. `bun run test src/domains/interactiveRunner` — 234/234 pass.

## Release Notes

None — CLI-only stderr message, no behavior change.
