### PR TITLE
build(cli): keep typescript out of the npm bundle

### DIFF
--- a/.changeset/typescript-out-of-bundle.md
+++ b/.changeset/typescript-out-of-bundle.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-The npm bundle no longer inlines the TypeScript compiler. It loads the installed `typescript` package only when `qawolf runner run` walks a flow's imports. `dist/cli.js` shrinks from 16 MB to 6.6 MB, `dist/runner-sdk.js` from 9.3 MB to 0.4 MB, and every command starts about 70 ms sooner under Node.
+The npm bundle no longer inlines the TypeScript compiler. It loads the installed `typescript` package only when a runner command or the runner SDK walks a flow's imports. `dist/cli.js` shrinks from 16 MB to 6.6 MB, `dist/runner-sdk.js` from 9.3 MB to 0.4 MB, and every command starts about 70 ms sooner under Node.

--- a/.changeset/typescript-out-of-bundle.md
+++ b/.changeset/typescript-out-of-bundle.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+The npm bundle no longer inlines the TypeScript compiler. It loads the installed `typescript` package only when `qawolf runner run` walks a flow's imports. `dist/cli.js` shrinks from 16 MB to 6.6 MB, `dist/runner-sdk.js` from 9.3 MB to 0.4 MB, and every command starts about 70 ms sooner under Node.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -17,8 +17,8 @@ const externals = [
   // installed on demand by ensureDeps (also external in the binary — see buildBinary.ts)
   "@qawolf/emails",
   "@qawolf/testkit",
-  // 9 MB that only the import-graph walk of `runner run` loads (dynamic import);
-  // inlined, Node would parse it on every command start
+  // the TypeScript compiler, loaded lazily by the import-graph walk; inlined,
+  // Node parses all of it on every command start
   "typescript",
 ];
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -17,6 +17,9 @@ const externals = [
   // installed on demand by ensureDeps (also external in the binary — see buildBinary.ts)
   "@qawolf/emails",
   "@qawolf/testkit",
+  // 9 MB that only the import-graph walk of `runner run` loads (dynamic import);
+  // inlined, Node would parse it on every command start
+  "typescript",
 ];
 
 function buildArgs(entry: string, name: string): string[] {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -26,9 +26,10 @@ for (const path of bundles) {
       process.exit(1);
     }
   }
-  if (source.length > maxBundleBytes) {
+  const sizeBytes = statSync(path).size;
+  if (sizeBytes > maxBundleBytes) {
     console.error(
-      `${path} is ${source.length} bytes, over the ${maxBundleBytes} byte ceiling`,
+      `${path} is ${sizeBytes} bytes, over the ${maxBundleBytes} byte ceiling`,
     );
     process.exit(1);
   }

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,11 +1,38 @@
 #!/usr/bin/env bun
-// Runs after `bun run build` to make dist/cli.js executable as a CLI.
-// Bun's bundler doesn't add a shebang, so we prepend one manually.
+// Runs after `bun run build`: checks the bundles stay lean, then makes
+// dist/cli.js executable as a CLI (Bun's bundler adds no shebang).
 // TypeScript rather than shell so the hook also runs on Windows, where
 // bun's script runner cannot execute .sh files (no shebang mechanism).
 import { chmodSync, readFileSync, statSync, writeFileSync } from "node:fs";
 
 const outfile = "dist/cli.js";
+const bundles = [outfile, "dist/runner-sdk.js"];
+
+// Externals that must only ever be reached through a dynamic import(). A static
+// import anywhere in src/ becomes a top-level import here, and Node would load
+// the whole package on every command start again.
+const lazyExternals = ["typescript"];
+// Startup is dominated by parsing the bundle; this catches a heavy dependency
+// slipping back in (typescript alone was 9 MB).
+const maxBundleBytes = 8_000_000;
+
+for (const path of bundles) {
+  const source = readFileSync(path, "utf8");
+  for (const pkg of lazyExternals) {
+    if (new RegExp(`^import\\b[^\\n]*"${pkg}"`, "m").test(source)) {
+      console.error(
+        `${path} imports "${pkg}" at top level; it must stay a dynamic import()`,
+      );
+      process.exit(1);
+    }
+  }
+  if (source.length > maxBundleBytes) {
+    console.error(
+      `${path} is ${source.length} bytes, over the ${maxBundleBytes} byte ceiling`,
+    );
+    process.exit(1);
+  }
+}
 
 // Prepend the Node.js shebang so the OS knows how to execute the file.
 // Skip when one is already present: a repeat run without a rebuild would


### PR DESCRIPTION
Closes WIZ-11968. Measurements: WIZ-11936.

# Overview of Changes

Every `qawolf` command parsed 9 MB of the TypeScript compiler at startup, though only `qawolf runner run` uses it to walk a flow's imports. That was more than half of the 16 MB npm bundle and a third of Node's startup time. The bundle now leaves `typescript` external, so Node loads it from `node_modules` only when a runner command or the runner SDK walks a flow's imports. `typescript` was already a runtime dependency, so nothing changes for installs.

The build now fails if either bundle imports `typescript` at top level or grows past 8 MB, so a stray static import cannot quietly bring the 9 MB back.

The compiled binary keeps TypeScript inlined: it has no `node_modules` next to it, and `runner run` must work offline. Its startup is the subject of WIZ-11970.

| | before | after |
| --- | --- | --- |
| `dist/cli.js` | 16 MB | 6.6 MB |
| `dist/runner-sdk.js` | 9.3 MB | 0.4 MB |
| `node dist/cli.js runner act --help`, median of 15 (local, M-series) | 239 ms | 169 ms |

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All pass (2111 tests). Also packed the tarball, installed it into an empty project with npm, and confirmed `typescript` lands next to the bundle, `qawolf runner act --help` runs, and `import("typescript")` resolves from `dist/`. Built the binary and confirmed `--version` and `runner act --help` still run. Checked the new build guard trips on a bundle with a top-level `typescript` import and on the old 16 MB bundle.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
