### PR TITLE
feat(runner): add a typed runner SDK at @qawolf/cli/runner-sdk

### DIFF
--- a/.changeset/typed-runner-sdk.md
+++ b/.changeset/typed-runner-sdk.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": minor
+---
+
+Add `@qawolf/cli/runner-sdk`, a typed library for driving interactive runners in process rather than by spawning `qawolf runner`. Every verb names the runner it addresses, so nothing is launched or billed implicitly, and answers come back as the `@qawolf/api-contracts` output types rather than parsed stdout.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -13,7 +13,7 @@
           },
           {
             "group": ["bun", "bun:*"],
-            "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+            "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
           }
         ]
       }
@@ -28,7 +28,7 @@
       "error",
       {
         "name": "Bun",
-        "message": "Bun global is not available in the nodejs build — use a Bun-compatible API or guard with typeof Bun !== 'undefined'."
+        "message": "Bun global is not available in the nodejs build \u2014 use a Bun-compatible API or guard with typeof Bun !== 'undefined'."
       }
     ],
     "eslint/eqeqeq": "error",
@@ -124,11 +124,11 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/shell/*", "~/shell/**"],
-                "message": "core/ must not import from shell/ — keep core/ pure."
+                "message": "core/ must not import from shell/ \u2014 keep core/ pure."
               },
               {
                 "group": ["~/domains/*", "~/domains/**"],
@@ -140,15 +140,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "core/ must not import node:fs — keep core/ pure."
+                "message": "core/ must not import node:fs \u2014 keep core/ pure."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "core/ must not import node:child_process — keep core/ pure."
+                "message": "core/ must not import node:child_process \u2014 keep core/ pure."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "core/ must not import node:readline — keep core/ pure."
+                "message": "core/ must not import node:readline \u2014 keep core/ pure."
               }
             ]
           }
@@ -168,7 +168,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/domains/*", "~/domains/**"],
@@ -196,7 +196,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -239,15 +239,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -267,7 +267,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -310,15 +310,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -338,7 +338,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -381,15 +381,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -409,7 +409,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -452,15 +452,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -480,7 +480,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -523,15 +523,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -551,7 +551,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -594,15 +594,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -622,7 +622,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -665,15 +665,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -693,7 +693,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -733,15 +733,15 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
               }
             ]
           }
@@ -761,7 +761,7 @@
               },
               {
                 "group": ["bun", "bun:*"],
-                "message": "Bun module imports are not available in the nodejs build — use a portable alternative."
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
               },
               {
                 "group": ["~/commands/*", "~/commands/**"],
@@ -804,15 +804,39 @@
               },
               {
                 "group": ["node:fs", "fs", "node:fs/promises", "fs/promises"],
-                "message": "domains/ must not import node:fs — file I/O belongs in shell/."
+                "message": "domains/ must not import node:fs \u2014 file I/O belongs in shell/."
               },
               {
                 "group": ["node:child_process", "child_process"],
-                "message": "domains/ must not import node:child_process — use SpawnFn from shell/spawn.js."
+                "message": "domains/ must not import node:child_process \u2014 use SpawnFn from shell/spawn.js."
               },
               {
                 "group": ["node:readline", "readline"],
-                "message": "domains/ must not import node:readline — use UI from shell/ui/."
+                "message": "domains/ must not import node:readline \u2014 use UI from shell/ui/."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/runnerSdk/**/*.ts"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["../*"],
+                "message": "Use \"~/\" path alias instead of relative parent imports."
+              },
+              {
+                "group": ["bun", "bun:*"],
+                "message": "Bun module imports are not available in the nodejs build \u2014 use a portable alternative."
+              },
+              {
+                "group": ["~/commands/*", "~/commands/**"],
+                "message": "runnerSdk/ is the published library entry and must not import from commands/."
               }
             ]
           }
@@ -827,17 +851,17 @@
           {
             "object": "process",
             "property": "stdout",
-            "message": "core/ and domains/ must not write to process.stdout — return data and let shell/ render it."
+            "message": "core/ and domains/ must not write to process.stdout \u2014 return data and let shell/ render it."
           },
           {
             "object": "process",
             "property": "stderr",
-            "message": "core/ and domains/ must not write to process.stderr — return data and let shell/ render it."
+            "message": "core/ and domains/ must not write to process.stderr \u2014 return data and let shell/ render it."
           },
           {
             "object": "process",
             "property": "stdin",
-            "message": "core/ and domains/ must not read from process.stdin — use UI from shell/ui/."
+            "message": "core/ and domains/ must not read from process.stdin \u2014 use UI from shell/ui/."
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ src/
 │   ├── interactiveRunner/ # remote runners: launch, stop, keepalive, runFlow, journal, screenshot, act, exec
 │   ├── runner/          # the LOCAL execution engine: flowsRun, runWebFlow, runAndroidFlow, worker dispatch + pool
 │   └── updateCheck/     # startUpdateCheck: new-version notice after commands
-└── commands/            # Thin CLI glue — Commander registration + composite root
+├── commands/            # Thin CLI glue — Commander registration + composite root
     ├── context.ts       # withContext() Commander action wrapper
     ├── program.ts       # createProgram() factory
     ├── auth/            # login, logout, whoami handlers
@@ -83,9 +83,13 @@ src/
     ├── init/            # init handler
     ├── install/         # install browsers/android handlers
     └── runner/          # lifecycle/run/interact registrations (domains/interactiveRunner)
+└── runnerSdk/           # Published library entry — @qawolf/cli/runner-sdk
+    ├── index.ts         # createRunnerSdk() — the only file `exports` points at
+    ├── types.ts         # the public types; imports only @qawolf/api-contracts
+    └── *Verbs.ts        # one file per verb group
 ```
 
-The codebase is organized into four strict layers. **`core/`** holds pure functions and types with zero I/O. **`shell/`** holds I/O executors (process spawning, Playwright, UI rendering, API clients). **`domains/`** holds bounded-context business logic; each domain may import `core/` and `shell/` but never a sibling domain. **`commands/`** is the composite root: thin Commander registration plus `runDefaults.ts`, which bridges multiple domains to assemble the `flows run` command. oxlint enforces these boundaries via per-layer `no-restricted-imports` overrides in `.oxlintrc.json`.
+The codebase is organized into five layers. **`core/`** holds pure functions and types with zero I/O. **`shell/`** holds I/O executors (process spawning, Playwright, UI rendering, API clients). **`domains/`** holds bounded-context business logic; each domain may import `core/` and `shell/` but never a sibling domain. **`commands/`** is the composite root: thin Commander registration plus `runDefaults.ts`, which bridges multiple domains to assemble the `flows run` command. **`runnerSdk/`** is the second composite root, serving a library consumer where `commands/` serves the terminal: it is the only directory the `exports` field points at, and it reuses `domains/interactiveRunner` rather than reimplementing it. oxlint enforces these boundaries via per-layer `no-restricted-imports` overrides in `.oxlintrc.json`; `runnerSdk/` additionally may not import from `commands/` or from `bun`, since it is published and runs under Node.
 
 API clients (tRPC for the QA Wolf platform, GitHub REST) live in `src/shell/platform/` and `src/shell/` respectively — one module per auth boundary.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ Omit `--global` to install the skill only for the current project. The skill als
 
 The skill is generated from its [source template](src/commands/qawolfCliSkill.template.md) and the command tree (`bun run generate`), and kept in sync by the test suite.
 
+## Runner SDK
+
+Drive interactive runners from TypeScript instead of spawning commands. Every verb names the runner it addresses, so nothing is launched or billed implicitly.
+
+```ts
+import { createRunnerSdk } from "@qawolf/cli/runner-sdk";
+
+const runner = createRunnerSdk({ apiKey: process.env.QAWOLF_API_KEY });
+
+await runner.launch({ id: "agent-1", runnerFamily: "default" });
+
+const submitted = await runner.run({
+  entryPointPath: "src/flows/smoke.flow.ts",
+  environment: "ambient",
+  runnerId: "agent-1",
+  selection: "whole-flow",
+});
+if (submitted.ok) console.log(submitted.value.runId, submitted.value.fileSync);
+```
+
+`ok: false` is a transport or auth failure. A runner that refused the request comes back as `ok: true` with `value.outcome === "failure"` and a `failureReason` from the published contract, so a caller can switch on it exhaustively.
+
 ## Reference
 
 - [Commands](https://docs.qawolf.com/qawolf/libraries/cli/api-reference/commands) — full command and flag reference

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,6 +3,7 @@ import type { KnipConfig } from "knip";
 const config: KnipConfig = {
   entry: [
     "*.config.ts",
+    "src/runnerSdk/index.ts",
     "src/**/*.test.ts",
     "src/**/*.mock.ts",
     "src/**/*.fixtures.ts",

--- a/package.json
+++ b/package.json
@@ -28,16 +28,27 @@
     "LICENSE",
     "README.md",
     "dist/cli.js",
+    "dist/runner-sdk.js",
+    "dist/types/runnerSdk/index.d.ts",
+    "dist/types/runnerSdk/types.d.ts",
     "skills"
   ],
   "type": "module",
+  "exports": {
+    "./runner-sdk": {
+      "types": "./dist/types/runnerSdk/index.d.ts",
+      "import": "./dist/runner-sdk.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "build": "bun run build:bundle",
-    "build:bundle": "bun run generate && bun scripts/build.ts",
     "build:binary": "bun run build && bun scripts/buildBinary.ts",
+    "build:bundle": "bun run generate && bun scripts/build.ts",
+    "build:types-gate": "bun scripts/checkSdkTypes.ts",
     "dev": "bun run src/main.ts",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,17 +19,31 @@ const externals = [
   "@qawolf/testkit",
 ];
 
-const buildArgs = [
-  "build",
-  "./src/main.ts",
-  "--outdir",
-  "dist",
-  "--entry-naming=cli.[ext]",
-  "--target",
-  "node",
-  ...externals.flatMap((pkg) => ["--external", pkg]),
-  "--sourcemap=external",
+function buildArgs(entry: string, name: string): string[] {
+  return [
+    "build",
+    entry,
+    "--outdir",
+    "dist",
+    `--entry-naming=${name}.[ext]`,
+    "--target",
+    "node",
+    ...externals.flatMap((pkg) => ["--external", pkg]),
+    "--sourcemap=external",
+  ];
+}
+
+const bundles = [
+  buildArgs("./src/main.ts", "cli"),
+  buildArgs("./src/runnerSdk/index.ts", "runner-sdk"),
 ];
 
-const result = spawnSync("bun", buildArgs, { stdio: "inherit" });
-process.exit(result.status ?? 1);
+for (const args of bundles) {
+  const result = spawnSync("bun", args, { stdio: "inherit" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+const types = spawnSync("bunx", ["tsc", "-p", "tsconfig.types.json"], {
+  stdio: "inherit",
+});
+process.exit(types.status ?? 1);

--- a/scripts/checkSdkTypes.ts
+++ b/scripts/checkSdkTypes.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+// Fails when the published SDK declarations reference anything outside
+// themselves. `~/` is a tsconfig alias and `../` reaches files that are not
+// published, so either would leave a consumer with types that do not resolve.
+import { readFileSync } from "node:fs";
+
+const published = [
+  "dist/types/runnerSdk/index.d.ts",
+  "dist/types/runnerSdk/types.d.ts",
+];
+
+const allowed = /^(\.\/types\.js|@qawolf\/api-contracts\/v1)$/;
+
+const leaks = published.flatMap((file) => {
+  const source = readFileSync(file, "utf8");
+  return [...source.matchAll(/from "([^"]+)"/g)]
+    .map((match) => match[1] ?? "")
+    .filter((specifier) => !allowed.test(specifier))
+    .map((specifier) => `${file} imports ${specifier}`);
+});
+
+if (leaks.length > 0) {
+  console.error(
+    `The published SDK types reach outside themselves:\n${leaks.map((leak) => `  ${leak}`).join("\n")}`,
+  );
+  process.exit(1);
+}
+
+console.log(`Checked ${published.length} published declaration files.`);

--- a/src/domains/interactiveRunner/evaluateSnippet.ts
+++ b/src/domains/interactiveRunner/evaluateSnippet.ts
@@ -1,10 +1,5 @@
-import { type RunFiles, publicContractsV1 } from "@qawolf/api-contracts/v1";
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
-import {
-  checkSnippetFiles,
-  describeRunFilesCheck,
-  toCollectedPath,
-} from "~/core/interactiveRunner/runFiles.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import type {
   AuthCommandContext,
@@ -15,35 +10,10 @@ import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { announceRunner, resolveRunner } from "./resolveRunner.js";
+import { resolveSnippetScope } from "./snippetScope.js";
 import { runnerCallOptions } from "./runnerCallOptions.js";
 
 const stdinArgument = "-";
-
-type Scope =
-  | { ok: true; filePath: string | undefined; files: RunFiles | undefined }
-  | { ok: false; error: string };
-
-/**
- * The scope a snippet is evaluated in. A runner holds no copy of the project, so
- * a snippet that touches the caller's own modules has to carry them: the named
- * file and everything the collector found beside it. Without `--file` the snippet
- * imports nothing of the caller's and nothing travels.
- */
-async function resolveScope(
-  contextFile: string | undefined,
-  deps: InteractiveRunnerDeps,
-): Promise<Scope> {
-  if (contextFile === undefined) {
-    return { filePath: undefined, files: undefined, ok: true };
-  }
-  const filePath = toCollectedPath(deps.cwd, contextFile);
-  const { files } = await deps.collectRunFiles([filePath]);
-  const check = checkSnippetFiles(files, filePath);
-  if (check.type !== "ok") {
-    return { error: describeRunFilesCheck(check), ok: false };
-  }
-  return { filePath, files, ok: true };
-}
 
 async function readCode(
   source: string,
@@ -87,7 +57,7 @@ export async function handleRunnerExec(
   const code = await readCode(options.source, deps);
   if (!code.ok) return { error: code.error, exitCode: exitCodes.invalidArgs };
 
-  const scope = await resolveScope(options.contextFile, deps);
+  const scope = await resolveSnippetScope(options.contextFile, deps);
   if (!scope.ok) return { error: scope.error, exitCode: exitCodes.invalidArgs };
 
   const resolved = await resolveRunner(

--- a/src/domains/interactiveRunner/list.ts
+++ b/src/domains/interactiveRunner/list.ts
@@ -6,6 +6,7 @@ import { type TableColumn, renderTable } from "~/core/renderTable.js";
 import type {
   AuthCommandContext,
   CommandResult,
+  RunnerApiContext,
 } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 import {
@@ -23,6 +24,10 @@ type RunnerListItem = {
   isDefault: boolean;
   runnerName: string | undefined;
 };
+
+export type ListedRunners =
+  | { items: RunnerListItem[]; ok: true }
+  | ({ ok: false } & PlatformFailure);
 
 const columns: readonly TableColumn<RunnerListItem>[] = [
   { header: "id", value: (row) => row.id },
@@ -55,7 +60,7 @@ async function readCandidates(deps: InteractiveRunnerDeps): Promise<{
 }
 
 async function probeRunner(
-  ctx: AuthCommandContext,
+  ctx: RunnerApiContext,
   runner: StoredRunner,
 ): Promise<Probe> {
   const result = await ctx.platformClient.callPublicApi(
@@ -67,10 +72,10 @@ async function probeRunner(
   return { ok: true, runner, running: result.value.running };
 }
 
-export async function handleRunnerList(
-  ctx: AuthCommandContext,
+export async function listRunners(
+  ctx: RunnerApiContext,
   deps: InteractiveRunnerDeps,
-): Promise<CommandResult> {
+): Promise<ListedRunners> {
   const { candidates, defaultRunnerId } = await readCandidates(deps);
 
   const running: StoredRunner[] = [];
@@ -80,23 +85,35 @@ export async function handleRunnerList(
     (runner) => probeRunner(ctx, runner),
     probeBatchSize,
   )) {
-    if (!probe.ok) {
-      return { ...failureFields(probe), exitCode: exitCodes.network };
-    }
+    if (!probe.ok) return { ...failureFields(probe), ok: false };
     if (probe.running) running.push(probe.runner);
     else gone.push(probe.runner.id);
   }
 
   await deps.store.dropRunners(gone).catch(() => undefined);
 
-  const items: RunnerListItem[] = [
-    ...running.filter((runner) => runner.id === defaultRunnerId),
-    ...running.filter((runner) => runner.id !== defaultRunnerId),
-  ].map((runner) => ({
-    id: runner.id,
-    isDefault: runner.id === defaultRunnerId,
-    runnerName: runner.runnerName,
-  }));
+  return {
+    items: [
+      ...running.filter((runner) => runner.id === defaultRunnerId),
+      ...running.filter((runner) => runner.id !== defaultRunnerId),
+    ].map((runner) => ({
+      id: runner.id,
+      isDefault: runner.id === defaultRunnerId,
+      runnerName: runner.runnerName,
+    })),
+    ok: true,
+  };
+}
+
+export async function handleRunnerList(
+  ctx: AuthCommandContext,
+  deps: InteractiveRunnerDeps,
+): Promise<CommandResult> {
+  const listed = await listRunners(ctx, deps);
+  if (!listed.ok) {
+    return { ...failureFields(listed), exitCode: exitCodes.network };
+  }
+  const items = listed.items;
 
   if (ctx.ui.mode === "json") {
     ctx.ui.json(items);

--- a/src/domains/interactiveRunner/readJournal.ts
+++ b/src/domains/interactiveRunner/readJournal.ts
@@ -1,7 +1,7 @@
 import { type JournalEntry, publicContractsV1 } from "@qawolf/api-contracts/v1";
 
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
-import type { AuthCommandContext } from "~/shell/commandContext.js";
+import type { RunnerApiContext } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
@@ -52,7 +52,7 @@ export const unreachableFailure = {
 
 /** One window of one stream. */
 export async function readJournal(
-  ctx: AuthCommandContext,
+  ctx: RunnerApiContext,
   runnerId: string,
   request: JournalRequest,
 ): Promise<JournalReadResult> {

--- a/src/domains/interactiveRunner/sendRunFlowRequest.ts
+++ b/src/domains/interactiveRunner/sendRunFlowRequest.ts
@@ -5,7 +5,7 @@ import {
 } from "@qawolf/api-contracts/v1";
 
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
-import type { AuthCommandContext } from "~/shell/commandContext.js";
+import type { RunnerApiContext } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
@@ -24,7 +24,7 @@ export type SendResult =
   | { type: "failed"; failure: RunSubmitRefusal };
 
 export async function sendRunFlowRequest(
-  ctx: AuthCommandContext,
+  ctx: RunnerApiContext,
   options: {
     entryPointPath: string;
     environment: Record<string, string> | undefined;

--- a/src/domains/interactiveRunner/snippetScope.ts
+++ b/src/domains/interactiveRunner/snippetScope.ts
@@ -1,0 +1,35 @@
+import type { RunFiles } from "@qawolf/api-contracts/v1";
+
+import {
+  checkSnippetFiles,
+  describeRunFilesCheck,
+  toCollectedPath,
+} from "~/core/interactiveRunner/runFiles.js";
+
+import type { InteractiveRunnerDeps } from "./deps.js";
+
+export type SnippetScope =
+  | { ok: true; filePath: string | undefined; files: RunFiles | undefined }
+  | { ok: false; error: string };
+
+/**
+ * The scope a snippet is evaluated in. A runner holds no copy of the project, so
+ * a snippet that touches the caller's own modules has to carry them: the named
+ * file and everything the collector found beside it. Without `--file` the snippet
+ * imports nothing of the caller's and nothing travels.
+ */
+export async function resolveSnippetScope(
+  contextFile: string | undefined,
+  deps: Pick<InteractiveRunnerDeps, "collectRunFiles" | "cwd">,
+): Promise<SnippetScope> {
+  if (contextFile === undefined) {
+    return { filePath: undefined, files: undefined, ok: true };
+  }
+  const filePath = toCollectedPath(deps.cwd, contextFile);
+  const { files } = await deps.collectRunFiles([filePath]);
+  const check = checkSnippetFiles(files, filePath);
+  if (check.type !== "ok") {
+    return { error: describeRunFilesCheck(check), ok: false };
+  }
+  return { filePath, files, ok: true };
+}

--- a/src/domains/interactiveRunner/submitRun.ts
+++ b/src/domains/interactiveRunner/submitRun.ts
@@ -5,7 +5,7 @@ import {
   toRunFilesManifest,
 } from "~/core/interactiveRunner/fileDelta.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
-import type { AuthCommandContext } from "~/shell/commandContext.js";
+import type { RunnerApiContext } from "~/shell/commandContext.js";
 import { exitCodes } from "~/shell/exit.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
@@ -27,7 +27,7 @@ export type SubmittedRun =
 type Runner = Extract<ResolvedRunner, { type: "launched" | "resolved" }>;
 
 export async function submitRun(
-  ctx: AuthCommandContext,
+  ctx: RunnerApiContext,
   options: {
     entryPointPath: string;
     environment: Record<string, string> | undefined;

--- a/src/runnerSdk/createContext.ts
+++ b/src/runnerSdk/createContext.ts
@@ -1,0 +1,36 @@
+import { makeInteractiveRunnerDeps } from "~/domains/interactiveRunner/deps.js";
+import type { InteractiveRunnerDeps } from "~/domains/interactiveRunner/deps.js";
+import { makeDefaultFs } from "~/shell/fs.js";
+import type { Fs } from "~/shell/fs.js";
+import type { Logger } from "~/shell/logger.js";
+import { createPlatformClient } from "~/shell/platform/createPlatformClient.js";
+import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
+import { resolveHostUrl } from "~/shell/resolveHostUrl.js";
+
+import type { RunnerSdkOptions } from "./types.js";
+
+export type SdkContextOptions = RunnerSdkOptions & {
+  fs?: Fs | undefined;
+  logger?: Logger | undefined;
+};
+
+export type SdkContext = {
+  deps: InteractiveRunnerDeps;
+  platformClient: PlatformClient;
+};
+
+export function createSdkContext(options: SdkContextOptions): SdkContext {
+  const cwd = options.cwd ?? process.cwd();
+  const fs = options.fs ?? makeDefaultFs();
+  const baseUrl = options.baseUrl ?? resolveHostUrl(process.env);
+
+  return {
+    deps: makeInteractiveRunnerDeps({ cwd, env: process.env, fs }),
+    platformClient: createPlatformClient(options.apiKey, {
+      baseUrl,
+      fetch: options.fetch ?? globalThis.fetch,
+      fs,
+      ...(options.logger ? { logger: options.logger } : {}),
+    }),
+  };
+}

--- a/src/runnerSdk/index.ts
+++ b/src/runnerSdk/index.ts
@@ -3,6 +3,7 @@ import { listRunners } from "~/domains/interactiveRunner/list.js";
 import { createSdkContext } from "./createContext.js";
 import { createLifecycleVerbs } from "./lifecycleVerbs.js";
 import { createPageVerbs } from "./pageVerbs.js";
+import { createProjectVerbs } from "./projectVerbs.js";
 import { createRunVerbs } from "./runVerbs.js";
 import type { ListedRunner, RunnerSdkOptions, SdkResult } from "./types.js";
 
@@ -59,6 +60,7 @@ export function createRunnerSdk(options: RunnerSdkOptions) {
     ...createLifecycleVerbs(context),
     ...createRunVerbs(context),
     ...createPageVerbs(context),
+    ...createProjectVerbs(context),
 
     async list(): Promise<SdkResult<ListedRunner[]>> {
       const listed = await listRunners(context, context.deps);

--- a/src/runnerSdk/index.ts
+++ b/src/runnerSdk/index.ts
@@ -1,0 +1,70 @@
+import { listRunners } from "~/domains/interactiveRunner/list.js";
+
+import { createSdkContext } from "./createContext.js";
+import { createLifecycleVerbs } from "./lifecycleVerbs.js";
+import { createPageVerbs } from "./pageVerbs.js";
+import { createRunVerbs } from "./runVerbs.js";
+import type { ListedRunner, RunnerSdkOptions, SdkResult } from "./types.js";
+
+export type {
+  ActRequest,
+  EvaluateSnippetRequest,
+  EvaluatedSnippet,
+  EventsRequest,
+  FileSync,
+  HighlightRequest,
+  HighlightSelectorRequest,
+  HighlightedSelector,
+  ImportPackageRequest,
+  ImportedPackage,
+  InspectRequest,
+  Inspected,
+  Journal,
+  JournalWindow,
+  KeptAlive,
+  LaunchRequest,
+  LaunchedRunner,
+  LinesLocation,
+  ListedRunner,
+  PackageVersion,
+  PerformedAction,
+  PromoteSnapshotRequest,
+  PromotedSnapshot,
+  RunEnvironment,
+  RunFilter,
+  RunRequest,
+  RunSelection,
+  RunnerFamily,
+  RunnerRequest,
+  RunnerSdkOptions,
+  Screenshot,
+  SdkResult,
+  SnippetScope,
+  StoppedRun,
+  SubmittedRun,
+  TerminatedRunner,
+} from "./types.js";
+
+export type RunnerSdk = ReturnType<typeof createRunnerSdk>;
+
+/**
+ * Drives interactive runners on the caller's team through the QA Wolf public
+ * API. Every verb names the runner it addresses, so nothing is launched or
+ * billed implicitly: call `launch` for that.
+ */
+export function createRunnerSdk(options: RunnerSdkOptions) {
+  const context = createSdkContext(options);
+
+  return {
+    ...createLifecycleVerbs(context),
+    ...createRunVerbs(context),
+    ...createPageVerbs(context),
+
+    async list(): Promise<SdkResult<ListedRunner[]>> {
+      const listed = await listRunners(context, context.deps);
+      return listed.ok
+        ? { ok: true, value: listed.items }
+        : { error: listed.error, ok: false };
+    },
+  };
+}

--- a/src/runnerSdk/lifecycleVerbs.ts
+++ b/src/runnerSdk/lifecycleVerbs.ts
@@ -1,0 +1,74 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+
+import { runnerCallOptions } from "~/domains/interactiveRunner/runnerCallOptions.js";
+
+import type { SdkContext } from "./createContext.js";
+import { toSdkResult } from "./toSdkResult.js";
+import type {
+  KeptAlive,
+  LaunchRequest,
+  LaunchedRunner,
+  RunnerRequest,
+  SdkResult,
+  StoppedRun,
+  TerminatedRunner,
+} from "./types.js";
+
+const { launch, readJournal, stopRun, terminate } = publicContractsV1.runner;
+
+export function createLifecycleVerbs({ platformClient }: SdkContext) {
+  return {
+    async keepalive({
+      runnerId,
+    }: RunnerRequest): Promise<SdkResult<KeptAlive>> {
+      const read = await platformClient.callPublicApi(
+        readJournal,
+        { id: runnerId, stream: "run-status", tail: 1 },
+        runnerCallOptions,
+      );
+      return read.ok
+        ? { ok: true, value: { id: runnerId } }
+        : { error: read.error, ok: false };
+    },
+
+    async launch({
+      id,
+      runnerFamily,
+    }: LaunchRequest): Promise<SdkResult<LaunchedRunner>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          launch,
+          {
+            id,
+            ...(runnerFamily === "default"
+              ? {}
+              : { runnerName: runnerFamily.name }),
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async stopRun({ runnerId }: RunnerRequest): Promise<SdkResult<StoppedRun>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          stopRun,
+          { id: runnerId },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async terminate({
+      runnerId,
+    }: RunnerRequest): Promise<SdkResult<TerminatedRunner>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          terminate,
+          { id: runnerId },
+          runnerCallOptions,
+        ),
+      );
+    },
+  };
+}

--- a/src/runnerSdk/lifecycleVerbs.ts
+++ b/src/runnerSdk/lifecycleVerbs.ts
@@ -1,5 +1,6 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
+import { readJournal } from "~/domains/interactiveRunner/readJournal.js";
 import { runnerCallOptions } from "~/domains/interactiveRunner/runnerCallOptions.js";
 
 import type { SdkContext } from "./createContext.js";
@@ -14,21 +15,28 @@ import type {
   TerminatedRunner,
 } from "./types.js";
 
-const { launch, readJournal, stopRun, terminate } = publicContractsV1.runner;
+const { launch, stopRun, terminate } = publicContractsV1.runner;
 
 export function createLifecycleVerbs({ platformClient }: SdkContext) {
+  const ctx = { platformClient };
+
   return {
     async keepalive({
       runnerId,
     }: RunnerRequest): Promise<SdkResult<KeptAlive>> {
-      const read = await platformClient.callPublicApi(
-        readJournal,
-        { id: runnerId, stream: "run-status", tail: 1 },
-        runnerCallOptions,
-      );
-      return read.ok
-        ? { ok: true, value: { id: runnerId } }
-        : { error: read.error, ok: false };
+      const read = await readJournal(ctx, runnerId, {
+        stream: "run-status",
+        tail: 1,
+      });
+
+      if (read.type === "read") return { ok: true, value: { id: runnerId } };
+      return {
+        error:
+          read.type === "unreachable"
+            ? "The runner could not be reached."
+            : read.error,
+        ok: false,
+      };
     },
 
     async launch({

--- a/src/runnerSdk/pageVerbs.ts
+++ b/src/runnerSdk/pageVerbs.ts
@@ -6,12 +6,8 @@ import type { SdkContext } from "./createContext.js";
 import { toSdkResult } from "./toSdkResult.js";
 import type {
   ActRequest,
-  EvaluateSnippetRequest,
-  EvaluatedSnippet,
   HighlightSelectorRequest,
   HighlightedSelector,
-  ImportPackageRequest,
-  ImportedPackage,
   InspectRequest,
   Inspected,
   PerformedAction,
@@ -23,9 +19,7 @@ import type {
 } from "./types.js";
 
 const {
-  evaluateSnippet,
   highlightSelector,
-  importPackage,
   inspect,
   performAction,
   promoteSnapshot,
@@ -47,24 +41,6 @@ export function createPageVerbs({ platformClient }: SdkContext) {
       );
     },
 
-    async evaluateSnippet({
-      runnerId,
-      scope,
-      source,
-    }: EvaluateSnippetRequest): Promise<SdkResult<EvaluatedSnippet>> {
-      return toSdkResult(
-        await platformClient.callPublicApi(
-          evaluateSnippet,
-          {
-            code: source,
-            id: runnerId,
-            ...(scope === "no-imports" ? {} : { filePath: scope.filePath }),
-          },
-          runnerCallOptions,
-        ),
-      );
-    },
-
     async highlightSelector({
       highlight,
       runnerId,
@@ -75,25 +51,6 @@ export function createPageVerbs({ platformClient }: SdkContext) {
           {
             id: runnerId,
             selector: highlight === "clear" ? "" : highlight.selector,
-          },
-          runnerCallOptions,
-        ),
-      );
-    },
-
-    async importPackage({
-      name,
-      runnerId,
-      version,
-    }: ImportPackageRequest): Promise<SdkResult<ImportedPackage>> {
-      return toSdkResult(
-        await platformClient.callPublicApi(
-          importPackage,
-          {
-            id: runnerId,
-            npmDependencies: {},
-            packageName: name,
-            packageVersion: version === "latest" ? "latest" : version.exact,
           },
           runnerCallOptions,
         ),

--- a/src/runnerSdk/pageVerbs.ts
+++ b/src/runnerSdk/pageVerbs.ts
@@ -1,0 +1,142 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+
+import { runnerCallOptions } from "~/domains/interactiveRunner/runnerCallOptions.js";
+
+import type { SdkContext } from "./createContext.js";
+import { toSdkResult } from "./toSdkResult.js";
+import type {
+  ActRequest,
+  EvaluateSnippetRequest,
+  EvaluatedSnippet,
+  HighlightSelectorRequest,
+  HighlightedSelector,
+  ImportPackageRequest,
+  ImportedPackage,
+  InspectRequest,
+  Inspected,
+  PerformedAction,
+  PromoteSnapshotRequest,
+  PromotedSnapshot,
+  RunnerRequest,
+  Screenshot,
+  SdkResult,
+} from "./types.js";
+
+const {
+  evaluateSnippet,
+  highlightSelector,
+  importPackage,
+  inspect,
+  performAction,
+  promoteSnapshot,
+  takeScreenshot,
+} = publicContractsV1.runner;
+
+export function createPageVerbs({ platformClient }: SdkContext) {
+  return {
+    async act({
+      action,
+      runnerId,
+    }: ActRequest): Promise<SdkResult<PerformedAction>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          performAction,
+          { action, id: runnerId },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async evaluateSnippet({
+      runnerId,
+      scope,
+      source,
+    }: EvaluateSnippetRequest): Promise<SdkResult<EvaluatedSnippet>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          evaluateSnippet,
+          {
+            code: source,
+            id: runnerId,
+            ...(scope === "no-imports" ? {} : { filePath: scope.filePath }),
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async highlightSelector({
+      highlight,
+      runnerId,
+    }: HighlightSelectorRequest): Promise<SdkResult<HighlightedSelector>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          highlightSelector,
+          {
+            id: runnerId,
+            selector: highlight === "clear" ? "" : highlight.selector,
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async importPackage({
+      name,
+      runnerId,
+      version,
+    }: ImportPackageRequest): Promise<SdkResult<ImportedPackage>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          importPackage,
+          {
+            id: runnerId,
+            npmDependencies: {},
+            packageName: name,
+            packageVersion: version === "latest" ? "latest" : version.exact,
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async inspect({
+      request,
+      runnerId,
+    }: InspectRequest): Promise<SdkResult<Inspected>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          inspect,
+          { id: runnerId, request },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async promoteSnapshot({
+      baselinePath,
+      runnerId,
+      screenshotPath,
+    }: PromoteSnapshotRequest): Promise<SdkResult<PromotedSnapshot>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          promoteSnapshot,
+          { baselinePath, id: runnerId, screenshotPath },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async screenshot({
+      runnerId,
+    }: RunnerRequest): Promise<SdkResult<Screenshot>> {
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          takeScreenshot,
+          { id: runnerId },
+          runnerCallOptions,
+        ),
+      );
+    },
+  };
+}

--- a/src/runnerSdk/projectVerbs.ts
+++ b/src/runnerSdk/projectVerbs.ts
@@ -1,0 +1,88 @@
+import {
+  publicContractsV1,
+  runPackageJsonPath,
+} from "@qawolf/api-contracts/v1";
+import { join } from "node:path";
+
+import { readNpmDependencies } from "~/core/interactiveRunner/npmDependencies.js";
+import { runnerCallOptions } from "~/domains/interactiveRunner/runnerCallOptions.js";
+import { resolveSnippetScope } from "~/domains/interactiveRunner/snippetScope.js";
+
+import type { SdkContext } from "./createContext.js";
+import { toSdkResult } from "./toSdkResult.js";
+import type {
+  EvaluateSnippetRequest,
+  EvaluatedSnippet,
+  ImportPackageRequest,
+  ImportedPackage,
+  SdkResult,
+} from "./types.js";
+
+const { evaluateSnippet, importPackage } = publicContractsV1.runner;
+
+export function createProjectVerbs({ deps, platformClient }: SdkContext) {
+  return {
+    async evaluateSnippet({
+      runnerId,
+      scope,
+      source,
+    }: EvaluateSnippetRequest): Promise<SdkResult<EvaluatedSnippet>> {
+      const resolved = await resolveSnippetScope(
+        scope === "no-imports" ? undefined : scope.filePath,
+        deps,
+      );
+      if (!resolved.ok) return { error: resolved.error, ok: false };
+
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          evaluateSnippet,
+          {
+            code: source,
+            id: runnerId,
+            ...(resolved.filePath === undefined
+              ? {}
+              : { filePath: resolved.filePath }),
+            ...(resolved.files === undefined ? {} : { files: resolved.files }),
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+
+    async importPackage({
+      name,
+      runnerId,
+      version,
+    }: ImportPackageRequest): Promise<SdkResult<ImportedPackage>> {
+      const content = await deps
+        .readFile(join(deps.cwd, runPackageJsonPath))
+        .catch(() => undefined);
+      if (content === undefined) {
+        return {
+          error: `No ${runPackageJsonPath} to install into.`,
+          ok: false,
+        };
+      }
+      const dependencies = readNpmDependencies(content);
+      if (!dependencies.ok) {
+        return {
+          error: `${runPackageJsonPath} could not be read: ${dependencies.reason}.`,
+          ok: false,
+        };
+      }
+
+      return toSdkResult(
+        await platformClient.callPublicApi(
+          importPackage,
+          {
+            id: runnerId,
+            npmDependencies: dependencies.dependencies,
+            packageName: name,
+            packageVersion: version === "latest" ? "latest" : version.exact,
+          },
+          runnerCallOptions,
+        ),
+      );
+    },
+  };
+}

--- a/src/runnerSdk/runVerbs.ts
+++ b/src/runnerSdk/runVerbs.ts
@@ -1,0 +1,99 @@
+import { prepareRun } from "~/domains/interactiveRunner/prepareRun.js";
+import { readJournal } from "~/domains/interactiveRunner/readJournal.js";
+import { submitRun } from "~/domains/interactiveRunner/submitRun.js";
+
+import type { SdkContext } from "./createContext.js";
+import type {
+  EventsRequest,
+  Journal,
+  RunRequest,
+  RunSelection,
+  SdkResult,
+  SubmittedRun,
+} from "./types.js";
+
+function toLineRange(selection: RunSelection): string | undefined {
+  return selection === "whole-flow"
+    ? undefined
+    : `${selection.startLine}-${selection.endLine}`;
+}
+
+function toLinesFile(selection: RunSelection): string | undefined {
+  if (selection === "whole-flow" || selection.linesIn === "entry-point")
+    return undefined;
+  return selection.linesIn.filePath;
+}
+
+export function createRunVerbs({ deps, platformClient }: SdkContext) {
+  const ctx = { platformClient };
+
+  return {
+    async events({
+      runFilter,
+      runnerId,
+      stream,
+      window,
+    }: EventsRequest): Promise<SdkResult<Journal>> {
+      const read = await readJournal(ctx, runnerId, {
+        stream,
+        ...(runFilter === "all-runs" ? {} : { runId: runFilter.runId }),
+        ...(window === "newest"
+          ? {}
+          : "tail" in window
+            ? { tail: window.tail }
+            : { sinceSequence: window.sinceSequence }),
+      });
+
+      if (read.type === "read") return { ok: true, value: read.value };
+      return {
+        error:
+          read.type === "unreachable"
+            ? "The runner could not be reached."
+            : read.error,
+        ok: false,
+      };
+    },
+
+    async run({
+      entryPointPath,
+      environment,
+      runnerId,
+      selection,
+    }: RunRequest): Promise<SdkResult<SubmittedRun>> {
+      const prepared = await prepareRun(
+        {
+          entryPointPath,
+          envFile: undefined,
+          envId: environment === "ambient" ? undefined : environment.id,
+          lines: toLineRange(selection),
+          linesFile: toLinesFile(selection),
+        },
+        deps,
+      );
+      if (!prepared.ok) return { error: prepared.error, ok: false };
+
+      const submitted = await submitRun(
+        ctx,
+        {
+          entryPointPath,
+          environment: prepared.environment,
+          environmentId: prepared.environmentId,
+          files: prepared.files,
+          resolved: { runnerId, type: "resolved" },
+          selection: prepared.selection,
+        },
+        deps,
+      );
+      if (!submitted.ok) return { error: submitted.error, ok: false };
+
+      return {
+        ok: true,
+        value: {
+          bootstrappedRunner: submitted.bootstrappedRunner,
+          fileSync: submitted.fileSync,
+          runId: submitted.runId,
+        },
+      };
+    },
+  };
+}

--- a/src/runnerSdk/toSdkResult.ts
+++ b/src/runnerSdk/toSdkResult.ts
@@ -1,0 +1,11 @@
+import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
+
+import type { SdkResult } from "./types.js";
+
+export function toSdkResult<Value>(
+  result: PlatformResult<Value>,
+): SdkResult<Value> {
+  return result.ok
+    ? { ok: true, value: result.value }
+    : { error: result.error, ok: false };
+}

--- a/src/runnerSdk/types.ts
+++ b/src/runnerSdk/types.ts
@@ -1,0 +1,125 @@
+import type {
+  BrowserAction,
+  InspectOnRunnerRequest,
+  JournalStream,
+  PublicApiOutput,
+  ReadJournalResponse,
+  RunnerNameForPublicApi,
+  publicContractsV1,
+} from "@qawolf/api-contracts/v1";
+
+type Runner = typeof publicContractsV1.runner;
+
+export type RunnerSdkOptions = {
+  /** A QA Wolf team API key. The SDK never reads the CLI's stored credentials. */
+  apiKey: string;
+  /** Defaults to `QAWOLF_HOST_URL`, then `https://app.qawolf.com`. */
+  baseUrl?: string | undefined;
+  /** Where a run collects its files from. Defaults to `process.cwd()`. */
+  cwd?: string | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+};
+
+export type SdkResult<Value> =
+  | { error: string; ok: false }
+  | { ok: true; value: Value };
+
+export type RunSelection =
+  | "whole-flow"
+  | { endLine: number; linesIn: LinesLocation; startLine: number };
+
+export type LinesLocation = "entry-point" | { filePath: string };
+
+export type RunEnvironment = "ambient" | { id: string };
+
+export type SnippetScope = "no-imports" | { filePath: string };
+
+export type HighlightRequest = "clear" | { selector: string };
+
+export type PackageVersion = "latest" | { exact: string };
+
+export type RunnerFamily = "default" | { name: RunnerNameForPublicApi };
+
+export type JournalWindow =
+  | "newest"
+  | { sinceSequence: number }
+  | { tail: number };
+
+export type RunFilter = "all-runs" | { runId: string };
+
+export type LaunchRequest = { id: string; runnerFamily: RunnerFamily };
+
+export type RunnerRequest = { runnerId: string };
+
+export type RunRequest = RunnerRequest & {
+  entryPointPath: string;
+  environment: RunEnvironment;
+  selection: RunSelection;
+};
+
+export type EventsRequest = RunnerRequest & {
+  runFilter: RunFilter;
+  stream: JournalStream;
+  window: JournalWindow;
+};
+
+export type ActRequest = RunnerRequest & { action: BrowserAction };
+
+export type EvaluateSnippetRequest = RunnerRequest & {
+  scope: SnippetScope;
+  source: string;
+};
+
+export type InspectRequest = RunnerRequest & {
+  request: InspectOnRunnerRequest;
+};
+
+export type ImportPackageRequest = RunnerRequest & {
+  name: string;
+  version: PackageVersion;
+};
+
+export type HighlightSelectorRequest = RunnerRequest & {
+  highlight: HighlightRequest;
+};
+
+export type PromoteSnapshotRequest = RunnerRequest & {
+  baselinePath: string;
+  screenshotPath: string;
+};
+
+export type LaunchedRunner = PublicApiOutput<Runner["launch"]>;
+export type TerminatedRunner = PublicApiOutput<Runner["terminate"]>;
+export type StoppedRun = PublicApiOutput<Runner["stopRun"]>;
+export type Screenshot = PublicApiOutput<Runner["takeScreenshot"]>;
+export type PerformedAction = PublicApiOutput<Runner["performAction"]>;
+export type EvaluatedSnippet = PublicApiOutput<Runner["evaluateSnippet"]>;
+export type Inspected = PublicApiOutput<Runner["inspect"]>;
+export type ImportedPackage = PublicApiOutput<Runner["importPackage"]>;
+export type HighlightedSelector = PublicApiOutput<Runner["highlightSelector"]>;
+export type PromotedSnapshot = PublicApiOutput<Runner["promoteSnapshot"]>;
+
+/** A journal window, as the public API answers it. */
+export type Journal = ReadJournalResponse;
+
+/** The CLI's own answer: the file set it sent whole, or only what changed. */
+export type FileSync = "delta" | "full";
+
+/**
+ * `fileSync` and `bootstrappedRunner` are the CLI's own, so this is not the
+ * `runner.runFlow` output verbatim.
+ */
+export type SubmittedRun = {
+  bootstrappedRunner: boolean;
+  fileSync: FileSync;
+  runId: string;
+};
+
+/** Runners this working directory launched, which the API has no notion of. */
+export type ListedRunner = {
+  id: string;
+  isDefault: boolean;
+  runnerName: string | undefined;
+};
+
+export type KeptAlive = { id: string };

--- a/src/runnerSdk/verbs.test.ts
+++ b/src/runnerSdk/verbs.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+
+import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
+
+import type { SdkContext } from "./createContext.js";
+import { createLifecycleVerbs } from "./lifecycleVerbs.js";
+import { createPageVerbs } from "./pageVerbs.js";
+
+type Sent = { input: unknown; name: string };
+
+function makeContext(answer: unknown = { outcome: "success" }) {
+  const sent: Sent[] = [];
+  const platformClient = {
+    callPublicApi: async (contract: { name: string }, input: unknown) => {
+      sent.push({ input, name: contract.name });
+      return { ok: true as const, value: answer };
+    },
+  } as unknown as PlatformClient;
+
+  const context = { deps: {}, platformClient } as unknown as SdkContext;
+  return {
+    lifecycle: createLifecycleVerbs(context),
+    page: createPageVerbs(context),
+    sent,
+  };
+}
+
+describe("the input each verb sends", () => {
+  it("names the runner family only when one is chosen", async () => {
+    const { lifecycle, sent } = makeContext();
+
+    await lifecycle.launch({ id: "agent-1", runnerFamily: "default" });
+    await lifecycle.launch({
+      id: "agent-1",
+      runnerFamily: { name: "playwright" },
+    });
+
+    expect(sent[0]).toEqual({
+      input: { id: "agent-1" },
+      name: "runner.launch",
+    });
+    expect(sent[1]?.input).toEqual({ id: "agent-1", runnerName: "playwright" });
+  });
+
+  it("keeps a runner alive with a one-entry journal read", async () => {
+    const { lifecycle, sent } = makeContext();
+
+    await lifecycle.keepalive({ runnerId: "agent-1" });
+
+    expect(sent[0]).toEqual({
+      input: { id: "agent-1", stream: "run-status", tail: 1 },
+      name: "runner.readJournal",
+    });
+  });
+
+  it("sends an empty selector to clear a highlight", async () => {
+    const { page, sent } = makeContext();
+
+    await page.highlightSelector({ highlight: "clear", runnerId: "agent-1" });
+    await page.highlightSelector({
+      highlight: { selector: "text=Sign in" },
+      runnerId: "agent-1",
+    });
+
+    expect(sent[0]?.input).toEqual({ id: "agent-1", selector: "" });
+    expect(sent[1]?.input).toEqual({
+      id: "agent-1",
+      selector: "text=Sign in",
+    });
+  });
+
+  it("scopes a snippet to a file only when one is named", async () => {
+    const { page, sent } = makeContext();
+
+    await page.evaluateSnippet({
+      runnerId: "agent-1",
+      scope: "no-imports",
+      source: "1",
+    });
+    await page.evaluateSnippet({
+      runnerId: "agent-1",
+      scope: { filePath: "src/pages/login.ts" },
+      source: "1",
+    });
+
+    expect(sent[0]?.input).toEqual({ code: "1", id: "agent-1" });
+    expect(sent[1]?.input).toEqual({
+      code: "1",
+      filePath: "src/pages/login.ts",
+      id: "agent-1",
+    });
+  });
+
+  it("resolves latest rather than sending a version the caller did not pick", async () => {
+    const { page, sent } = makeContext();
+
+    await page.importPackage({
+      name: "dayjs",
+      runnerId: "agent-1",
+      version: "latest",
+    });
+    await page.importPackage({
+      name: "dayjs",
+      runnerId: "agent-1",
+      version: { exact: "1.11.13" },
+    });
+
+    expect(sent[0]?.input).toMatchObject({ packageVersion: "latest" });
+    expect(sent[1]?.input).toMatchObject({ packageVersion: "1.11.13" });
+  });
+});
+
+describe("what a caller gets back", () => {
+  it("hands the runner's own refusal back rather than throwing", async () => {
+    const { lifecycle } = makeContext({
+      failureReason: "runner-unreachable",
+      outcome: "failure",
+    });
+
+    const answer = await lifecycle.stopRun({ runnerId: "agent-1" });
+
+    expect(answer.ok).toBe(true);
+    if (!answer.ok) return;
+    expect(answer.value.outcome).toBe("failure");
+  });
+
+  it("carries no exit code on a transport failure", async () => {
+    const platformClient = {
+      callPublicApi: async () => ({
+        error: "The request failed.",
+        exitCode: 4,
+        ok: false as const,
+      }),
+    } as unknown as PlatformClient;
+    const { terminate } = createLifecycleVerbs({
+      deps: {},
+      platformClient,
+    } as unknown as SdkContext);
+
+    const answer = await terminate({ runnerId: "agent-1" });
+
+    expect(answer).toEqual({ error: "The request failed.", ok: false });
+  });
+});

--- a/src/runnerSdk/verbs.test.ts
+++ b/src/runnerSdk/verbs.test.ts
@@ -118,6 +118,19 @@ describe("what a caller gets back", () => {
     expect(answer.value.outcome).toBe("failure");
   });
 
+  // The clock could not be reset because there is no runner to reset, so a
+  // caller must not read this as the runner still being there.
+  it("reports an unreachable runner as a failed keepalive", async () => {
+    const { lifecycle } = makeContext({
+      failureReason: "runner-unreachable",
+      outcome: "failure",
+    });
+
+    const answer = await lifecycle.keepalive({ runnerId: "agent-1" });
+
+    expect(answer.ok).toBe(false);
+  });
+
   it("carries no exit code on a transport failure", async () => {
     const platformClient = {
       callPublicApi: async () => ({

--- a/src/runnerSdk/verbs.test.ts
+++ b/src/runnerSdk/verbs.test.ts
@@ -5,8 +5,19 @@ import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
 import type { SdkContext } from "./createContext.js";
 import { createLifecycleVerbs } from "./lifecycleVerbs.js";
 import { createPageVerbs } from "./pageVerbs.js";
+import { createProjectVerbs } from "./projectVerbs.js";
 
 type Sent = { input: unknown; name: string };
+
+const packageJson = JSON.stringify({
+  dependencies: { dayjs: "1.11.13" },
+  devDependencies: { typescript: "5.9.3" },
+});
+
+const scopeFiles = {
+  "src/pages/helper.ts": "export const helper = 2;",
+  "src/pages/login.ts": "export const login = 1;",
+};
 
 function makeContext(answer: unknown = { outcome: "success" }) {
   const sent: Sent[] = [];
@@ -17,10 +28,15 @@ function makeContext(answer: unknown = { outcome: "success" }) {
     },
   } as unknown as PlatformClient;
 
-  const context = { deps: {}, platformClient } as unknown as SdkContext;
+  const deps = {
+    collectRunFiles: async () => ({ files: scopeFiles }),
+    cwd: "/workspace",
+    readFile: async () => packageJson,
+  };
+  const context = { deps, platformClient } as unknown as SdkContext;
   return {
     lifecycle: createLifecycleVerbs(context),
-    page: createPageVerbs(context),
+    page: { ...createPageVerbs(context), ...createProjectVerbs(context) },
     sent,
   };
 }
@@ -66,28 +82,6 @@ describe("the input each verb sends", () => {
     expect(sent[1]?.input).toEqual({
       id: "agent-1",
       selector: "text=Sign in",
-    });
-  });
-
-  it("scopes a snippet to a file only when one is named", async () => {
-    const { page, sent } = makeContext();
-
-    await page.evaluateSnippet({
-      runnerId: "agent-1",
-      scope: "no-imports",
-      source: "1",
-    });
-    await page.evaluateSnippet({
-      runnerId: "agent-1",
-      scope: { filePath: "src/pages/login.ts" },
-      source: "1",
-    });
-
-    expect(sent[0]?.input).toEqual({ code: "1", id: "agent-1" });
-    expect(sent[1]?.input).toEqual({
-      code: "1",
-      filePath: "src/pages/login.ts",
-      id: "agent-1",
     });
   });
 
@@ -140,5 +134,78 @@ describe("what a caller gets back", () => {
     const answer = await terminate({ runnerId: "agent-1" });
 
     expect(answer).toEqual({ error: "The request failed.", ok: false });
+  });
+});
+
+describe("what the CLI sends that a hand-written input would miss", () => {
+  it("resolves the project's npm dependencies rather than sending none", async () => {
+    const { page, sent } = makeContext();
+
+    await page.importPackage({
+      name: "dayjs",
+      runnerId: "agent-1",
+      version: "latest",
+    });
+
+    expect(sent[0]?.input).toMatchObject({
+      npmDependencies: { dayjs: "1.11.13", typescript: "5.9.3" },
+    });
+  });
+
+  it("refuses rather than installing against nothing when package.json is absent", async () => {
+    const sent: Sent[] = [];
+    const platformClient = {
+      callPublicApi: async (contract: { name: string }, input: unknown) => {
+        sent.push({ input, name: contract.name });
+        return { ok: true as const, value: { outcome: "success" } };
+      },
+    } as unknown as PlatformClient;
+    const { importPackage } = createProjectVerbs({
+      deps: {
+        cwd: "/workspace",
+        readFile: async (): Promise<string> => {
+          throw new Error("ENOENT");
+        },
+      },
+      platformClient,
+    } as unknown as SdkContext);
+
+    const answer = await importPackage({
+      name: "dayjs",
+      runnerId: "agent-1",
+      version: "latest",
+    });
+
+    expect(answer.ok).toBe(false);
+    expect(sent).toEqual([]);
+  });
+
+  // A runner holds no copy of the project, so naming a scope whose files never
+  // arrive is worse than sending no scope at all.
+  it("ships the scope's files alongside its path", async () => {
+    const { page, sent } = makeContext();
+
+    await page.evaluateSnippet({
+      runnerId: "agent-1",
+      scope: { filePath: "src/pages/login.ts" },
+      source: "1",
+    });
+
+    expect(sent[0]?.input).toMatchObject({
+      filePath: "src/pages/login.ts",
+      files: scopeFiles,
+    });
+  });
+
+  it("sends neither a path nor files when the snippet imports nothing", async () => {
+    const { page, sent } = makeContext();
+
+    await page.evaluateSnippet({
+      runnerId: "agent-1",
+      scope: "no-imports",
+      source: "1",
+    });
+
+    expect(sent[0]?.input).toEqual({ code: "1", id: "agent-1" });
   });
 });

--- a/src/shell/commandContext.ts
+++ b/src/shell/commandContext.ts
@@ -21,6 +21,8 @@ export type AuthCommandContext = CommandContext & {
   readonly apiKeySource: string;
 };
 
+export type RunnerApiContext = Pick<AuthCommandContext, "platformClient">;
+
 export type CommandResult = {
   readonly error: string;
   /** Multi-line detail rendered under the error (json mode emits it as `body`). */

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "dist/types",
+    "rootDir": "src"
+  },
+  "include": ["src/runnerSdk"],
+  "exclude": ["**/*.test.ts"]
+}


### PR DESCRIPTION
# Overview of Changes

`tester-session` drives interactive runners by spawning `qawolf runner` and reading stdout, so every request is argv and every answer is parsed text. A renamed flag or a reshaped payload only surfaces at runtime, inside a pod. The CLI already holds a typed value layer under its command handlers: `submitRun`, `prepareRun`, `sendRunFlowRequest` and `readJournal` all return discriminated unions, and across the whole runner domain they touch one thing from the command context, `ctx.platformClient`. Every use of `ctx.ui` sits in the handlers, which is the layer that throws the typed value away into stdout. This adds a second consumer of that layer which is not a terminal.

- [x] Add `@qawolf/cli/runner-sdk`, covering all 16 `qawolf runner` verbs as typed functions over the public API.
- [x] Return the `@qawolf/api-contracts` output type for the 14 verbs that pass straight through, so the new permanent type surface is one result wrapper, the request types, and the three answers the CLI invents for `list`, `keepalive` and a run's `fileSync`.
- [x] Keep `exitCode` out of the surface, since a library caller has no process to exit, and report a runner's refusal as `value.outcome === "failure"` with the contract's own `failureReason` so a caller can switch on it exhaustively.
- [x] Give every verb an explicit runner id, so nothing is launched or billed implicitly.
- [x] Name each absence rather than making a field optional, so `RunSelection` is `"whole-flow" | { startLine, endLine, linesIn }` and a `--lines-file` with no range cannot be expressed.
- [x] Narrow `sendRunFlowRequest`, `readJournal` and `submitRun` from `AuthCommandContext` to the new `RunnerApiContext`, which is `Pick<AuthCommandContext, "platformClient">`, with no change to what they do.
- [x] Extract `listRunners` out of `handleRunnerList`, which mixed the value it computes with the table it prints, with no change to what the command outputs.
- [x] Build `dist/runner-sdk.js` beside the CLI bundle and emit declarations with `tsc`, since bun's bundler has none, and map `./package.json` in `exports` so `require.resolve("@qawolf/cli/package.json")` keeps working for `tester-skills`.
- [x] Add `scripts/checkSdkTypes.ts`, which fails when a published declaration imports anything but `./types.js` or `@qawolf/api-contracts/v1`, because a `~/` alias does not resolve for anyone who installs the package.
- [x] Lift `resolveSnippetScope` out of `evaluateSnippet.ts` so the handler and the SDK share one implementation rather than the SDK carrying a second copy.

### Parity with what `tester-session` drives today

A per-verb audit compared the contract input each CLI handler sends against the input the SDK sends. Twelve verbs matched exactly, because they call the same contract through the same `callPublicApi`, so timeout and retry policy are shared rather than reimplemented. Two did not, and both are fixed here:

- `importPackage` sent `npmDependencies: {}` instead of the project's own, so an install resolved against nothing. It now reads `package.json` through `readNpmDependencies`, as the handler does, and refuses when that file is missing or unreadable.
- `evaluateSnippet` sent a `filePath` with no `files`, so a scoped snippet named modules that never travelled. It now resolves the scope with the same collector the handler uses.

Two behaviours were verified rather than assumed. `prepareRun` reads `QAWOLF_ENVIRONMENT` when given neither an env id nor an env file, so `environment: "ambient"` keeps that fallback. And `submitRun` recovers from `needs-full-sync` with one bounded resend, so always passing a resolved rather than launched runner is safe against a stale file manifest.

The SDK never auto-launches, which is the one deliberate difference. `qawolf runner run`, `act` and `exec` start a runner when none resolves; every SDK verb takes an explicit id so a library cannot silently start and bill a pod. An integration that relied on `QAWOLF_RUNNER_ID` has to pass the id instead.

# Testing

```sh
bun run typecheck && bun run lint && bun run format:check
bun run knip && bun run test
bun run build && bun run build:types-gate
```

2096 tests pass, and typecheck, lint, format, knip and the type gate are clean.

- The type gate caught a real leak while this was being built: `RunnerSdkOptions` first lived beside the context factory and exposed the internal `Fs` and `Logger` types. Moving it and dropping those two fields shrank the public surface and removed the need for an alias-rewriting build step.
- Packed the tarball and installed it in a scratch directory outside the repo, then typechecked a file importing `createRunnerSdk` from `@qawolf/cli/runner-sdk`. It compiles, and `selection: "not-a-selection"` fails with `TS2322`, so the published types bind rather than just resolve.
- `dist/runner-sdk.js` is 9.7 MB, taking the packed tarball from 3.1 MB to 4.8 MB. Most of it is `typescript`, bundled because collecting a run's files walks imports with the compiler API. Marking it external would cut that sharply and it is already a declared runtime dependency, so it is worth deciding before this publishes.

