### PR TITLE
chore(cli): bump api-contracts to 0.39.0

### DIFF
--- a/.changeset/api-contracts-0-39-0.md
+++ b/.changeset/api-contracts-0-39-0.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+Upgrades `@qawolf/api-contracts` to `0.39.0`.
+
+That release adds the `authConfigResponse` schema, which gives the WorkOS client id that a client must send to start a device authorization grant. No command changes: the CLI does not read the schema yet, and the release adds no endpoint contracts for the generated public-API commands.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.38.0",
+        "@qawolf/api-contracts": "0.39.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.38.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-1oAijhF5FqJrRXPZB4ifAHICzgNxu5RhFQ60nwgCwcLg2FwpOoLkP/hdCA3XOLuvEPFWK6RNHwM0F3aAullAow=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.39.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-WbKDVrzkCD12zGmq3m0G8MDmkqEzJ8T906aC2s2yNi5tX0nu9Rraa7xeN2GY38yROETqcNuaN0MyEP0ef9C8hQ=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.38.0",
+    "@qawolf/api-contracts": "0.39.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

Platform published `@qawolf/api-contracts` 0.39.0. This picks it up. The CLI was on 0.38.0.

Diffing the two published tarballs, 0.39.0 adds exactly one export: `authConfigResponse`, a schema carrying the WorkOS client id a client must send to start a device authorization grant. It adds no endpoint contracts, so `registerPublicApiCommands` generates the same command surface as before — the `help.test.ts` snapshot is unchanged, which is the tripwire past bumps tripped when the generated surface moved.

- **`package.json` / `bun.lock`**: `@qawolf/api-contracts` 0.38.0 → 0.39.0.
- **`.changeset/api-contracts-0-39-0.md`**: patch changeset. Patch rather than minor because nothing user facing changes in this release — the CLI does not read the new schema yet.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All pass. 2111 tests, 0 failures, 30 snapshots — including the generated-command help snapshot, which needed no update.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
