### PR TITLE
feat(cli): list the team's runners from the platform

### DIFF
--- a/.changeset/api-contracts-0-47-0.md
+++ b/.changeset/api-contracts-0-47-0.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": minor
+---
+
+`qawolf runner list` now asks the platform which runners your team has running, so it shows runners launched from another directory, another machine, or an earlier session, and always shows each runner's family. Upgrades `@qawolf/api-contracts` to `0.47.0`, which adds the `runner.list` contract behind it.

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@clack/prompts": "1.5.1",
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
-        "@qawolf/api-contracts": "0.40.0",
+        "@qawolf/api-contracts": "0.47.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.40.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-jDoe+RL82pMQ48/nwBRPi37QBpDgFTbXhKP2jcwqSx7zRZN2bSDwuIrFlRCwy7ZxO07sGcRRmlyvvvkjsERzUw=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.47.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-I0ibBSgbghCdN29dQSzeGDypBLLVQcbP1lmBJgsGEHNcIOvXMfYS6bhXnsuG1+sMrZ3EmgJaO5rRkz1WBaxcVQ=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.23.0",
+  "version": "1.22.1",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",
@@ -71,7 +71,7 @@
     "@clack/prompts": "1.5.1",
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
-    "@qawolf/api-contracts": "0.40.0",
+    "@qawolf/api-contracts": "0.47.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -132,6 +132,11 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf auth whoami` | read | Show authentication status |
 | `qawolf automate` | write | Request automation for draft flows. First create a named local .flow.ts draft for every requested journey that does not already have a matching draft; never reuse a generic starter or placeholder. Each new draft must start with a JSDoc Goal: description, import flow from @qawolf/flows/web, and use export default flow(...); a comment-only file or direct test(...) call is not a valid draft. Commit and push all changes with Git to publish them, then list remote drafts to resolve every selected ID. Do not use patch to create or rename a selected flow. Finally make one automation request containing all requested flow IDs. |
 | `qawolf doctor` | local | Diagnose problems running flows locally |
+| `qawolf email find` | read | List the workspace's inbox, or its sent mail, newest first. Read a message body with email.get. |
+| `qawolf email get` | read | Read one email of the workspace, with its plain text and HTML bodies. Use it to pull a sign-in code or a verification link out of a message. |
+| `qawolf email getAttachment` | read | Read one attachment of a workspace email as base64 content, by file name or by position. email.get lists both. |
+| `qawolf email listAddresses` | read | List the workspace's inbox addresses, alphabetical. A flow can sign up with a plus-suffixed form of any of them, and email.find reads what arrives. |
+| `qawolf email send` | write | Send an email from one of the workspace's inbox addresses, for example to exercise a flow that reacts to incoming mail. Returns the sent email; read it back with email.get. |
 | `qawolf environment create` | write | Create an environment on the caller's team and return it in the environment.get shape. |
 | `qawolf environment deleteVariable` | write | Remove one environment variable by name. Succeeds whether or not the variable existed. |
 | `qawolf environment find` | read | List the team's environments, newest first. |
@@ -140,7 +145,8 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf environment listVariableNames` | read | Use this to answer which QA Wolf environment variables are available to test code. Returns names only; values never leave the server. |
 | `qawolf environment setVariable` | write | Create or replace an environment variable. If the user asks to create one for "my email" without naming it, use DEFAULT_EMAIL. The value is never returned. |
 | `qawolf environment update` | write | Update an environment owned by the caller's team and return it in the environment.get shape. Omitted fields remain unchanged. |
-| `qawolf flow addTag` | write | Assign an existing tag to the selected flows. Create tags with tag.create. |
+| `qawolf flow addTag` | write | Assign an existing tag to the selected flows. Create tags with tag.create. Flows that already carry the tag are reported in skippedFlows. |
+| `qawolf flow removeTag` | write | Remove a tag from the selected flows. Succeeds whether or not each flow carried the tag; the flows that did not are reported in skippedFlows. |
 | `qawolf flow update` | write | Move a flow between draft and active readiness. The other statuses shown in the app are derived and cannot be set. |
 | `qawolf flows list` | local (read with --remote) | List flows matching [pattern] from the local project, or from a QA Wolf environment with --remote |
 | `qawolf flows pull` | read | Download an environment's flows into the local .qawolf/<env>/ cache |
@@ -154,6 +160,7 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf issue create` | write | Create a bug or coverage request issue for the caller's team. Maintenance issues cannot be created through the public API. |
 | `qawolf issue find` | read | List the team's bug reports, maintenance reports, or coverage requests, newest first. |
 | `qawolf issue get` | read | Get an issue by id. |
+| `qawolf issue removeFlows` | write | Remove flows from a coverage request owned by the caller's team. Flows the request does not cover are left alone. Bug and maintenance reports link to flows through the runs that reproduce them, so their flows cannot be set directly. |
 | `qawolf issue update` | write | Update an issue owned by the caller's team. Omitted fields remain unchanged. |
 | `qawolf run create` | write | Create a run for the selected flows and/or tags in an environment. |
 | `qawolf run diagnose` | write | Diagnose failed flows in a run as reproductions of a bug or maintenance report owned by the caller's team. The issue's type selects the diagnosis. Each flow must have failed in the run. A flow that is already diagnosed moves to this issue. The diagnosis appears on the run, and the reproduction appears under the issue's reproductions. Coverage requests cannot be diagnosed; use issue.addFlows to cover flows instead. |
@@ -174,7 +181,7 @@ that `url`; never guess a route and never send a repository link in its place.
 | `qawolf runner inspect variable` | read | Print a top-level variable's value from the running workflow |
 | `qawolf runner keepalive` | read | Reset a runner's inactivity clock, for a caller that pauses between actions |
 | `qawolf runner launch` | write | Launch an interactive runner and make it this directory's default |
-| `qawolf runner list` | read | List the runners this directory holds that are still running |
+| `qawolf runner list` | read | List the runners running on your team |
 | `qawolf runner promote-snapshot` | write | Accept a run's screenshot as the new baseline for an image diff, on the runner that produced it |
 | `qawolf runner run` | write | Run a flow on an interactive runner, shipping the flow and what it imports |
 | `qawolf runner screenshot` | read | Save a JPEG of an interactive runner's screen to a file |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -37,6 +37,7 @@ Commands:
                                Do not use patch to create or rename a selected
                                flow. Finally make one automation request
                                containing all requested flow IDs.
+  email                        QA Wolf public API email commands
   environment                  QA Wolf public API environment commands
   flow                         QA Wolf public API flow commands
   issue                        QA Wolf public API issue commands
@@ -291,7 +292,7 @@ Options:
 
 Commands:
   launch [options]                         Launch an interactive runner and make it this directory's default
-  list                                     List the runners this directory holds that are still running
+  list                                     List the runners running on your team
   terminate [options]                      End an interactive runner, and the pod it runs on with it
   stop-run [options]                       Stop what a runner is currently executing, leaving the runner up
   keepalive [options]                      Reset a runner's inactivity clock, for a caller that pauses between actions

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -292,7 +292,7 @@ Options:
 
 Commands:
   launch [options]                         Launch an interactive runner and make it this directory's default
-  list                                     List the runners running on your team
+  list [options]                           List the runners running on your team
   terminate [options]                      End an interactive runner, and the pod it runs on with it
   stop-run [options]                       Stop what a runner is currently executing, leaving the runner up
   keepalive [options]                      Reset a runner's inactivity clock, for a caller that pauses between actions

--- a/src/commands/runner/lifecycle.register.ts
+++ b/src/commands/runner/lifecycle.register.ts
@@ -52,7 +52,7 @@ export function registerRunnerLifecycleCommands(
     );
 
   declareCommandKind(runner.command("list"), "read")
-    .description("List the runners this directory holds that are still running")
+    .description("List the runners running on your team")
     .addHelpText("after", listExamples)
     .action((opts: Record<string, never>, command: Command) =>
       withAuthContext(signals, (ctx) => handleRunnerList(ctx, runnerDeps(ctx)))(

--- a/src/commands/runner/lifecycle.register.ts
+++ b/src/commands/runner/lifecycle.register.ts
@@ -20,6 +20,7 @@ Examples:
 const listExamples = `
 Examples:
   $ qawolf runner list
+  $ qawolf runner list --here
   $ qawolf runner list --json`;
 
 const keepaliveExamples = `
@@ -53,12 +54,12 @@ export function registerRunnerLifecycleCommands(
 
   declareCommandKind(runner.command("list"), "read")
     .description("List the runners running on your team")
+    .option("--here", "Only the runners this directory launched")
     .addHelpText("after", listExamples)
-    .action((opts: Record<string, never>, command: Command) =>
-      withAuthContext(signals, (ctx) => handleRunnerList(ctx, runnerDeps(ctx)))(
-        opts,
-        command,
-      ),
+    .action((opts: { here?: boolean }, command: Command) =>
+      withAuthContext(signals, (ctx) =>
+        handleRunnerList(ctx, { here: opts.here === true }, runnerDeps(ctx)),
+      )(opts, command),
     );
 
   declareCommandKind(runner.command("terminate"), "write")

--- a/src/core/messages/interactiveRunner/list.ts
+++ b/src/core/messages/interactiveRunner/list.ts
@@ -1,6 +1,6 @@
 export const listMessages = {
   noRunners:
-    "This directory has no runner running. Launch one with qawolf runner launch, or pass --runner to address a runner started elsewhere.",
+    "Your team has no runner running. Launch one with qawolf runner launch.",
   runnerCount: (count: number) =>
     count === 1 ? "1 runner" : `${String(count)} runners`,
   title: "Runners",

--- a/src/core/messages/interactiveRunner/list.ts
+++ b/src/core/messages/interactiveRunner/list.ts
@@ -1,6 +1,8 @@
 export const listMessages = {
   noRunners:
     "Your team has no runner running. Launch one with qawolf runner launch.",
+  noRunnersHere:
+    "This directory has no runner running. Launch one with qawolf runner launch, or drop --here to see the whole team's.",
   runnerCount: (count: number) =>
     count === 1 ? "1 runner" : `${String(count)} runners`,
   title: "Runners",

--- a/src/core/messages/interactiveRunner/list.ts
+++ b/src/core/messages/interactiveRunner/list.ts
@@ -2,7 +2,7 @@ export const listMessages = {
   noRunners:
     "Your team has no runner running. Launch one with qawolf runner launch.",
   noRunnersHere:
-    "This directory has no runner running. Launch one with qawolf runner launch, or drop --here to see the whole team's.",
+    "This directory has no runner running. Launch one with qawolf runner launch, or drop --here to see the whole team's runners.",
   runnerCount: (count: number) =>
     count === 1 ? "1 runner" : `${String(count)} runners`,
   title: "Runners",

--- a/src/domains/interactiveRunner/list.test.ts
+++ b/src/domains/interactiveRunner/list.test.ts
@@ -15,12 +15,15 @@ function listed(...runners: ListedRunner[]): { ok: true; value: unknown } {
   return { ok: true, value: { outcome: "success", runners } };
 }
 
+const everywhere = { here: false };
+const onlyHere = { here: true };
+
 describe("handleRunnerList", () => {
   it("says so when the team has no runner running", async () => {
     const { callPublicApi, ctx, infos } = makeAuthCtx();
     callPublicApi.mockResolvedValue(listed());
 
-    const result = await handleRunnerList(ctx, makeTestDeps());
+    const result = await handleRunnerList(ctx, everywhere, makeTestDeps());
 
     expect(result).toBeUndefined();
     expect(infos()[0]).toContain("no runner running");
@@ -34,7 +37,7 @@ describe("handleRunnerList", () => {
       listed(runner("ci"), runner("review", "android")),
     );
 
-    await handleRunnerList(ctx, deps);
+    await handleRunnerList(ctx, everywhere, deps);
 
     const written = callsOf(ctx.ui.write)
       .map((call) => String(call[0]))
@@ -42,6 +45,88 @@ describe("handleRunnerList", () => {
     expect(written).toContain("ci");
     expect(written).toContain("review");
     expect(written).toContain("android");
+    expect(written).toContain("launched here");
+  });
+
+  it("marks the runners this directory launched", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx("json");
+    const deps = makeTestDeps();
+    await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
+    callPublicApi.mockResolvedValue(
+      listed(runner("elsewhere", "android"), runner("ci")),
+    );
+
+    await handleRunnerList(ctx, everywhere, deps);
+
+    expect(ctx.ui.json).toHaveBeenCalledWith([
+      {
+        id: "ci",
+        isDefault: true,
+        launchedHere: true,
+        runnerName: "playwright",
+      },
+      {
+        id: "elsewhere",
+        isDefault: false,
+        launchedHere: false,
+        runnerName: "android",
+      },
+    ]);
+  });
+
+  it("orders the default first, then this directory's, then the rest by id", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx("json");
+    const deps = makeTestDeps();
+    await deps.store.rememberLaunch({ id: "mine-b" });
+    await deps.store.rememberLaunch({ id: "mine-a" });
+    await deps.store.rememberLaunch({ id: "chosen" });
+    callPublicApi.mockResolvedValue(
+      listed(
+        runner("theirs-b"),
+        runner("mine-b"),
+        runner("chosen"),
+        runner("theirs-a"),
+        runner("mine-a"),
+      ),
+    );
+
+    await handleRunnerList(ctx, everywhere, deps);
+
+    const ids = callsOf(ctx.ui.json).map((call) =>
+      (call[0] as { id: string }[]).map((item) => item.id),
+    );
+    expect(ids).toEqual([
+      ["chosen", "mine-a", "mine-b", "theirs-a", "theirs-b"],
+    ]);
+  });
+
+  it("keeps only this directory's runners with --here", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx("json");
+    const deps = makeTestDeps();
+    await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
+    callPublicApi.mockResolvedValue(
+      listed(runner("elsewhere", "android"), runner("ci")),
+    );
+
+    await handleRunnerList(ctx, onlyHere, deps);
+
+    expect(ctx.ui.json).toHaveBeenCalledWith([
+      {
+        id: "ci",
+        isDefault: true,
+        launchedHere: true,
+        runnerName: "playwright",
+      },
+    ]);
+  });
+
+  it("says so when --here finds nothing but the team has runners", async () => {
+    const { callPublicApi, ctx, infos } = makeAuthCtx();
+    callPublicApi.mockResolvedValue(listed(runner("elsewhere")));
+
+    await handleRunnerList(ctx, onlyHere, makeTestDeps());
+
+    expect(infos()[0]).toContain("This directory has no runner running");
   });
 
   it("forgets a held runner the platform no longer has", async () => {
@@ -51,10 +136,15 @@ describe("handleRunnerList", () => {
     await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
     callPublicApi.mockResolvedValue(listed(runner("ci")));
 
-    await handleRunnerList(ctx, deps);
+    await handleRunnerList(ctx, everywhere, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "ci", isDefault: true, runnerName: "playwright" },
+      {
+        id: "ci",
+        isDefault: true,
+        launchedHere: true,
+        runnerName: "playwright",
+      },
     ]);
     expect((await deps.store.readRunners()).map((held) => held.id)).toEqual([
       "ci",
@@ -71,10 +161,15 @@ describe("handleRunnerList", () => {
     await deps.store.rememberLaunch({ id: "idled-out" });
     callPublicApi.mockResolvedValue(listed(runner("ci")));
 
-    await handleRunnerList(ctx, deps);
+    await handleRunnerList(ctx, everywhere, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "ci", isDefault: false, runnerName: "playwright" },
+      {
+        id: "ci",
+        isDefault: false,
+        launchedHere: true,
+        runnerName: "playwright",
+      },
     ]);
     expect(await deps.store.readDefaultRunnerId()).toBe("idled-out");
   });
@@ -87,11 +182,21 @@ describe("handleRunnerList", () => {
       listed(runner("stored"), runner("from-env", "basic")),
     );
 
-    await handleRunnerList(ctx, deps);
+    await handleRunnerList(ctx, everywhere, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "from-env", isDefault: true, runnerName: "basic" },
-      { id: "stored", isDefault: false, runnerName: "playwright" },
+      {
+        id: "from-env",
+        isDefault: true,
+        launchedHere: false,
+        runnerName: "basic",
+      },
+      {
+        id: "stored",
+        isDefault: false,
+        launchedHere: true,
+        runnerName: "playwright",
+      },
     ]);
   });
 
@@ -101,10 +206,10 @@ describe("handleRunnerList", () => {
     await deps.store.rememberLaunch({ id: "ci" });
     callPublicApi.mockResolvedValue(listed(runner("ci", "android")));
 
-    await handleRunnerList(ctx, deps);
+    await handleRunnerList(ctx, everywhere, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "ci", isDefault: true, runnerName: "android" },
+      { id: "ci", isDefault: true, launchedHere: true, runnerName: "android" },
     ]);
   });
 
@@ -117,7 +222,7 @@ describe("handleRunnerList", () => {
       ok: false,
     });
 
-    const result = await handleRunnerList(ctx, deps);
+    const result = await handleRunnerList(ctx, everywhere, deps);
 
     expect(result?.error).toContain("network unreachable");
     expect(ctx.ui.json).not.toHaveBeenCalled();
@@ -130,7 +235,7 @@ describe("handleRunnerList", () => {
     const { callPublicApi, ctx } = makeAuthCtx();
     callPublicApi.mockResolvedValue(listed());
 
-    await handleRunnerList(ctx, makeTestDeps());
+    await handleRunnerList(ctx, everywhere, makeTestDeps());
 
     const contracts = callsOf(callPublicApi).map(
       (call) => (call[0] as { kind: string; name: string }).name,

--- a/src/domains/interactiveRunner/list.test.ts
+++ b/src/domains/interactiveRunner/list.test.ts
@@ -5,17 +5,20 @@ import { callsOf } from "~/shell/commandContext.testUtils.js";
 import { handleRunnerList } from "./list.js";
 import { makeAuthCtx, makeTestDeps } from "./deps.testUtils.js";
 
-function running(id: string): { ok: true; value: unknown } {
-  return { ok: true, value: { id, outcome: "success", running: true } };
+type ListedRunner = { gpuAccelerated: boolean; id: string; runnerName: string };
+
+function runner(id: string, runnerName = "playwright"): ListedRunner {
+  return { gpuAccelerated: false, id, runnerName };
 }
 
-function gone(id: string): { ok: true; value: unknown } {
-  return { ok: true, value: { id, outcome: "success", running: false } };
+function listed(...runners: ListedRunner[]): { ok: true; value: unknown } {
+  return { ok: true, value: { outcome: "success", runners } };
 }
 
 describe("handleRunnerList", () => {
-  it("says so when the directory holds no runner", async () => {
-    const { ctx, infos } = makeAuthCtx();
+  it("says so when the team has no runner running", async () => {
+    const { callPublicApi, ctx, infos } = makeAuthCtx();
+    callPublicApi.mockResolvedValue(listed());
 
     const result = await handleRunnerList(ctx, makeTestDeps());
 
@@ -23,13 +26,12 @@ describe("handleRunnerList", () => {
     expect(infos()[0]).toContain("no runner running");
   });
 
-  it("names every runner the directory launched", async () => {
+  it("names every runner the team runs, wherever it was launched", async () => {
     const { callPublicApi, ctx } = makeAuthCtx("agent");
     const deps = makeTestDeps();
     await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
-    await deps.store.rememberLaunch({ id: "review", runnerName: "android" });
-    callPublicApi.mockImplementation(async (_contract, input) =>
-      running(String((input as { id: string }).id)),
+    callPublicApi.mockResolvedValue(
+      listed(runner("ci"), runner("review", "android")),
     );
 
     await handleRunnerList(ctx, deps);
@@ -42,24 +44,21 @@ describe("handleRunnerList", () => {
     expect(written).toContain("android");
   });
 
-  it("leaves out a runner that has terminated, and forgets it", async () => {
+  it("forgets a held runner the platform no longer has", async () => {
     const { callPublicApi, ctx } = makeAuthCtx("json");
     const deps = makeTestDeps();
     await deps.store.rememberLaunch({ id: "idled-out" });
     await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
-    callPublicApi.mockImplementation(async (_contract, input) => {
-      const { id } = input as { id: string };
-      return id === "ci" ? running(id) : gone(id);
-    });
+    callPublicApi.mockResolvedValue(listed(runner("ci")));
 
     await handleRunnerList(ctx, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
       { id: "ci", isDefault: true, runnerName: "playwright" },
     ]);
-    expect((await deps.store.readRunners()).map((runner) => runner.id)).toEqual(
-      ["ci"],
-    );
+    expect((await deps.store.readRunners()).map((held) => held.id)).toEqual([
+      "ci",
+    ]);
   });
 
   // Listing is a read, so it reports that the default is gone without
@@ -70,10 +69,7 @@ describe("handleRunnerList", () => {
     const deps = makeTestDeps();
     await deps.store.rememberLaunch({ id: "ci", runnerName: "playwright" });
     await deps.store.rememberLaunch({ id: "idled-out" });
-    callPublicApi.mockImplementation(async (_contract, input) => {
-      const { id } = input as { id: string };
-      return id === "ci" ? running(id) : gone(id);
-    });
+    callPublicApi.mockResolvedValue(listed(runner("ci")));
 
     await handleRunnerList(ctx, deps);
 
@@ -83,40 +79,36 @@ describe("handleRunnerList", () => {
     expect(await deps.store.readDefaultRunnerId()).toBe("idled-out");
   });
 
-  // The session's first runner is launched for the CLI rather than by it, so
-  // nothing but the environment names it.
-  it("includes the runner named by the environment", async () => {
-    const { callPublicApi, ctx } = makeAuthCtx("json");
-    const deps = makeTestDeps({ env: { QAWOLF_RUNNER_ID: "tester-abc" } });
-    callPublicApi.mockImplementation(async (_contract, input) =>
-      running(String((input as { id: string }).id)),
-    );
-
-    await handleRunnerList(ctx, deps);
-
-    expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "tester-abc", isDefault: true, runnerName: undefined },
-    ]);
-  });
-
   it("marks the environment's runner as the default over the stored one", async () => {
     const { callPublicApi, ctx } = makeAuthCtx("json");
     const deps = makeTestDeps({ env: { QAWOLF_RUNNER_ID: "from-env" } });
     await deps.store.rememberLaunch({ id: "stored", runnerName: "playwright" });
-    callPublicApi.mockImplementation(async (_contract, input) =>
-      running(String((input as { id: string }).id)),
+    callPublicApi.mockResolvedValue(
+      listed(runner("stored"), runner("from-env", "basic")),
     );
 
     await handleRunnerList(ctx, deps);
 
     expect(ctx.ui.json).toHaveBeenCalledWith([
-      { id: "from-env", isDefault: true, runnerName: undefined },
+      { id: "from-env", isDefault: true, runnerName: "basic" },
       { id: "stored", isDefault: false, runnerName: "playwright" },
     ]);
   });
 
-  // A shorter list would read as the whole truth.
-  it("reports a lookup that failed rather than a partial list", async () => {
+  it("lists the family the platform reports, not the one remembered locally", async () => {
+    const { callPublicApi, ctx } = makeAuthCtx("json");
+    const deps = makeTestDeps();
+    await deps.store.rememberLaunch({ id: "ci" });
+    callPublicApi.mockResolvedValue(listed(runner("ci", "android")));
+
+    await handleRunnerList(ctx, deps);
+
+    expect(ctx.ui.json).toHaveBeenCalledWith([
+      { id: "ci", isDefault: true, runnerName: "android" },
+    ]);
+  });
+
+  it("reports a listing that failed", async () => {
     const { callPublicApi, ctx } = makeAuthCtx("json");
     const deps = makeTestDeps();
     await deps.store.rememberLaunch({ id: "ci" });
@@ -129,13 +121,20 @@ describe("handleRunnerList", () => {
 
     expect(result?.error).toContain("network unreachable");
     expect(ctx.ui.json).not.toHaveBeenCalled();
+    expect((await deps.store.readRunners()).map((held) => held.id)).toEqual([
+      "ci",
+    ]);
   });
 
-  it("never launches a runner", async () => {
+  it("only reads, and never launches a runner", async () => {
     const { callPublicApi, ctx } = makeAuthCtx();
+    callPublicApi.mockResolvedValue(listed());
 
     await handleRunnerList(ctx, makeTestDeps());
 
-    expect(callPublicApi).not.toHaveBeenCalled();
+    const contracts = callsOf(callPublicApi).map(
+      (call) => (call[0] as { kind: string; name: string }).name,
+    );
+    expect(contracts).toEqual(["runner.list"]);
   });
 });

--- a/src/domains/interactiveRunner/list.ts
+++ b/src/domains/interactiveRunner/list.ts
@@ -52,8 +52,9 @@ async function readDefaultRunnerId(
 /**
  * The team's active runners: a runner launched from another checkout, another
  * machine, or an earlier session is listed alongside this directory's own.
- * The directory's records only say which runners were launched here, and are
- * pruned of the runners that are no longer active.
+ * The directory's records supply the default runner when QAWOLF_RUNNER_ID is
+ * unset, say which runners were launched here, and are pruned of the runners
+ * that are no longer active.
  */
 export async function listRunners(
   ctx: RunnerApiContext,

--- a/src/domains/interactiveRunner/list.ts
+++ b/src/domains/interactiveRunner/list.ts
@@ -1,6 +1,5 @@
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
-import { batchMap } from "~/core/batchMap.js";
 import { interactiveRunnerMessages } from "~/core/messages/index.js";
 import { type TableColumn, renderTable } from "~/core/renderTable.js";
 import type {
@@ -13,7 +12,6 @@ import {
   failureFields,
   type PlatformFailure,
 } from "~/shell/platform/requestWithRetry.js";
-import type { StoredRunner } from "~/shell/interactiveRunner/runnerStore.js";
 
 import type { InteractiveRunnerDeps } from "./deps.js";
 import { runnerIdEnvironmentVariable } from "./resolveRunner.js";
@@ -22,7 +20,7 @@ import { runnerCallOptions } from "./runnerCallOptions.js";
 type RunnerListItem = {
   id: string;
   isDefault: boolean;
-  runnerName: string | undefined;
+  runnerName: string;
 };
 
 export type ListedRunners =
@@ -31,71 +29,50 @@ export type ListedRunners =
 
 const columns: readonly TableColumn<RunnerListItem>[] = [
   { header: "id", value: (row) => row.id },
-  { header: "family", value: (row) => row.runnerName ?? "" },
+  { header: "family", value: (row) => row.runnerName },
   { header: "default", value: (row) => (row.isDefault ? "yes" : "") },
 ];
 
-const probeBatchSize = 8;
-
-type Probe =
-  | { ok: true; runner: StoredRunner; running: boolean }
-  | ({ ok: false } & PlatformFailure);
-
-async function readCandidates(deps: InteractiveRunnerDeps): Promise<{
-  candidates: StoredRunner[];
-  defaultRunnerId: string | undefined;
-}> {
-  const held = await deps.store.readRunners();
-  const storedDefault = await deps.store.readDefaultRunnerId();
+async function readDefaultRunnerId(
+  deps: InteractiveRunnerDeps,
+): Promise<string | undefined> {
   const environmentValue = deps.env[runnerIdEnvironmentVariable]?.trim();
-  const fromEnvironment = environmentValue ? environmentValue : undefined;
-
-  const candidates = [...held];
-  for (const id of [storedDefault, fromEnvironment]) {
-    if (id !== undefined && !candidates.some((runner) => runner.id === id)) {
-      candidates.push({ id });
-    }
-  }
-  return { candidates, defaultRunnerId: fromEnvironment ?? storedDefault };
+  if (environmentValue) return environmentValue;
+  return deps.store.readDefaultRunnerId();
 }
 
-async function probeRunner(
-  ctx: RunnerApiContext,
-  runner: StoredRunner,
-): Promise<Probe> {
-  const result = await ctx.platformClient.callPublicApi(
-    publicContractsV1.runner.get,
-    { id: runner.id },
-    runnerCallOptions,
-  );
-  if (!result.ok) return { ...failureFields(result), ok: false };
-  return { ok: true, runner, running: result.value.running };
-}
-
+/**
+ * The team's running runners, as the platform sees them: a runner launched from
+ * another checkout, another machine, or an earlier session is listed alongside
+ * this directory's own. The directory's records are only consulted to forget
+ * the runners the platform no longer has.
+ */
 export async function listRunners(
   ctx: RunnerApiContext,
   deps: InteractiveRunnerDeps,
 ): Promise<ListedRunners> {
-  const { candidates, defaultRunnerId } = await readCandidates(deps);
+  const listed = await ctx.platformClient.callPublicApi(
+    publicContractsV1.runner.list,
+    {},
+    runnerCallOptions,
+  );
+  if (!listed.ok) return { ...failureFields(listed), ok: false };
 
-  const running: StoredRunner[] = [];
-  const gone: string[] = [];
-  for await (const probe of batchMap(
-    candidates,
-    (runner) => probeRunner(ctx, runner),
-    probeBatchSize,
-  )) {
-    if (!probe.ok) return { ...failureFields(probe), ok: false };
-    if (probe.running) running.push(probe.runner);
-    else gone.push(probe.runner.id);
-  }
-
+  const defaultRunnerId = await readDefaultRunnerId(deps);
+  const runningIds = new Set(listed.value.runners.map((runner) => runner.id));
+  const held = await deps.store.readRunners();
+  const gone = held
+    .filter((runner) => !runningIds.has(runner.id))
+    .map((runner) => runner.id);
   await deps.store.dropRunners(gone).catch(() => undefined);
 
+  const byId = [...listed.value.runners].sort((left, right) =>
+    left.id.localeCompare(right.id),
+  );
   return {
     items: [
-      ...running.filter((runner) => runner.id === defaultRunnerId),
-      ...running.filter((runner) => runner.id !== defaultRunnerId),
+      ...byId.filter((runner) => runner.id === defaultRunnerId),
+      ...byId.filter((runner) => runner.id !== defaultRunnerId),
     ].map((runner) => ({
       id: runner.id,
       isDefault: runner.id === defaultRunnerId,

--- a/src/domains/interactiveRunner/list.ts
+++ b/src/domains/interactiveRunner/list.ts
@@ -42,10 +42,10 @@ async function readDefaultRunnerId(
 }
 
 /**
- * The team's running runners, as the platform sees them: a runner launched from
- * another checkout, another machine, or an earlier session is listed alongside
- * this directory's own. The directory's records are only consulted to forget
- * the runners the platform no longer has.
+ * The team's active runners: a runner launched from another checkout, another
+ * machine, or an earlier session is listed alongside this directory's own.
+ * The directory's records are only consulted to forget the runners that are no
+ * longer active.
  */
 export async function listRunners(
   ctx: RunnerApiContext,

--- a/src/domains/interactiveRunner/list.ts
+++ b/src/domains/interactiveRunner/list.ts
@@ -20,6 +20,8 @@ import { runnerCallOptions } from "./runnerCallOptions.js";
 type RunnerListItem = {
   id: string;
   isDefault: boolean;
+  /** Whether this directory launched the runner, as opposed to another checkout, machine or session. */
+  launchedHere: boolean;
   runnerName: string;
 };
 
@@ -30,8 +32,14 @@ export type ListedRunners =
 const columns: readonly TableColumn<RunnerListItem>[] = [
   { header: "id", value: (row) => row.id },
   { header: "family", value: (row) => row.runnerName },
+  { header: "launched here", value: (row) => (row.launchedHere ? "yes" : "") },
   { header: "default", value: (row) => (row.isDefault ? "yes" : "") },
 ];
+
+function rank(item: RunnerListItem): number {
+  if (item.isDefault) return 0;
+  return item.launchedHere ? 1 : 2;
+}
 
 async function readDefaultRunnerId(
   deps: InteractiveRunnerDeps,
@@ -44,8 +52,8 @@ async function readDefaultRunnerId(
 /**
  * The team's active runners: a runner launched from another checkout, another
  * machine, or an earlier session is listed alongside this directory's own.
- * The directory's records are only consulted to forget the runners that are no
- * longer active.
+ * The directory's records only say which runners were launched here, and are
+ * pruned of the runners that are no longer active.
  */
 export async function listRunners(
   ctx: RunnerApiContext,
@@ -66,38 +74,45 @@ export async function listRunners(
     .map((runner) => runner.id);
   await deps.store.dropRunners(gone).catch(() => undefined);
 
-  const byId = [...listed.value.runners].sort((left, right) =>
-    left.id.localeCompare(right.id),
-  );
+  const heldIds = new Set(held.map((runner) => runner.id));
+  const items = listed.value.runners.map((runner) => ({
+    id: runner.id,
+    isDefault: runner.id === defaultRunnerId,
+    launchedHere: heldIds.has(runner.id),
+    runnerName: runner.runnerName,
+  }));
   return {
-    items: [
-      ...byId.filter((runner) => runner.id === defaultRunnerId),
-      ...byId.filter((runner) => runner.id !== defaultRunnerId),
-    ].map((runner) => ({
-      id: runner.id,
-      isDefault: runner.id === defaultRunnerId,
-      runnerName: runner.runnerName,
-    })),
+    items: items.sort(
+      (left, right) =>
+        rank(left) - rank(right) || left.id.localeCompare(right.id),
+    ),
     ok: true,
   };
 }
 
 export async function handleRunnerList(
   ctx: AuthCommandContext,
+  options: { here: boolean },
   deps: InteractiveRunnerDeps,
 ): Promise<CommandResult> {
   const listed = await listRunners(ctx, deps);
   if (!listed.ok) {
     return { ...failureFields(listed), exitCode: exitCodes.network };
   }
-  const items = listed.items;
+  const items = options.here
+    ? listed.items.filter((item) => item.launchedHere)
+    : listed.items;
 
   if (ctx.ui.mode === "json") {
     ctx.ui.json(items);
     return;
   }
   if (items.length === 0) {
-    ctx.ui.info(interactiveRunnerMessages.noRunners);
+    ctx.ui.info(
+      options.here
+        ? interactiveRunnerMessages.noRunnersHere
+        : interactiveRunnerMessages.noRunners,
+    );
     return;
   }
   if (ctx.ui.mode === "agent") {

--- a/src/domains/publicApi/skippedContracts.ts
+++ b/src/domains/publicApi/skippedContracts.ts
@@ -25,6 +25,7 @@ export const skippedContractNames: ReadonlySet<string> = new Set([
   "runner.inspect",
   "runner.inspectMobile",
   "runner.launch",
+  "runner.list",
   "runner.performAction",
   "runner.promoteSnapshot",
   "runner.readJournal",

--- a/src/runnerSdk/types.ts
+++ b/src/runnerSdk/types.ts
@@ -115,11 +115,15 @@ export type SubmittedRun = {
   runId: string;
 };
 
-/** Runners this working directory launched, which the API has no notion of. */
+/**
+ * A runner running on the team. `isDefault` and `launchedHere` are this working
+ * directory's own knowledge, which the API has no notion of.
+ */
 export type ListedRunner = {
   id: string;
   isDefault: boolean;
-  runnerName: string | undefined;
+  launchedHere: boolean;
+  runnerName: string;
 };
 
 export type KeptAlive = { id: string };

--- a/src/shell/interactiveRunner/runnerStore.ts
+++ b/src/shell/interactiveRunner/runnerStore.ts
@@ -24,7 +24,7 @@ const storeSchema = z.object({
   defaultRunnerId: z.string().optional(),
 });
 
-export type StoredRunner = z.output<typeof storedRunnerSchema>;
+type StoredRunner = z.output<typeof storedRunnerSchema>;
 
 function parseJson(text: string): unknown {
   try {


### PR DESCRIPTION
Relates to [WIZ-11964](https://linear.app/qawolf/issue/WIZ-11964) and qawolf/platform#32920.

# Overview of Changes

`qawolf runner list` only knew about runners launched from the current directory, because it read a list the CLI kept on the local disk. A runner launched from another checkout, another machine, or an earlier session never showed up. The platform now answers this itself with the `runner.list` route, so the command asks the platform and shows every runner running on the team, with each runner's family always filled in. The local records are still used to mark the directory's default runner, to mark which runners were launched from this directory (a new `launched here` column, `launchedHere` in JSON), and to forget runners the platform no longer has. `--here` narrows the list to this directory's own runners.

`@qawolf/api-contracts` goes 0.40.0 → 0.47.0, the first published build with the new contract. That range also brings the `email` commands into the generated command surface, which is why the skill doc and the help snapshot moved. `runner.list` is added to the skipped contracts so the generator does not mint a second `runner list`.

Tested against the platform preview for #32920: two runners launched from one directory were listed from a second directory, terminated one at a time, and disappeared from the list as they went.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All pass locally: 2113 tests, 0 failures.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
