### PR TITLE
fix(runner): correct promote-snapshot journal filter event type

### DIFF
--- a/.changeset/promote-snapshot-jq-filter.md
+++ b/.changeset/promote-snapshot-jq-filter.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Fix the `promote-snapshot` example's journal filter. The image-diff run event's type is `imageDiffArtifact`, so the documented `jq 'select(.type == "image-diff-artifact")'` matched nothing and left the two paths it is meant to surface unfindable.

--- a/.changeset/promote-snapshot-jq-filter.md
+++ b/.changeset/promote-snapshot-jq-filter.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-Fix the `promote-snapshot` example's journal filter. The image-diff run event's type is `imageDiffArtifact`, so the documented `jq 'select(.type == "image-diff-artifact")'` matched nothing and left the two paths it is meant to surface unfindable.
+Name the image-diff run event correctly wherever `promote-snapshot` points at it. Its type is `imageDiffArtifact`, so the documented `jq 'select(.type == "image-diff-artifact")'` filter matched nothing, and the failure message shown when a path is wrong sent readers after an entry name that does not exist — in both cases leaving the two paths the command requires unfindable.

--- a/skills/qawolf-cli/references/runner.md
+++ b/skills/qawolf-cli/references/runner.md
@@ -288,7 +288,7 @@ When a run's image diff fails and the new screenshot is the one you want, this
 replaces the baseline on the runner that produced it:
 
 ```sh
-qawolf runner events run-events --tail 20 | jq 'select(.type == "image-diff-artifact")'
+qawolf runner events run-events --tail 20 | jq 'select(.type == "imageDiffArtifact")'
 qawolf runner promote-snapshot --screenshot checkout-1-actual.png --baseline checkout-1.png
 ```
 

--- a/src/commands/runner/promoteSnapshot.register.ts
+++ b/src/commands/runner/promoteSnapshot.register.ts
@@ -10,7 +10,7 @@ import { runnerDeps, runnerFlagDescription } from "./context.js";
 const promoteSnapshotExamples = `
 Examples:
   $ qawolf runner promote-snapshot --screenshot checkout-1-actual.png --baseline checkout-1.png
-  $ qawolf runner events run-events --tail 20 | jq 'select(.type == "image-diff-artifact")'`;
+  $ qawolf runner events run-events --tail 20 | jq 'select(.type == "imageDiffArtifact")'`;
 
 export function registerRunnerPromoteSnapshotCommand(
   runner: Command,

--- a/src/core/messages/interactiveRunner/interact.ts
+++ b/src/core/messages/interactiveRunner/interact.ts
@@ -85,7 +85,7 @@ export const interactMessages = {
   snapshotPromoted: (screenshotPath: string, baselinePath: string) =>
     `Promoted ${screenshotPath} to the baseline at ${baselinePath}.`,
   snapshotNotFound: (screenshotPath: string) =>
-    `The run wrote no screenshot at "${screenshotPath}", so nothing was changed. The two paths have to be the ones an image diff reported: read them from the image-diff-artifact entry on qawolf runner events run-events.`,
+    `The run wrote no screenshot at "${screenshotPath}", so nothing was changed. The two paths have to be the ones an image diff reported: read them from the imageDiffArtifact entry on qawolf runner events run-events.`,
   runnerCannotPromoteSnapshots:
     "This runner stores no screenshots, so it holds no baseline to replace. Retrying will never help.",
   promoteSnapshotAnsweredUnknown: (failureReason: string) =>

--- a/src/domains/interactiveRunner/promoteSnapshot.test.ts
+++ b/src/domains/interactiveRunner/promoteSnapshot.test.ts
@@ -52,7 +52,7 @@ describe("handleRunnerPromoteSnapshot", () => {
 
     expect(result?.exitCode).toBe(2);
     expect(result?.error).toContain("checkout-1-actual.png");
-    expect(result?.error).toContain("image-diff-artifact");
+    expect(result?.error).toContain("imageDiffArtifact");
   });
 
   it.each([


### PR DESCRIPTION
# Overview of Changes

The `promote-snapshot` example told readers to filter the runner journal with `jq 'select(.type == "image-diff-artifact")'`, but the image-diff run event's type is `imageDiffArtifact`. The filter matched nothing, so the screenshot and baseline paths it exists to surface were unfindable — and since both paths are required flags, the documented workflow dead-ended. The wrong string was in two places: the skill's runner reference, and the command's own `--help` examples.

Found this while watching Tester follow the guide end-to-end: it fetched `references/runner.md`, then repeated the broken filter verbatim in its answer.

# Testing

Confirmed `image-diff-artifact` appears nowhere in the platform, while `imageDiffArtifact` is the event schema's literal (`packages/domain-runner-types/src/lib/events-schema.ts`). The CLI passes journal payloads through without renaming, so the printed type is the schema's.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable) — documentation strings only
- [x] No breaking changes (or described below)