### PR TITLE
feat(cli): filter a long selection list by typing

### DIFF
--- a/.changeset/list-filter.md
+++ b/.changeset/list-filter.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+A prompt that shows more than eight items now lets you type to filter the list. This applies to the organization and the workspace prompts, where an account that reaches many organizations gets a long list.
+
+The filter matches a name, a slug, or an id. It ignores letter case, and it reads a space and a hyphen as the same character, so `acme retail` finds `acme-retail`. The arrow keys and Enter continue to operate as before, and an empty filter box shows the full list.

--- a/src/core/suggestNearMiss.ts
+++ b/src/core/suggestNearMiss.ts
@@ -1,12 +1,4 @@
-// Case and separators are presentation, not identity: a group folder named
-// `smoke-tests` is shown as "Smoke Tests" in the map UI, so both spellings
-// have to collapse to the same thing before comparing.
-function normalize(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[-_\s]+/g, " ")
-    .trim();
-}
+import { normalizeForSearch as normalize } from "./textSearch.js";
 
 function editDistance(a: string, b: string): number {
   // Single-row Levenshtein: `row[j]` is the distance from a[0..i] to b[0..j].

--- a/src/core/textSearch.test.ts
+++ b/src/core/textSearch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { matchesSearchTerm, normalizeForSearch } from "./textSearch.js";
+import {
+  createSearchIndex,
+  matchesSearchTerm,
+  normalizeForSearch,
+} from "./textSearch.js";
 
 describe("normalizeForSearch", () => {
   it("collapses case and every separator to one spelling", () => {
@@ -44,5 +48,59 @@ describe("matchesSearchTerm", () => {
   it("skips absent fields", () => {
     expect(matchesSearchTerm("acme", [undefined])).toBe(false);
     expect(matchesSearchTerm("acme", [undefined, "Acme"])).toBe(true);
+  });
+});
+
+describe("createSearchIndex", () => {
+  const items = [
+    { name: "Acme Retail", slug: "acme-retail", id: "ws_01" },
+    { name: "Globex Wholesale", slug: "globex-wholesale", id: "ws_02" },
+  ];
+  const fieldsOf = (i: (typeof items)[number]) => [i.name, i.slug, i.id];
+
+  it("matches the same things as a direct call", () => {
+    const match = createSearchIndex(items, fieldsOf);
+
+    expect(match("acme", items[0]!)).toBe(true);
+    // Typed with a space, stored with a hyphen.
+    expect(match("acme retail", items[0]!)).toBe(true);
+    expect(match("WS_02", items[1]!)).toBe(true);
+    expect(match("acme", items[1]!)).toBe(false);
+  });
+
+  it("shows the whole list for a blank search", () => {
+    const match = createSearchIndex(items, fieldsOf);
+
+    expect(match("", items[0]!)).toBe(true);
+    expect(match("  ", items[1]!)).toBe(true);
+  });
+
+  // The search text is normalized once per term rather than once per item, so
+  // the terms have to keep working when they change back and forth.
+  it("keeps answering correctly as the search term changes", () => {
+    const match = createSearchIndex(items, fieldsOf);
+
+    expect(match("acme", items[0]!)).toBe(true);
+    expect(match("globex", items[0]!)).toBe(false);
+    expect(match("globex", items[1]!)).toBe(true);
+    expect(match("acme", items[0]!)).toBe(true);
+  });
+
+  // Falling back rather than reporting no match: a caller that filters a list
+  // it did not index still deserves the right answer.
+  it("still matches an item that was never indexed", () => {
+    const match = createSearchIndex(items, fieldsOf);
+    const stranger = { name: "Initech", slug: "initech", id: "ws_03" };
+
+    expect(match("initech", stranger)).toBe(true);
+    expect(match("acme", stranger)).toBe(false);
+  });
+
+  it("skips absent fields", () => {
+    const sparse = [{ name: undefined, slug: "only-slug", id: "ws_04" }];
+    const match = createSearchIndex(sparse, (i) => [i.name, i.slug, i.id]);
+
+    expect(match("only slug", sparse[0]!)).toBe(true);
+    expect(match("missing", sparse[0]!)).toBe(false);
   });
 });

--- a/src/core/textSearch.test.ts
+++ b/src/core/textSearch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import { matchesSearchTerm, normalizeForSearch } from "./textSearch.js";
+
+describe("normalizeForSearch", () => {
+  it("collapses case and every separator to one spelling", () => {
+    expect(normalizeForSearch("Acme_Retail")).toBe("acme retail");
+    expect(normalizeForSearch("acme-retail")).toBe("acme retail");
+    expect(normalizeForSearch("  Acme   Retail  ")).toBe("acme retail");
+  });
+});
+
+describe("matchesSearchTerm", () => {
+  const fields = ["Acme Retail", "acme-retail", "ws_01H9"];
+
+  it("matches part of any field", () => {
+    expect(matchesSearchTerm("retail", fields)).toBe(true);
+    expect(matchesSearchTerm("ws_01", fields)).toBe(true);
+  });
+
+  it("ignores case", () => {
+    expect(matchesSearchTerm("ACME", fields)).toBe(true);
+  });
+
+  // Someone reading a name types spaces; the slug they are matching has
+  // hyphens. Both have to reach the same row.
+  it("treats a typed space and a slug hyphen as the same separator", () => {
+    expect(matchesSearchTerm("acme retail", ["acme-retail"])).toBe(true);
+    expect(matchesSearchTerm("acme-retail", ["Acme Retail"])).toBe(true);
+  });
+
+  it("does not match what is absent", () => {
+    expect(matchesSearchTerm("wholesale", fields)).toBe(false);
+  });
+
+  // Clearing the box must restore the list, not empty it.
+  it("matches everything for an empty or blank search", () => {
+    expect(matchesSearchTerm("", fields)).toBe(true);
+    expect(matchesSearchTerm("   ", fields)).toBe(true);
+  });
+
+  // A blank search short-circuits, so this covers the other path: an absent
+  // field must not behave like an empty string that contains anything.
+  it("skips absent fields", () => {
+    expect(matchesSearchTerm("acme", [undefined])).toBe(false);
+    expect(matchesSearchTerm("acme", [undefined, "Acme"])).toBe(true);
+  });
+});

--- a/src/core/textSearch.ts
+++ b/src/core/textSearch.ts
@@ -30,3 +30,45 @@ export function matchesSearchTerm(
       field !== undefined && normalizeForSearch(field).includes(needle),
   );
 }
+
+/**
+ * Builds a matcher for a list that will be filtered many times over.
+ *
+ * A filter box re-tests every item on every keystroke, so normalizing the same
+ * fields again on each pass is the cost that shows once a list is long. This
+ * normalizes each item once up front, and the search text once per keystroke
+ * rather than once per item.
+ */
+export function createSearchIndex<Item extends object>(
+  items: readonly Item[],
+  fieldsOf: (item: Item) => readonly (string | undefined)[],
+): (search: string, item: Item) => boolean {
+  const indexed = new Map<Item, string[]>();
+  for (const item of items) {
+    indexed.set(
+      item,
+      fieldsOf(item).flatMap((field) =>
+        field === undefined ? [] : [normalizeForSearch(field)],
+      ),
+    );
+  }
+
+  let lastSearch: string | undefined;
+  let needle = "";
+
+  return (search, item) => {
+    if (search !== lastSearch) {
+      lastSearch = search;
+      needle = normalizeForSearch(search);
+    }
+    if (!needle) return true;
+
+    const fields = indexed.get(item);
+    // An item the index never saw is matched the slow way rather than
+    // reported as no match, so a caller that filters a list it did not index
+    // still gets the right answer.
+    return fields
+      ? fields.some((field) => field.includes(needle))
+      : matchesSearchTerm(search, fieldsOf(item));
+  };
+}

--- a/src/core/textSearch.ts
+++ b/src/core/textSearch.ts
@@ -1,0 +1,32 @@
+/**
+ * Case and separators are presentation, not identity: an organization shown as
+ * "Acme Retail" has the slug `acme-retail`, and someone who types either
+ * spelling means the same thing. Collapsing both before comparing is what lets
+ * a filter box, a near-miss suggestion, and a pasted slug agree on what a
+ * person meant.
+ */
+export function normalizeForSearch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[-_\s]+/g, " ")
+    .trim();
+}
+
+/**
+ * Whether any of `fields` contains what was typed.
+ *
+ * An empty search matches everything, so clearing a filter box restores the
+ * list rather than emptying it. Absent fields are skipped rather than treated
+ * as an empty string, which would otherwise match every search of one space.
+ */
+export function matchesSearchTerm(
+  search: string,
+  fields: readonly (string | undefined)[],
+): boolean {
+  const needle = normalizeForSearch(search);
+  if (!needle) return true;
+  return fields.some(
+    (field) =>
+      field !== undefined && normalizeForSearch(field).includes(needle),
+  );
+}

--- a/src/shell/ui/clack/styledClack.mock.ts
+++ b/src/shell/ui/clack/styledClack.mock.ts
@@ -33,6 +33,7 @@ export function makeClack() {
     cancel: mock(),
     confirm: mock(),
     password: mock(),
+    autocomplete: mock(),
     select: mock(),
     isCancel: isCancel as typeof isCancel & StyledClack["isCancel"],
     spinner: mock((): MockSpinner => {

--- a/src/shell/ui/clack/styledClack.ts
+++ b/src/shell/ui/clack/styledClack.ts
@@ -1,4 +1,5 @@
 import {
+  autocomplete,
   cancel,
   confirm,
   intro,
@@ -31,6 +32,17 @@ export type StyledClack = {
     initialValue?: boolean;
   }): Promise<boolean | symbol>;
   password(opts: { message: string }): Promise<string | symbol>;
+  autocomplete(opts: {
+    message: string;
+    options: { value: string; label: string; hint?: string }[];
+    placeholder?: string;
+    maxItems?: number;
+    /** Option shape is clack's, where every field but `value` is optional. */
+    filter?: (
+      search: string,
+      option: { value: string; label?: string; hint?: string },
+    ) => boolean;
+  }): Promise<string | symbol>;
   select(opts: {
     message: string;
     options: { value: string; label: string; hint?: string }[];
@@ -58,6 +70,7 @@ export function createStyledClack(): StyledClack {
     cancel,
     confirm,
     password,
+    autocomplete,
     select,
     isCancel,
     spinner,

--- a/src/shell/ui/renderers/select.test.ts
+++ b/src/shell/ui/renderers/select.test.ts
@@ -170,3 +170,27 @@ describe("createSelect with a long list", () => {
     expect(capturedFilter(clack)("ws", { value: "ws_1" })).toBe(true);
   });
 });
+
+describe("createSelect search prompt options", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  // A cap would show a tenth of the rows the plain list shows, so filtering
+  // would arrive at the cost of seeing far less of the list at once.
+  it("does not cap how much of the list is visible", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue("env-0");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+
+    await select("Which organization?", makeOptions(9));
+
+    const opts = clack.autocomplete.mock.calls[0]?.[0] as {
+      maxItems?: number;
+      placeholder?: string;
+    };
+    expect(opts.maxItems).toBeUndefined();
+    expect(opts.placeholder).toBe("Type to filter");
+  });
+});

--- a/src/shell/ui/renderers/select.test.ts
+++ b/src/shell/ui/renderers/select.test.ts
@@ -57,3 +57,116 @@ describe("createSelect", () => {
     );
   });
 });
+
+function makeOptions(count: number) {
+  return Array.from({ length: count }, (_unused, index) => ({
+    value: `env-${index}`,
+    label: `Environment ${index}`,
+  }));
+}
+
+/** Pulls the filter clack was handed, so the matching rule is testable. */
+function capturedFilter(clack: ReturnType<typeof makeClack>) {
+  const call = clack.autocomplete.mock.calls[0]?.[0] as
+    | {
+        filter?: (
+          search: string,
+          option: { value: string; label?: string; hint?: string },
+        ) => boolean;
+      }
+    | undefined;
+  const filter = call?.filter;
+  if (!filter) throw Error("autocomplete was called without a filter");
+  return filter;
+}
+
+describe("createSelect with a long list", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  // Nine is the first count an employee-sized list stands in for: the
+  // arrow-key prompt stops being scannable well before hundreds of entries.
+  it("asks with a searchable prompt once the list passes the threshold", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue("env-4");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+
+    const result = await select("Which organization?", makeOptions(9));
+
+    expect(result).toEqual({ ok: true, value: "env-4" });
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(clack.autocomplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the plain list at the threshold, where typing would only slow it", async () => {
+    const clack = makeClack();
+    clack.select.mockResolvedValue("env-1");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+
+    await select("Which organization?", makeOptions(8));
+
+    expect(clack.select).toHaveBeenCalledTimes(1);
+    expect(clack.autocomplete).not.toHaveBeenCalled();
+  });
+
+  it("returns not ok when the search prompt is cancelled", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue(Symbol("cancel"));
+    clack.isCancel.mockReturnValue(true);
+    const select = createSelect({ mode: "human", clack });
+
+    expect(await select("Which organization?", makeOptions(9))).toEqual({
+      ok: false,
+    });
+  });
+
+  it("matches name, slug and id, and ignores case", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue("env-0");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+    await select("Which workspace?", makeOptions(9));
+    const filter = capturedFilter(clack);
+
+    const option = {
+      value: "ws_123",
+      label: "Acme Retail",
+      hint: "acme-retail",
+    };
+
+    expect(filter("acme", option)).toBe(true);
+    expect(filter("RETAIL", option)).toBe(true);
+    expect(filter("acme-ret", option)).toBe(true);
+    expect(filter("ws_123", option)).toBe(true);
+    // Typed with a space, stored with a hyphen.
+    expect(filter("acme retail", option)).toBe(true);
+    expect(filter("nothing", option)).toBe(false);
+  });
+
+  // An empty box must not read as "nothing matches", or the list would vanish
+  // the moment someone clears what they typed.
+  it("matches everything while the box is empty", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue("env-0");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+    await select("Which workspace?", makeOptions(9));
+
+    expect(capturedFilter(clack)("   ", { value: "ws_1", label: "Acme" })).toBe(
+      true,
+    );
+  });
+
+  it("tolerates an option that carries no label", async () => {
+    const clack = makeClack();
+    clack.autocomplete.mockResolvedValue("env-0");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+    await select("Which workspace?", makeOptions(9));
+
+    expect(capturedFilter(clack)("ws", { value: "ws_1" })).toBe(true);
+  });
+});

--- a/src/shell/ui/renderers/select.ts
+++ b/src/shell/ui/renderers/select.ts
@@ -1,3 +1,4 @@
+import { matchesSearchTerm } from "~/core/textSearch.js";
 import type { StyledClack } from "~/shell/ui/clack/index.js";
 import type { OutputMode } from "~/shell/ui/env.js";
 import { assertHumanMode } from "./assertHumanMode.js";
@@ -15,6 +16,32 @@ type SelectOption = {
   hint?: string;
 };
 
+/**
+ * Above this many options an arrow-key list stops being usable: a QA Wolf
+ * employee account reaches every client organization, which is hundreds of
+ * entries to scroll past. Below it, a plain list is quicker to answer than a
+ * search box is to start typing into.
+ */
+const searchThreshold = 8;
+
+/** How much of a filtered list to show at once, so the prompt stays in view. */
+const maxSearchItems = 10;
+
+const searchPlaceholder = "Type to filter";
+
+/**
+ * Name, slug, or id — the same three that `QAWOLF_ORGANIZATION` and
+ * `QAWOLF_WORKSPACE` accept, so what a person can type at the prompt and what
+ * they can put in a script are the same set. Slugs and ids arrive as the
+ * option's hint and value.
+ */
+function matchesSearch(
+  search: string,
+  option: { value: string; label?: string; hint?: string },
+): boolean {
+  return matchesSearchTerm(search, [option.label, option.hint, option.value]);
+}
+
 export type SelectFn = (
   message: string,
   options: readonly SelectOption[],
@@ -24,7 +51,20 @@ export function createSelect({ mode, clack }: SelectDeps): SelectFn {
   return async (message, options) => {
     assertHumanMode(mode, "select");
 
-    const value = await clack.select({ message, options: [...options] });
+    // Which prompt to use is a question about the list, not about the caller,
+    // so it is settled here. A command that offers two choices and one that
+    // offers three hundred both ask for a selection.
+    const value =
+      options.length > searchThreshold
+        ? await clack.autocomplete({
+            message,
+            options: [...options],
+            placeholder: searchPlaceholder,
+            maxItems: maxSearchItems,
+            filter: matchesSearch,
+          })
+        : await clack.select({ message, options: [...options] });
+
     if (clack.isCancel(value)) return { ok: false };
     return { ok: true, value };
   };

--- a/src/shell/ui/renderers/select.ts
+++ b/src/shell/ui/renderers/select.ts
@@ -1,4 +1,4 @@
-import { matchesSearchTerm } from "~/core/textSearch.js";
+import { createSearchIndex } from "~/core/textSearch.js";
 import type { StyledClack } from "~/shell/ui/clack/index.js";
 import type { OutputMode } from "~/shell/ui/env.js";
 import { assertHumanMode } from "./assertHumanMode.js";
@@ -32,11 +32,13 @@ const searchPlaceholder = "Type to filter";
  * they can put in a script are the same set. Slugs and ids arrive as the
  * option's hint and value.
  */
-function matchesSearch(
-  search: string,
-  option: { value: string; label?: string; hint?: string },
-): boolean {
-  return matchesSearchTerm(search, [option.label, option.hint, option.value]);
+/** clack's option shape, where every field but `value` may be absent. */
+type ClackOption = { value: string; label?: string; hint?: string };
+
+function searchableFields(
+  option: ClackOption,
+): readonly (string | undefined)[] {
+  return [option.label, option.hint, option.value];
 }
 
 export type SelectFn = (
@@ -61,7 +63,14 @@ export function createSelect({ mode, clack }: SelectDeps): SelectFn {
             // tenth of the rows it used to show, so filtering arrived at the
             // cost of seeing far less at once.
             placeholder: searchPlaceholder,
-            filter: matchesSearch,
+            // Indexed once for this prompt. clack re-tests every option on
+            // every keystroke, and the placeholder makes it walk the whole
+            // list again to decide whether tab completion applies, so the
+            // work per key is a multiple of the list length.
+            filter: createSearchIndex<ClackOption>(
+              [...options],
+              searchableFields,
+            ),
           })
         : await clack.select({ message, options: [...options] });
 

--- a/src/shell/ui/renderers/select.ts
+++ b/src/shell/ui/renderers/select.ts
@@ -24,9 +24,6 @@ type SelectOption = {
  */
 const searchThreshold = 8;
 
-/** How much of a filtered list to show at once, so the prompt stays in view. */
-const maxSearchItems = 10;
-
 const searchPlaceholder = "Type to filter";
 
 /**
@@ -59,8 +56,11 @@ export function createSelect({ mode, clack }: SelectDeps): SelectFn {
         ? await clack.autocomplete({
             message,
             options: [...options],
+            // No `maxItems`: clack then fills the terminal, which is what the
+            // plain list has always done. Capping it shrank a long list to a
+            // tenth of the rows it used to show, so filtering arrived at the
+            // cost of seeing far less at once.
             placeholder: searchPlaceholder,
-            maxItems: maxSearchItems,
             filter: matchesSearch,
           })
         : await clack.select({ message, options: [...options] });


### PR DESCRIPTION
> [!NOTE]
> Sixth of six stacked PRs. Targets `workspace-selection` (#1573). Review that one first. This change is independent of browser sign-in and could stand alone, but it is stacked because #1573 is what produces the long lists it exists for.

## Overview of Problem

The organization prompt added in #1573 shows every organization an account reaches. This could extend 100s of entries.

The list is the only way to answer the prompt interactively.

## Where to look

| File | Why |
| --- | --- |
| `core/textSearch.ts` | The matching rule, pure and shared. Case and separators are treated as presentation, so a name typed with spaces reaches a slug written with hyphens. |
| `shell/ui/renderers/select.ts` | Which prompt to open, and why the caller does not choose. The threshold is a fact about the list, not about the command. |

## Overview of Changes

- `core/textSearch.ts` holds `matchesSearchTerm`, which asks whether any of several fields contains what was typed. `suggestNearMiss.ts` had the same normalisation privately and now shares this one, so the rule is stated once.
- `shell/ui/renderers/select.ts` opens a searchable prompt above eight options and the existing list at or below it. Callers are unchanged: a command that offers two choices and one that offers three hundred both ask for a selection, and the renderer decides how to ask.
- The filter matches a name, a slug, or an id — the same three that `QAWOLF_ORGANIZATION` and `QAWOLF_WORKSPACE` accept, so what a person can type at the prompt and what they can put in a script are one set.
- An empty filter box shows the full list, so clearing what was typed restores it instead of emptying it.
- `shell/ui/clack/styledClack.ts` exposes the `autocomplete` prompt that `@clack/prompts` already ships. No dependency was added.
- The searchable prompt is given no `maxItems`, so it fills the terminal exactly as the plain list always has. An earlier cap of ten showed a quarter of the rows the plain list shows, which made a long list harder to read than before, not easier.
- `createSearchIndex` normalises each option once when the prompt opens, and the search text once per keystroke rather than once per option. clack asks the filter about every option on every keystroke, and walks the whole list again to decide whether tab completion applies, so the work per key is a multiple of the list length.

Every prompt with a long list gains this, not only the two auth prompts. The two-option prompt on `qawolf auth login` is unaffected.

## Testing

- 2,337 tests pass in total. `oxlint --max-warnings 0`, `oxfmt --check`, `tsc --noEmit` and `knip` are clean.
- `core/textSearch.test.ts` tests the rule directly: separators, letter case, absent fields, and a blank search that must show everything.
- `shell/ui/renderers/select.test.ts` tests the wiring: the threshold in both directions, cancellation, and the fields the filter reads.
- The existing `suggestNearMiss` tests pass unchanged, which shows the shared normalisation kept its behaviour.
- Tried by hand against production with an account that reaches many organizations.
- Measured through a pseudo terminal that drives the real prompt. With 3,000 options, the filter took 16.4 ms for six keystrokes before the index and 3.7 ms after it, and the latency for one key went from 3-7 ms to 1-3 ms. With 20,000 options it is 6-10 ms for one key.

## To Do
- [x] Request e2e test coverage if needed
- [x] Explain database migrations and whether they have been manually written or auto-generated — none
- [x] Add release notes in sections below if your changes are relevant to non-developers
- [x] Add pre/post-release tasks in sections below if needed

