### PR TITLE
build(cli): keep the mobile webdriver stack out of the npm bundle

### DIFF
--- a/.changeset/mobile-stack-out-of-bundle.md
+++ b/.changeset/mobile-stack-out-of-bundle.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-The npm bundle no longer inlines webdriverio and the rest of the mobile stack. Mobile runs load webdriverio from the managed runtime that `ensureDeps` already installs on first use, the same way `@qawolf/emails` and `@qawolf/testkit` are loaded. `dist/cli.js` shrinks from 6.6 MB to 1.1 MB and every command starts about 25 ms sooner under Node. The compiled binary is unchanged.
+The npm package no longer bundles webdriverio and the rest of the mobile stack. Mobile runs load it from the managed runtime that is installed on first use. `dist/cli.js` shrinks from 6.6 MB to 1.1 MB and every command starts about 25 ms sooner under Node. The compiled binary is unchanged.

--- a/.changeset/mobile-stack-out-of-bundle.md
+++ b/.changeset/mobile-stack-out-of-bundle.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+The npm bundle no longer inlines webdriverio and the rest of the mobile stack. Mobile runs load webdriverio from the managed runtime that `ensureDeps` already installs on first use, the same way `@qawolf/emails` and `@qawolf/testkit` are loaded. `dist/cli.js` shrinks from 6.6 MB to 1.1 MB and every command starts about 25 ms sooner under Node. The compiled binary is unchanged.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,8 +20,8 @@ const externals = [
   // the TypeScript compiler, loaded lazily by the import-graph walk; inlined,
   // Node parses all of it on every command start
   "typescript",
-  // the mobile stack; ensureDeps installs it on demand and loadWebdriverio
-  // imports it from there, so the specifier here is reached only by the binary
+  // loaded from the run's dependency root at runtime (loadWebdriverio); only
+  // the compiled binary, a separate build, takes the bare specifier
   "webdriverio",
 ];
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,6 +20,9 @@ const externals = [
   // the TypeScript compiler, loaded lazily by the import-graph walk; inlined,
   // Node parses all of it on every command start
   "typescript",
+  // the mobile stack; ensureDeps installs it on demand and loadWebdriverio
+  // imports it from there, so the specifier here is reached only by the binary
+  "webdriverio",
 ];
 
 function buildArgs(entry: string, name: string): string[] {

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -11,10 +11,10 @@ const bundles = [outfile, "dist/runner-sdk.js"];
 // Externals that must only ever be reached through a dynamic import(). A static
 // import anywhere in src/ becomes a top-level import here, and Node would load
 // the whole package on every command start again.
-const lazyExternals = ["typescript"];
+const lazyExternals = ["typescript", "webdriverio"];
 // Startup is dominated by parsing the bundle; this catches a heavy dependency
-// slipping back in (typescript alone was 9 MB).
-const maxBundleBytes = 8_000_000;
+// slipping back in (typescript alone was 9 MB, the webdriver stack 5 MB).
+const maxBundleBytes = 2_000_000;
 
 for (const path of bundles) {
   const source = readFileSync(path, "utf8");

--- a/src/domains/runner/loadWebdriverio.test.ts
+++ b/src/domains/runner/loadWebdriverio.test.ts
@@ -6,6 +6,8 @@ import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 
 import { loadWebdriverio } from "./loadWebdriverio.js";
 
+type FakeRemote = (opts: Record<string, unknown>) => Promise<unknown>;
+
 const tracker = makeTmpDirTracker("qawolf-load-webdriverio-");
 
 afterEach(() => tracker.cleanup());
@@ -34,9 +36,9 @@ describe("loadWebdriverio", () => {
     await writeFakeWebdriverio(envDir);
 
     const { remote } = await loadWebdriverio(envDir);
-    const session = (await remote({ port: 4723 })) as unknown as {
-      opts: { port: number };
-    };
+    const session = (await (remote as unknown as FakeRemote)({
+      port: 4723,
+    })) as { opts: { port: number } };
 
     expect(session.opts.port).toBe(4723);
   });

--- a/src/domains/runner/loadWebdriverio.test.ts
+++ b/src/domains/runner/loadWebdriverio.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
+
+import { loadWebdriverio } from "./loadWebdriverio.js";
+
+const tracker = makeTmpDirTracker("qawolf-load-webdriverio-");
+
+afterEach(() => tracker.cleanup());
+
+async function writeFakeWebdriverio(envDir: string): Promise<void> {
+  const pkgDir = join(envDir, "node_modules", "webdriverio");
+  await mkdir(pkgDir, { recursive: true });
+  await writeFile(
+    join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "webdriverio",
+      version: "0.0.0-test",
+      type: "module",
+      exports: { ".": { import: "./index.js" } },
+    }),
+  );
+  await writeFile(
+    join(pkgDir, "index.js"),
+    "export const remote = async (opts) => ({ opts });\n",
+  );
+}
+
+describe("loadWebdriverio", () => {
+  it("imports webdriverio from the env dir's node_modules, not the CLI's", async () => {
+    const envDir = await tracker.makeTmpDir();
+    await writeFakeWebdriverio(envDir);
+
+    const { remote } = await loadWebdriverio(envDir);
+    const session = (await remote({ port: 4723 })) as unknown as {
+      opts: { port: number };
+    };
+
+    expect(session.opts.port).toBe(4723);
+  });
+
+  it("names the package and env dir when it is not installed there", async () => {
+    const envDir = await tracker.makeTmpDir();
+
+    let caught: unknown;
+    try {
+      await loadWebdriverio(envDir);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("webdriverio");
+    expect((caught as Error).message).toContain(envDir);
+  });
+});

--- a/src/domains/runner/loadWebdriverio.ts
+++ b/src/domains/runner/loadWebdriverio.ts
@@ -1,0 +1,44 @@
+import { errorMessage } from "~/core/errors.js";
+import { packageLoadFailed } from "~/core/messages/index.js";
+import { importFromPath } from "~/shell/importFromPath.js";
+import { resolveFromEnvDir } from "~/shell/resolveExport.js";
+
+export type WdioRemote = {
+  startRecordingScreen(): Promise<void>;
+  stopRecordingScreen(): Promise<string>;
+  deleteSession(): Promise<void>;
+};
+
+export type WebdriverioModule = {
+  remote: (opts: Record<string, unknown>) => Promise<WdioRemote>;
+};
+
+/**
+ * Loads webdriverio from the run's dependency root, where ensureRuntimeEnv
+ * installed it on demand. It is a devDependency of the CLI, never a published
+ * one, so the npm bundle marks the specifier external and every command starts
+ * without parsing the mobile stack.
+ *
+ * The compiled binary cannot resolve a package's own bare imports out of
+ * node_modules (the same limit testkit.ts works around), so it keeps webdriverio
+ * inlined and takes the specifier branch, which --define makes static.
+ */
+export async function loadWebdriverio(
+  envDir: string,
+): Promise<WebdriverioModule> {
+  if (process.env.QAWOLF_COMPILED === "true") {
+    return (await import("webdriverio")) as unknown as WebdriverioModule;
+  }
+  try {
+    return (await importFromPath(
+      resolveFromEnvDir(envDir, "webdriverio"),
+    )) as WebdriverioModule;
+  } catch (err) {
+    throw new Error(
+      packageLoadFailed("webdriverio", envDir, errorMessage(err)),
+      {
+        cause: err,
+      },
+    );
+  }
+}

--- a/src/domains/runner/loadWebdriverio.ts
+++ b/src/domains/runner/loadWebdriverio.ts
@@ -1,34 +1,22 @@
+import type { remote } from "webdriverio";
+
 import { errorMessage } from "~/core/errors.js";
 import { packageLoadFailed } from "~/core/messages/index.js";
 import { importFromPath } from "~/shell/importFromPath.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
 
-export type WdioRemote = {
-  startRecordingScreen(): Promise<void>;
-  stopRecordingScreen(): Promise<string>;
-  deleteSession(): Promise<void>;
-};
-
-export type WebdriverioModule = {
-  remote: (opts: Record<string, unknown>) => Promise<WdioRemote>;
-};
+export type WebdriverioModule = { remote: typeof remote };
 
 /**
- * Loads webdriverio from the run's dependency root, where ensureRuntimeEnv
- * installed it on demand. It is a devDependency of the CLI, never a published
- * one, so the npm bundle marks the specifier external and every command starts
- * without parsing the mobile stack.
- *
- * The compiled binary cannot resolve a package's own bare imports out of
- * node_modules (the same limit testkit.ts works around), so it keeps webdriverio
- * inlined and takes the specifier branch, which --define makes static.
+ * Loads webdriverio from the run's dependency root, where the managed runtime
+ * installs it on first use; the npm bundle does not ship it. The compiled
+ * binary cannot resolve a package's own bare imports out of node_modules, so
+ * it keeps webdriverio inlined and takes the specifier branch instead.
  */
 export async function loadWebdriverio(
   envDir: string,
 ): Promise<WebdriverioModule> {
-  if (process.env.QAWOLF_COMPILED === "true") {
-    return (await import("webdriverio")) as unknown as WebdriverioModule;
-  }
+  if (process.env.QAWOLF_COMPILED === "true") return import("webdriverio");
   try {
     return (await importFromPath(
       resolveFromEnvDir(envDir, "webdriverio"),
@@ -36,9 +24,7 @@ export async function loadWebdriverio(
   } catch (err) {
     throw new Error(
       packageLoadFailed("webdriverio", envDir, errorMessage(err)),
-      {
-        cause: err,
-      },
+      { cause: err },
     );
   }
 }

--- a/src/domains/runner/runAndroidFlowDeps.ts
+++ b/src/domains/runner/runAndroidFlowDeps.ts
@@ -6,39 +6,27 @@ import { androidSdkHome } from "~/shell/androidSdkHome.js";
 import type { RunAndroidFlowDeps } from "./runAndroidFlow.js";
 import { createRunnerDeps } from "./runnerDeps.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+import { loadWebdriverio } from "./loadWebdriverio.js";
 
-type WdioRemote = {
-  startRecordingScreen(): Promise<void>;
-  stopRecordingScreen(): Promise<string>;
-  deleteSession(): Promise<void>;
-};
-
-async function createSession(
-  port: number,
-  serial: string,
-): Promise<AppiumDriver> {
-  // Deferred so web-only runs never pay to load webdriverio. It is still a
-  // build-time dep, not a published one: Bun inlines this static specifier into
-  // dist/cli.js, so the shipped bundle carries webdriverio and never resolves it
-  // from node_modules. That is why it is a devDependency — see pinnedPackages.ts.
-  const { remote } = (await import("webdriverio")) as unknown as {
-    remote: (opts: Record<string, unknown>) => Promise<WdioRemote>;
-  };
-  const driver = await remote({
-    hostname: "127.0.0.1",
-    port,
-    logLevel: "silent",
-    capabilities: {
-      platformName: "Android",
-      "appium:udid": serial,
-      "appium:automationName": "UiAutomator2",
-      "appium:noReset": true,
-    },
-  });
-  return {
-    startRecordingScreen: () => driver.startRecordingScreen(),
-    stopRecordingScreen: () => driver.stopRecordingScreen(),
-    deleteSession: () => driver.deleteSession(),
+function createSession(envDir: string) {
+  return async (port: number, serial: string): Promise<AppiumDriver> => {
+    const { remote } = await loadWebdriverio(envDir);
+    const driver = await remote({
+      hostname: "127.0.0.1",
+      port,
+      logLevel: "silent",
+      capabilities: {
+        platformName: "Android",
+        "appium:udid": serial,
+        "appium:automationName": "UiAutomator2",
+        "appium:noReset": true,
+      },
+    });
+    return {
+      startRecordingScreen: () => driver.startRecordingScreen(),
+      stopRecordingScreen: () => driver.stopRecordingScreen(),
+      deleteSession: () => driver.deleteSession(),
+    };
   };
 }
 
@@ -65,7 +53,7 @@ export function createAndroidDeps(
     ...createRunnerDeps(signals, envDir),
     appiumServer: serverHandle,
     emulatorPool: pool,
-    createSession,
+    createSession: createSession(envDir),
     adb: defaultAdb,
   };
 

--- a/src/domains/runtimeEnv/pinnedPackages.ts
+++ b/src/domains/runtimeEnv/pinnedPackages.ts
@@ -30,6 +30,11 @@ export const pinnedPackages: PinnedPackage[] = [
   // Installing it here keeps it out of the consumer's resolution, and this
   // managed install passes --legacy-peer-deps so the cycle is never explored.
   { name: "expect-webdriverio", version: expectWebdriverioVersion },
+  // The Android runner loads webdriverio from the run's dependency root
+  // (loadWebdriverio); the npm bundle does not ship it, so this pin is what
+  // guarantees every dependency root has it. Same devDependency-only rule as
+  // expect-webdriverio above.
+  { name: "webdriverio", version: webdriverioVersion },
   // expect-webdriverio's own peers. The managed install passes --legacy-peer-deps,
   // which skips peers entirely, so without these `import("expect-webdriverio")`
   // throws ERR_MODULE_NOT_FOUND on @wdio/logger. That import is what
@@ -38,7 +43,6 @@ export const pinnedPackages: PinnedPackage[] = [
   // initFlowRuntime, and initFlowRuntime hardcodes platform "web", so
   // configureFlowRuntime skips its mobile branch. This removes the first blocker
   // only. They carry the same devDependency-only rule as expect-webdriverio above.
-  { name: "webdriverio", version: webdriverioVersion },
   { name: "@wdio/globals", version: wdioGlobalsVersion },
   { name: "@wdio/logger", version: wdioLoggerVersion },
 ];

--- a/src/shell/appium/types.ts
+++ b/src/shell/appium/types.ts
@@ -32,7 +32,6 @@ export type WriteFileFn = (filePath: string, data: Buffer) => Promise<void>; // 
 export type AndroidLaunchDeps = {
   appiumServer: AppiumServerHandle;
   emulatorPool: EmulatorPoolHandle;
-  /** Required: no default until WebDriverIO is added in the runner wiring ticket. */
   createSession: CreateSessionFn;
   adb?: AdbFn;
   writeFile?: WriteFileFn;


### PR DESCRIPTION
Closes WIZ-11969. Measurements: WIZ-11936. Stacked on #1575.

# Overview of Changes

After TypeScript, the largest thing every `qawolf` command parsed at startup was the mobile stack: webdriverio and everything it pulls in (undici, readable-stream, the wdio protocols), about 5 MB of the bundle, used only by Android runs. These are devDependencies, and the bundler inlined them because it found them locally.

Mobile runs now load webdriverio from the run's dependency root, where the managed runtime already installs it on first use, the same way `@qawolf/emails` and `@qawolf/testkit` are loaded. The bundle keeps the specifier external, so nothing from the mobile stack ships in `dist/cli.js`. A user running a mobile flow sees no difference: the packages were already pinned and installed on demand.

The loader is typed from webdriverio's own `remote` export, so a changed signature fails typecheck. The pin in the managed runtime's package list is what guarantees webdriverio is present in every dependency root, and its comment now says so. The build guard from #1575 now also rejects a top-level `webdriverio` import and a bundle over 2 MB.

The compiled binary keeps webdriverio inlined. A Bun-compiled binary cannot resolve a package's own bare imports out of `node_modules` (loading webdriverio from a managed install fails on `jszip`), so the binary takes the inlined branch that the build-time define makes static.

| | before | after |
| --- | --- | --- |
| `dist/cli.js` | 6.6 MB | 1.1 MB |
| `node dist/cli.js runner act --help`, median of 15 (local, M-series) | 169 ms | 144 ms |
| `node dist/cli.js --version` | 167 ms | 140 ms |

Node itself is about 40 ms of the remaining time. What is left in the bundle is our own source (0.7 MB), zod, commander and api-contracts.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All pass (2113 tests). New tests cover loading webdriverio from an env dir and the error when it is missing there. Also ran a real managed-runtime install into an empty directory and loaded the installed webdriverio from it. Built the binary and confirmed it still runs with webdriverio inlined.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
