### PR TITLE
chore(cli): bump api-contracts to 0.40.0

### DIFF
--- a/.changeset/api-contracts-0-40-0.md
+++ b/.changeset/api-contracts-0-40-0.md
@@ -1,0 +1,9 @@
+---
+"@qawolf/cli": minor
+---
+
+Upgrades `@qawolf/api-contracts` to `0.40.0`.
+
+That release adds three endpoint contracts. The generator adds one public-API command for each contract. `qawolf agent send` tells the QA Wolf AI to do work, in plain language. `qawolf agent get` reads the replies from that work and shows its status. `qawolf run diagnose` records the failed flows of a run as reproductions of a bug report or a maintenance report.
+
+The release also changes the description of `qawolf issue addFlows`. The new description points to `run.diagnose` for bug reports and maintenance reports.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.39.0",
+        "@qawolf/api-contracts": "0.40.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.39.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-WbKDVrzkCD12zGmq3m0G8MDmkqEzJ8T906aC2s2yNi5tX0nu9Rraa7xeN2GY38yROETqcNuaN0MyEP0ef9C8hQ=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.40.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-jDoe+RL82pMQ48/nwBRPi37QBpDgFTbXhKP2jcwqSx7zRZN2bSDwuIrFlRCwy7ZxO07sGcRRmlyvvvkjsERzUw=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.39.0",
+    "@qawolf/api-contracts": "0.40.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -125,6 +125,8 @@ that `url`; never guess a route and never send a repository link in its place.
 <!-- prettier-ignore -->
 | Command | Kind | What it does |
 | --- | --- | --- |
+| `qawolf agent get` | read | Read what the QA Wolf AI has said and whether it is still working. Poll this after agent.send until the status settles. A status of "waiting-for-you" means the last reply is a question the work is blocked on, and answering it with agent.send is what unblocks it. Replies accumulate, so a caller that polls repeatedly sees the earlier ones again. |
+| `qawolf agent send` | write | Ask the QA Wolf AI to do a piece of work in plain language, such as covering a user journey, investigating a failing run, or fixing a broken flow. This is the one verb that starts work from nothing: every other write acts on a flow, run or issue that already exists. Answers as soon as the request is accepted, with the id to follow it by, because the work runs for minutes to tens of minutes. Poll agent.get for progress, and send here again to answer a question or add context to work already running. |
 | `qawolf auth login` | local | Authenticate with your QA Wolf API key |
 | `qawolf auth logout` | local | Remove stored credentials |
 | `qawolf auth whoami` | read | Show authentication status |
@@ -148,12 +150,13 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf install android` | local | Install Android system images, AVDs, and the Appium driver used by the project's Android flows |
 | `qawolf install browsers` | local | Install Playwright browsers used by the project's web flows |
 | `qawolf install clear` | local | Remove the managed runtime cache (all installed runtime versions) |
-| `qawolf issue addFlows` | write | Add flows to a coverage request owned by the caller's team. Flows already covered stay covered. Bug and maintenance reports link to flows through the runs that reproduce them, so their flows cannot be set directly. |
+| `qawolf issue addFlows` | write | Add flows to a coverage request owned by the caller's team. Flows already covered stay covered. Bug and maintenance reports link to flows through the runs that reproduce them; use run.diagnose to record one. |
 | `qawolf issue create` | write | Create a bug or coverage request issue for the caller's team. Maintenance issues cannot be created through the public API. |
 | `qawolf issue find` | read | List the team's bug reports, maintenance reports, or coverage requests, newest first. |
 | `qawolf issue get` | read | Get an issue by id. |
 | `qawolf issue update` | write | Update an issue owned by the caller's team. Omitted fields remain unchanged. |
 | `qawolf run create` | write | Create a run for the selected flows and/or tags in an environment. |
+| `qawolf run diagnose` | write | Diagnose failed flows in a run as reproductions of a bug or maintenance report owned by the caller's team. The issue's type selects the diagnosis. Each flow must have failed in the run. A flow that is already diagnosed moves to this issue. The diagnosis appears on the run, and the reproduction appears under the issue's reproductions. Coverage requests cannot be diagnosed; use issue.addFlows to cover flows instead. |
 | `qawolf run find` | read | List an environment's recent runs, newest first. |
 | `qawolf run get` | read | Get a run's status, per-flow results, and links. |
 | `qawolf run reattempt` | write | Request new attempts for a run's flows, in the same run. A flow is eligible once its result is failed or canceled and QA Wolf's automatic retries have finished. A fully investigated run no longer accepts reattempts. Attempts run with the latest flow code. Poll run.get for results. |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -22,6 +22,7 @@ Commands:
                                flows need
   runner                       Drive an interactive runner on the QA Wolf
                                platform
+  agent                        QA Wolf public API agent commands
   automate [options]           Request automation for draft flows. First create
                                a named local .flow.ts draft for every requested
                                journey that does not already have a matching


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

`@qawolf/api-contracts` 0.40.0 is on npm. It adds three endpoint contracts that the CLI does not expose yet. `registerPublicApiCommands` builds one command from each contract, so the bump alone adds the commands. No hand-written command code is necessary.

- **`package.json`** / **`bun.lock`**: move the `@qawolf/api-contracts` pin from `0.39.0` to `0.40.0`.
- **`skills/qawolf-cli/SKILL.md`**: generated. The command table gains `qawolf agent get`, `qawolf agent send` and `qawolf run diagnose`. The description of `qawolf issue addFlows` also changes, because 0.40.0 points it to `run.diagnose`.
- **`src/commands/__snapshots__/help.test.ts.snap`**: generated. The root `--help` output gains the `agent` group, on one line.
- **`.changeset/api-contracts-0-40-0.md`**: a `minor` changeset. This bump adds commands, so it is not a patch like the 0.39.0 bump.

The three new commands are:

- `qawolf agent send` tells the QA Wolf AI to do work, in plain language. `--message` is necessary. `--session-id`, `--environment-id` and `--workspace-id` are optional.
- `qawolf agent get` reads the replies from that work and shows its status. `--session-id` is necessary.
- `qawolf run diagnose` records the failed flows of a run as reproductions of a bug report or a maintenance report. `--flow-ids`, `--issue-id` and `--run-id` are all necessary.

The `agent` group keeps the generic group description, as `environment`, `flow`, `issue` and `tag` do. Only `run` has a curated description in `groupDescriptions`. Add one there if the group must read differently.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- The full suite gives 2113 passes and 0 failures. Only the root `--help` snapshot changed, and it changed by one line.
- Checked the generated help of each new command: `qawolf agent send --help`, `qawolf agent get --help` and `qawolf run diagnose --help` show the expected flags and descriptions.
- Checked that a missing necessary flag stops the command before the auth step. `qawolf agent get` reports `required option '--session-id <value>' not specified`.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
