### PR TITLE
feat(run): forward QAWOLF_CHAT_SESSION_ID to run create

### DIFF
--- a/.changeset/run-create-chat-session-id.md
+++ b/.changeset/run-create-chat-session-id.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+`qawolf run create` forwards `QAWOLF_CHAT_SESSION_ID` as `chatSessionId`, so a run started from a chat session reports its result back into that chat. Pins `@qawolf/api-contracts` 0.38.0.
+
+The contract rejects `aiTaskId` and `chatSessionId` together, and an AI task pod that holds a conversation exports both variables, so the CLI sends one: an explicit flag beats an ambient variable, and when both are ambient the task id wins, which is the id such a pod sends today.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.37.0",
+        "@qawolf/api-contracts": "0.38.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.37.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-4F/TqDEva3eKJnsC8ol+YmH3+6vm/GCqhYd2f7pFORZ0kleZlsk1LocOkKvdK+82tKSrYcXBgZdSuDXtnNiBGg=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.38.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-1oAijhF5FqJrRXPZB4ifAHICzgNxu5RhFQ60nwgCwcLg2FwpOoLkP/hdCA3XOLuvEPFWK6RNHwM0F3aAullAow=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.37.0",
+    "@qawolf/api-contracts": "0.38.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/src/commands/publicApi/environmentOptions.ts
+++ b/src/commands/publicApi/environmentOptions.ts
@@ -1,0 +1,61 @@
+import type { Command } from "commander";
+
+import type { CommandSpec } from "~/domains/publicApi/commandSpecs.js";
+
+// Generated options a variable can fill, keyed by contract path and input path
+// (`public.run.create.aiTaskId`) or by input path alone, which covers the field
+// wherever it appears (`environmentId`).
+const optionEnvironmentVariables = new Map([
+  ["environmentId", "QAWOLF_ENVIRONMENT"],
+  ["public.run.create.aiTaskId", "QAWOLF_AI_TASK_ID"],
+  ["public.run.create.chatSessionId", "QAWOLF_CHAT_SESSION_ID"],
+]);
+
+export function optionEnvironmentVariable(
+  spec: CommandSpec,
+  path: string[],
+): string | undefined {
+  const dotted = path.join(".");
+  return (
+    optionEnvironmentVariables.get(`${spec.trpcPath}.${dotted}`) ??
+    optionEnvironmentVariables.get(dotted)
+  );
+}
+
+// A pair of options a contract refuses together, where both can arrive from
+// the environment. An AI task pod that holds a conversation exports
+// QAWOLF_AI_TASK_ID and QAWOLF_CHAT_SESSION_ID at once, and `run.create`
+// rejects a request carrying both, since a task already implies its own chat
+// session. `keep` is the one that survives when both are ambient: the id such
+// a pod sends today, whose conversation is that same chat session.
+const exclusiveOptions = new Map<string, { keep: string; drop: string }>([
+  ["public.run.create", { keep: "aiTaskId", drop: "chatSessionId" }],
+]);
+
+/**
+ * Drops the ambient half of a pair the contract refuses together, so a shell
+ * that exports both variables still gets a request the contract accepts.
+ *
+ * An explicit flag outranks a variable. Two explicit flags are left as typed:
+ * the contract then reports the contradiction the caller asked for.
+ */
+export function withoutExclusiveConflict(
+  spec: CommandSpec,
+  command: Command,
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  const pair = exclusiveOptions.get(spec.trpcPath);
+  if (!pair) return options;
+  if (options[pair.keep] === undefined || options[pair.drop] === undefined) {
+    return options;
+  }
+  const fromEnvironment = (key: string): boolean =>
+    command.getOptionValueSource(key) === "env";
+  if (!fromEnvironment(pair.keep) && !fromEnvironment(pair.drop)) {
+    return options;
+  }
+  const dropped = fromEnvironment(pair.drop) ? pair.drop : pair.keep;
+  return Object.fromEntries(
+    Object.entries(options).filter(([key]) => key !== dropped),
+  );
+}

--- a/src/commands/publicApi/index.environment.test.ts
+++ b/src/commands/publicApi/index.environment.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, it } from "bun:test";
+import type { AnyPublicApiContract } from "@qawolf/api-contracts/v1";
 import { Command } from "commander";
 import { z } from "zod";
 
@@ -11,6 +12,7 @@ import { createSignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { registerPublicApiCommands } from "./index.js";
 
 const originalAiTaskId = process.env["QAWOLF_AI_TASK_ID"];
+const originalChatSessionId = process.env["QAWOLF_CHAT_SESSION_ID"];
 const originalEnvironment = process.env["QAWOLF_ENVIRONMENT"];
 
 afterEach(() => {
@@ -20,12 +22,53 @@ afterEach(() => {
   } else {
     process.env["QAWOLF_AI_TASK_ID"] = originalAiTaskId;
   }
+  if (originalChatSessionId === undefined) {
+    delete process.env["QAWOLF_CHAT_SESSION_ID"];
+  } else {
+    process.env["QAWOLF_CHAT_SESSION_ID"] = originalChatSessionId;
+  }
   if (originalEnvironment === undefined) {
     delete process.env["QAWOLF_ENVIRONMENT"];
   } else {
     process.env["QAWOLF_ENVIRONMENT"] = originalEnvironment;
   }
 });
+
+// Stands in for the published run.create: both notification ids, optional,
+// beside the required environment. The published contract rejects the pair,
+// which is what the CLI must never send; the stand-in accepts it so a test can
+// see which id the CLI chose.
+function makeNotificationContract() {
+  return {
+    description: "Create a run.",
+    input: z.object({
+      aiTaskId: z.string().optional(),
+      chatSessionId: z.string().optional(),
+      environmentId: z.string(),
+    }),
+    kind: "write",
+    name: "run.create",
+    output: z.object({ runId: z.string(), tracking: z.string() }),
+  } as const;
+}
+
+// A fresh program per invocation: Commander reads an environment variable when
+// the option is parsed, so a program built before the variable was set would
+// not see it.
+function registerRunCreate(
+  contract: AnyPublicApiContract,
+  callPublicApi: ReturnType<typeof makeCallPublicApiMock>,
+): Command {
+  const program = new Command().name("qawolf").exitOverride();
+  registerPublicApiCommands(program, createSignalRegistry(), {
+    authDeps: {
+      requireApiKey: async () => ({ key: "qawolf_key", source: "env" }),
+      createPlatform: () => makeMockPlatformClient({ callPublicApi }),
+    },
+    contracts: { run: { create: contract } },
+  });
+  return program;
+}
 
 it("defaults public API options from their environment variables", async () => {
   const contract = {
@@ -42,22 +85,14 @@ it("defaults public API options from their environment variables", async () => {
     ok: true,
     value: { runId: "run-id" },
   });
-  const register = () => {
-    const program = new Command().name("qawolf").exitOverride();
-    registerPublicApiCommands(program, createSignalRegistry(), {
-      authDeps: {
-        requireApiKey: async () => ({ key: "qawolf_key", source: "env" }),
-        createPlatform: () => makeMockPlatformClient({ callPublicApi }),
-      },
-      contracts: { run: { create: contract } },
-    });
-    return program;
-  };
   process.env["QAWOLF_AI_TASK_ID"] = "environment-task-id";
   process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
 
-  await register().parseAsync(["run", "create"], { from: "user" });
-  await register().parseAsync(
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create"],
+    { from: "user" },
+  );
+  await registerRunCreate(contract, callPublicApi).parseAsync(
     [
       "run",
       "create",
@@ -76,5 +111,102 @@ it("defaults public API options from their environment variables", async () => {
   expect(callPublicApi).toHaveBeenNthCalledWith(2, contract, {
     aiTaskId: "flag-task-id",
     environmentId: "flag-environment-id",
+  });
+});
+
+// A Global Chat pod exports QAWOLF_CHAT_SESSION_ID, and a run created there
+// reports its result back into that chat only if the id reaches the request.
+it("defaults run.create chatSessionId from QAWOLF_CHAT_SESSION_ID", async () => {
+  const contract = makeNotificationContract();
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id", tracking: "registered" },
+  });
+  delete process.env["QAWOLF_AI_TASK_ID"];
+  process.env["QAWOLF_CHAT_SESSION_ID"] = "environment-chat-session-id";
+  process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
+
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create"],
+    { from: "user" },
+  );
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create", "--chat-session-id", "flag-chat-session-id"],
+    { from: "user" },
+  );
+
+  expect(callPublicApi).toHaveBeenNthCalledWith(1, contract, {
+    chatSessionId: "environment-chat-session-id",
+    environmentId: "environment-environment-id",
+  });
+  expect(callPublicApi).toHaveBeenNthCalledWith(2, contract, {
+    chatSessionId: "flag-chat-session-id",
+    environmentId: "environment-environment-id",
+  });
+});
+
+// An AI task pod that holds a conversation exports both variables, and the
+// contract rejects a request carrying the pair, so the CLI sends the task id
+// alone: the id such a pod already sends today, and the one whose conversation
+// is the task's own chat session.
+it("sends aiTaskId alone when both variables are set", async () => {
+  const contract = makeNotificationContract();
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id", tracking: "registered" },
+  });
+  process.env["QAWOLF_AI_TASK_ID"] = "environment-task-id";
+  process.env["QAWOLF_CHAT_SESSION_ID"] = "environment-chat-session-id";
+  process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
+
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create"],
+    { from: "user" },
+  );
+
+  expect(callPublicApi).toHaveBeenCalledWith(contract, {
+    aiTaskId: "environment-task-id",
+    environmentId: "environment-environment-id",
+  });
+});
+
+it("prefers an explicit --chat-session-id over an ambient QAWOLF_AI_TASK_ID", async () => {
+  const contract = makeNotificationContract();
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id", tracking: "registered" },
+  });
+  process.env["QAWOLF_AI_TASK_ID"] = "environment-task-id";
+  process.env["QAWOLF_CHAT_SESSION_ID"] = "environment-chat-session-id";
+  process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
+
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create", "--chat-session-id", "flag-chat-session-id"],
+    { from: "user" },
+  );
+
+  expect(callPublicApi).toHaveBeenCalledWith(contract, {
+    chatSessionId: "flag-chat-session-id",
+    environmentId: "environment-environment-id",
+  });
+});
+
+it("omits chatSessionId when neither the flag nor the variable is set", async () => {
+  const contract = makeNotificationContract();
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id", tracking: "not-requested" },
+  });
+  delete process.env["QAWOLF_AI_TASK_ID"];
+  delete process.env["QAWOLF_CHAT_SESSION_ID"];
+  process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
+
+  await registerRunCreate(contract, callPublicApi).parseAsync(
+    ["run", "create"],
+    { from: "user" },
+  );
+
+  expect(callPublicApi).toHaveBeenCalledWith(contract, {
+    environmentId: "environment-environment-id",
   });
 });

--- a/src/commands/publicApi/index.test.ts
+++ b/src/commands/publicApi/index.test.ts
@@ -38,6 +38,7 @@ describe("registerPublicApiCommands", () => {
     );
     expect(create?.options.map((option) => option.flags)).toEqual([
       "--ai-task-id <value>",
+      "--chat-session-id <value>",
       "--environment-id <value>",
       "--environment-variables <KEY=VALUE...>",
       "--ignore-rules",
@@ -47,6 +48,7 @@ describe("registerPublicApiCommands", () => {
       "--tag-names <values...>",
     ]);
     expect(create?.options.map((option) => option.mandatory)).toEqual([
+      false,
       false,
       true,
       false,

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -12,6 +12,11 @@ import { skippedContractNames } from "~/domains/publicApi/skippedContracts.js";
 import { declareCommandKind } from "~/commands/commandKind.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
+import {
+  optionEnvironmentVariable,
+  withoutExclusiveConflict,
+} from "./environmentOptions.js";
+
 type AuthDeps = Parameters<typeof withAuthContext>[2];
 
 type Options = {
@@ -26,22 +31,6 @@ type Options = {
 const groupDescriptions: Record<string, string> = {
   run: "Trigger and manage QA Wolf runs on the platform",
 };
-
-const optionEnvironmentVariables = new Map([
-  ["environmentId", "QAWOLF_ENVIRONMENT"],
-  ["public.run.create.aiTaskId", "QAWOLF_AI_TASK_ID"],
-]);
-
-function optionEnvironmentVariable(
-  spec: CommandSpec,
-  path: string[],
-): string | undefined {
-  const dotted = path.join(".");
-  return (
-    optionEnvironmentVariables.get(`${spec.trpcPath}.${dotted}`) ??
-    optionEnvironmentVariables.get(dotted)
-  );
-}
 
 function resolveGroup(parent: Command, segment: string): Command {
   const existing = parent.commands.find(
@@ -100,7 +89,12 @@ function registerSpec(
   command.action((options: Record<string, unknown>, leaf: Command) =>
     withAuthContext(
       signals,
-      (ctx) => handlePublicApiCommand(ctx, spec, options),
+      (ctx) =>
+        handlePublicApiCommand(
+          ctx,
+          spec,
+          withoutExclusiveConflict(spec, leaf, options),
+        ),
       authDeps ?? {},
     )(options, leaf),
   );

--- a/src/core/publicApi/flagSpecs.test.ts
+++ b/src/core/publicApi/flagSpecs.test.ts
@@ -75,6 +75,7 @@ describe("buildFlagSpecs", () => {
       })),
     ).toEqual([
       { flag: "--ai-task-id <value>", required: false },
+      { flag: "--chat-session-id <value>", required: false },
       { flag: "--environment-id <value>", required: true },
       { flag: "--environment-variables <KEY=VALUE...>", required: false },
       { flag: "--ignore-rules", required: false },

--- a/src/domains/publicApi/commandSpecs.test.ts
+++ b/src/domains/publicApi/commandSpecs.test.ts
@@ -23,6 +23,7 @@ describe("buildCommandSpecs", () => {
     expect(runCreate?.contract).toBe(publicContractsV1.run.create);
     expect(runCreate?.flags.map((flag) => flag.path.join("."))).toEqual([
       "aiTaskId",
+      "chatSessionId",
       "environmentId",
       "environmentVariables",
       "ignoreRules",

--- a/src/shell/platform/callPublicApi.test.ts
+++ b/src/shell/platform/callPublicApi.test.ts
@@ -35,7 +35,14 @@ describe("callPublicApi", () => {
     const runId = "run-id";
     const url = "https://app.qawolf.com/runs/run-id";
     const fetchSpy = mock<typeof fetch>().mockResolvedValue(
-      jsonResponse(wrapped({ excludedFlows: [], runId, url })),
+      jsonResponse(
+        wrapped({
+          excludedFlows: [],
+          runId,
+          tracking: "not-requested",
+          url,
+        }),
+      ),
     );
     const trpc = createTrpcClient(apiKey, {
       baseUrl,
@@ -53,7 +60,7 @@ describe("callPublicApi", () => {
     );
     expect(result).toEqual({
       ok: true,
-      data: { excludedFlows: [], runId, url },
+      data: { excludedFlows: [], runId, tracking: "not-requested", url },
     });
   });
 

--- a/src/shell/platform/createPlatformClient.callPublicApi.test.ts
+++ b/src/shell/platform/createPlatformClient.callPublicApi.test.ts
@@ -47,7 +47,16 @@ describe("callPublicApi", () => {
   it("sends a write contract as a mutation and returns the value", async () => {
     const runId = "run-id";
     const url = "https://app.qawolf.com/runs/run-id";
-    const f = mockFetch(json(trpcWrapped({ excludedFlows: [], runId, url })));
+    const f = mockFetch(
+      json(
+        trpcWrapped({
+          excludedFlows: [],
+          runId,
+          tracking: "not-requested",
+          url,
+        }),
+      ),
+    );
 
     const result = await createPlatformClient(apiKey, {
       fetch: f,
@@ -63,7 +72,7 @@ describe("callPublicApi", () => {
     expect(req.auth).toBe(`Bearer ${apiKey}`);
     expect(result).toEqual({
       ok: true,
-      value: { excludedFlows: [], runId, url },
+      value: { excludedFlows: [], runId, tracking: "not-requested", url },
     });
   });
 


### PR DESCRIPTION
# Overview of Changes

A run created from a chat session reports its result back into that chat only when the request names the session, so Global Chat runs register no tracking today: the published CLI pins `@qawolf/api-contracts` 0.37.0, whose `run.create` has no `chatSessionId` input. This pins 0.38.0, the release that adds the optional `chatSessionId` input (exclusive with `aiTaskId`) and the required `tracking` output, and maps `QAWOLF_CHAT_SESSION_ID` onto that input the way `QAWOLF_AI_TASK_ID` is already mapped onto `aiTaskId`. `qawolf run create --help` documents the new option with its variable, and the JSON and human renderers print whatever the response carries, so `tracking` needs no rendering work.

The contract refuses `aiTaskId` and `chatSessionId` together, since a task already implies its own chat session, and an AI task pod that holds a conversation exports both variables. The CLI therefore sends one id: an explicit flag beats an ambient variable, and when both are ambient the task id wins, which is the id such a pod sends today. Two explicit flags are left as typed, so the contract reports the contradiction the caller asked for. That rule and the variable map live in `src/commands/publicApi/environmentOptions.ts`.

Note on the pin: the task named 0.39.0, which is on GitHub Packages only. This repo's `.npmrc` pins `@qawolf` to public npm, where 0.38.0 is the newest release, so a 0.39.0 pin would not install. The `run.create` contract in 0.38.0 is byte-identical to 0.39.0 (0.39.0 adds only `auth/config` and `identity/organizations` exports, which the CLI does not use), so 0.38.0 carries everything this change needs. It is also the version qawolf/platform#32825 names as its precondition.

Once this ships in a CLI release and the ai-task image is rebuilt (its Dockerfile installs `@qawolf/cli@latest` at build time), qawolf/platform#32825 removes the prompt rule that has the Global Chat agent create runs with a direct `POST /api/trpc/public.run.create`.

# Testing

```bash
bun run typecheck
bun run lint --max-warnings 0
bun run format:check
bun run knip
bun run test
bun run build
```

All pass locally: 2111 tests across 285 files, 0 failures.

Behavior checked by hand:

```bash
bun run src/main.ts run create --help
#   --chat-session-id <value>  The chat session whose transcript should receive
#                              run status updates. (env: QAWOLF_CHAT_SESSION_ID)
```

New tests in `src/commands/publicApi/index.environment.test.ts` cover the variable filling the option, an explicit `--chat-session-id` winning over it, the option staying absent when neither is set, both variables yielding the task id alone, and an explicit `--chat-session-id` winning over an ambient `QAWOLF_AI_TASK_ID`.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
