### PR TITLE
build(cli): build release binaries with bun 1.4.2

### DIFF
--- a/.changeset/bun-1-4-release-binaries.md
+++ b/.changeset/bun-1-4-release-binaries.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-Release binaries are built with Bun 1.4.2 instead of 1.3.13. The standalone `qawolf` binary starts about 2.5x faster (492 ms to 188 ms for `qawolf --version` on a laptop). Nothing in the CLI itself changes.
+Built with Bun 1.4.2 instead of 1.3.13. The standalone `qawolf` binary starts about 2.5x faster (492 ms to 188 ms for `qawolf --version` on a laptop). The npm bundle is produced by the same bundler version and is meant to behave exactly as before.

--- a/.changeset/bun-1-4-release-binaries.md
+++ b/.changeset/bun-1-4-release-binaries.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Release binaries are built with Bun 1.4.2 instead of 1.3.13. The standalone `qawolf` binary starts about 2.5x faster (492 ms to 188 ms for `qawolf --version` on a laptop). Nothing in the CLI itself changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
       - run: bun run knip
       - run: bun run test
       - run: bun run build
+      # Built before the tarball check so its dist/qawolf exclusion is tested
+      # against a real file. Also the only pre-release run of the binary build
+      # on Linux; release-binaries.yml runs on publish only.
+      - name: Build and smoke the binary
+        run: |
+          bun scripts/buildBinary.ts
+          ./dist/qawolf --version
       - name: Verify tarball contents
         run: |
           output=$(bun pm pack --dry-run 2>&1)
@@ -133,6 +140,13 @@ jobs:
       # runner, which cannot shell out to .sh files (release v1.1.0–v1.4.2
       # Windows binaries all failed on exactly that).
       - run: bun run build
+      # The only pre-release run of the Windows binary build; release-binaries.yml
+      # runs on publish only.
+      - name: Build and smoke the binary
+        shell: bash
+        run: |
+          bun scripts/buildBinary.ts --outfile dist/qawolf.exe
+          ./dist/qawolf.exe --version
       # Bundling resolves the `~/` alias Node cannot. Only spawn.ts needs it;
       # the production-wiring check below runs the shipped bundle instead.
       - name: Bundle defaultSpawn for smoke

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "@changesets/cli": "2.31.0",
         "@tsconfig/bun": "1.0.10",
         "@tsconfig/strictest": "2.0.8",
-        "@types/bun": "1.3.14",
+        "@types/bun": "1.4.1",
         "@types/picomatch": "4.0.3",
         "@wdio/globals": "9.29.1",
         "@wdio/logger": "9.18.0",
@@ -500,7 +500,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
@@ -656,7 +656,7 @@
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@changesets/cli": "2.31.0",
     "@tsconfig/bun": "1.0.10",
     "@tsconfig/strictest": "2.0.8",
-    "@types/bun": "1.3.14",
+    "@types/bun": "1.4.1",
     "@types/picomatch": "4.0.3",
     "@wdio/globals": "9.29.1",
     "@wdio/logger": "9.18.0",

--- a/package.json
+++ b/package.json
@@ -107,5 +107,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "packageManager": "bun@1.3.13"
+  "packageManager": "bun@1.4.2"
 }


### PR DESCRIPTION
Closes WIZ-11970. Measurements: WIZ-11936. Stacked on #1576.

# Overview of Changes

The standalone `qawolf` binary built with Bun 1.3.13 takes about half a second to start, slower than running the npm bundle under Node. The same build under Bun 1.4.2 starts in under 200 ms. Nothing in the source changes, only the toolchain pin; the npm bundle is produced by the same bundler version and is meant to behave exactly as before.

`packageManager` moves to `bun@1.4.2`. Every workflow already reads its Bun version from that field through `setup-bun`, so no workflow edits were needed. `bun install --frozen-lockfile` passes under 1.4.2 with no lockfile changes. `@types/bun` moves to 1.4.1, the newest published, in its own commit; the lockfile keeps `bun-types` on the already hoisted `@types/node` 20 rather than nesting a Node 25 copy.

CI now also builds the binary and runs `--version` on Linux and Windows. Before, the only binary build was the release workflow itself, so a Bun bump was never exercised as a binary before a release, and the tarball check's `dist/qawolf` exclusion ran with no binary on disk.

`bun build --compile --bytecode` was tried on this bundle and crashes in both 1.3.14 and 1.4.2, so it is not added.

| `./dist/qawolf`, median of 10 (local, M-series) | Bun 1.3.13 | Bun 1.4.2 |
| --- | --- | --- |
| `--version` | 492 ms | 188 ms |
| `runner act --help` | 500 ms | 191 ms |

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
bun run build:binary && ./dist/qawolf --version
```

All pass under Bun 1.4.2 (2113 tests). The last line is the smoke check the release-binaries workflow runs; the built binary reports Bun 1.4.2 as its embedded runtime.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
