### PR TITLE
fix(runner): narrow shadow warning's fix to --runner (ARC-661)

### DIFF
--- a/.changeset/runner-launch-shadow-warning-followup.md
+++ b/.changeset/runner-launch-shadow-warning-followup.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+The `QAWOLF_RUNNER_ID` shadow warning added in the previous release no longer suggests `export QAWOLF_RUNNER_ID=<launchedId>` as a fix, since that repoints every other runner-less command too rather than just the one you meant; `--runner <launchedId>` is the only fix it now names. `references/runner.md` documents the new warning alongside the resolution order it stems from.

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -17,7 +17,7 @@ Commands that target a runner find one in this order: `--runner`, then
 `QAWOLF_RUNNER_ID`, then the runner stored for the current directory (which
 `qawolf runner launch` sets). Setting the environment variable once is the most
 robust for a harness whose working directory may not be stable, but it comes
-with two catches worth knowing before you rely on it.
+with three catches worth knowing before you rely on it.
 
 `qawolf runner launch` is not in that order: it takes its id from `--id` and
 never reads `QAWOLF_RUNNER_ID`. Bare `qawolf runner launch` invents a random id,
@@ -30,6 +30,13 @@ running under it. So exporting `QAWOLF_RUNNER_ID=agent-1` turns off the
 auto-launch described next: instead of starting `agent-1`, commands try to reach
 it and fail with exit code `4`, which reads as "retry" and never succeeds.
 Launch that id once yourself and the rest follows.
+
+And launching an id that differs from `QAWOLF_RUNNER_ID` prints a warning on
+stderr naming both ids: the variable still outranks the directory default, so
+commands that omit `--runner` keep going to whatever it names, not the runner
+you just launched. Expected when you are launching an additional runner on
+purpose — address that one with `--runner` rather than re-exporting the
+variable, which would repoint every other runner-less command too.
 
 If nothing names a runner, the commands that change something will launch one
 and say so on stderr, naming it: `run`, `act` and `exec`. **Read that

--- a/src/core/messages/interactiveRunner/lifecycle.ts
+++ b/src/core/messages/interactiveRunner/lifecycle.ts
@@ -8,7 +8,7 @@ export const lifecycleMessages = {
   defaultNotForgotten: (id: string) =>
     `Runner ${id} was terminated, but it could not be removed from .qawolf as this directory's default, so later commands will still be sent to it. Pass --runner, or launch a new runner.`,
   envRunnerIdShadowsLaunch: (launchedId: string, envId: string) =>
-    `QAWOLF_RUNNER_ID=${envId} is still set, so commands that omit --runner will keep targeting it instead of the runner just launched. Pass --runner ${launchedId}, or export QAWOLF_RUNNER_ID=${launchedId}.`,
+    `QAWOLF_RUNNER_ID=${envId} is still set, so commands that omit --runner will keep targeting it instead of the runner just launched. Pass --runner ${launchedId} to address this one.`,
   keptAlive: (id: string) =>
     `Runner ${id} is alive, and its inactivity clock has been reset.`,
   launchFailed: (id: string, error: string) =>


### PR DESCRIPTION
# Overview of Changes

Follow-up to #1550, addressing review comments left after merge.

`envRunnerIdShadowsLaunch` suggested `export QAWOLF_RUNNER_ID=<launchedId>` alongside `--runner <launchedId>`. Exporting repoints every other runner-less command in the session, not just the one the warning is about — not the right fix for the multi-runner case, where a fresh `QAWOLF_RUNNER_ID` mismatch is expected on every additional launch. The warning now suggests only `--runner`.

`references/runner.md` documents the new stderr warning next to the resolution-order catches it already describes, since that's the only doc a harness gets at pod start.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All green locally, 1928/1928 tests pass. No test asserted the old message text.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)