### PR TITLE
docs(cli): point skill references at absolute raw URLs

### DIFF
--- a/.changeset/skill-reference-urls.md
+++ b/.changeset/skill-reference-urls.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Point the `qawolf-cli` skill's reference files at absolute raw URLs, so a harness that loads `SKILL.md` without its surrounding directory can still reach `references/runner.md` and `references/run-results.md`.

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -81,7 +81,9 @@ artifact URLs expire, its failure fields are absent from a passing run, and its
 `traceUrl` downloads a Playwright trace that you can read as JSON without
 opening the trace viewer. **Read
 [`references/run-results.md`](references/run-results.md) before reporting on a
-run's outcome or opening its trace.**
+run's outcome or opening its trace.** If that path is not on your filesystem,
+fetch it:
+`https://raw.githubusercontent.com/qawolf/cli/main/skills/qawolf-cli/references/run-results.md`.
 
 ## Safety: reads vs writes
 
@@ -199,4 +201,5 @@ The full workflow is its own guide: how a runner is billed, why the first call
 must be a run, the order the commands go in, the see-and-act loop, `exec`, the
 recorder, reading history, staying alive, and an end-to-end example. **Read
 [`references/runner.md`](references/runner.md) before driving a runner for the
-first time.**
+first time.** If that path is not on your filesystem, fetch it:
+`https://raw.githubusercontent.com/qawolf/cli/main/skills/qawolf-cli/references/runner.md`.

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -81,7 +81,9 @@ artifact URLs expire, its failure fields are absent from a passing run, and its
 `traceUrl` downloads a Playwright trace that you can read as JSON without
 opening the trace viewer. **Read
 [`references/run-results.md`](references/run-results.md) before reporting on a
-run's outcome or opening its trace.**
+run's outcome or opening its trace.** If that path is not on your filesystem,
+fetch it:
+`https://raw.githubusercontent.com/qawolf/cli/main/skills/qawolf-cli/references/run-results.md`.
 
 ## Safety: reads vs writes
 
@@ -141,4 +143,5 @@ The full workflow is its own guide: how a runner is billed, why the first call
 must be a run, the order the commands go in, the see-and-act loop, `exec`, the
 recorder, reading history, staying alive, and an end-to-end example. **Read
 [`references/runner.md`](references/runner.md) before driving a runner for the
-first time.**
+first time.** If that path is not on your filesystem, fetch it:
+`https://raw.githubusercontent.com/qawolf/cli/main/skills/qawolf-cli/references/runner.md`.


### PR DESCRIPTION
# Overview of Changes

`tester-skills` exposes this skill to Tester by reading `skills/qawolf-cli/SKILL.md` out of the installed package and passing its contents through `createSkillFromSkillMd`. Only that one file travels, so the relative links to `references/runner.md` and `references/run-results.md` point at paths Tester has no way to open, and the two guides the skill tells it to read first are unreachable.

- [x] Name the raw GitHub URL beside each relative reference path, so a harness holding only `SKILL.md` can still fetch the guide.
- [x] Change the template rather than the generated file, so `bun run generate` keeps `skills/qawolf-cli/SKILL.md` in step.

# Testing

```sh
bun run typecheck && bun run lint && bun run format:check
bun run knip && bun run test
```

2089 tests pass, and typecheck, lint, format and knip are clean.

- `bun run generate` leaves `skills/qawolf-cli/SKILL.md` byte-identical, so the committed file and its template agree.
