### PR TITLE
fix(cli): exit with the command's own status code on Windows

### DIFF
--- a/.changeset/windows-exit-code.md
+++ b/.changeset/windows-exit-code.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+Commands that read the platform API now exit with their own status code on Windows. The CLI stopped the process as soon as a command was complete. If the reply was still in the process of teardown, Windows builds of Node stopped with an assertion failure, and the crash code replaced the code of the command. The output was correct, but a script could not tell success from an authentication failure or a refused payment. The CLI now records the status code and lets the work that is in progress complete. A 2 second backstop stops a run that keeps the event loop busy, which is what a flow run does with its browsers.
+
+The update check no longer keeps a request open after the command is complete. This made each command that used the npm registry lookup approximately 250 ms slower.

--- a/.changeset/windows-exit-code.md
+++ b/.changeset/windows-exit-code.md
@@ -5,3 +5,5 @@
 Commands that read the platform API now exit with their own status code on Windows. The CLI stopped the process as soon as a command was complete. If the reply was still in the process of teardown, Windows builds of Node stopped with an assertion failure, and the crash code replaced the code of the command. The output was correct, but a script could not tell success from an authentication failure or a refused payment. The CLI now records the status code and lets the work that is in progress complete. A 2 second backstop stops a run that keeps the event loop busy, which is what a flow run does with its browsers.
 
 The update check no longer keeps a request open after the command is complete. This made each command that used the npm registry lookup approximately 250 ms slower.
+
+An interrupt also keeps its exit code. Ctrl+C gave the same crash code when it stopped a command during a reply. The CLI now runs the cleanup, then gives the work in progress 150 ms to complete before it stops. A second interrupt stops the process immediately.

--- a/.changeset/windows-exit-code.md
+++ b/.changeset/windows-exit-code.md
@@ -4,6 +4,6 @@
 
 Commands that read the platform API now exit with their own status code on Windows. The CLI stopped the process as soon as a command was complete. If the reply was still in the process of teardown, Windows builds of Node stopped with an assertion failure, and the crash code replaced the code of the command. The output was correct, but a script could not tell success from an authentication failure or a refused payment. The CLI now records the status code and lets the work that is in progress complete. A 2 second backstop stops a run that keeps the event loop busy, which is what a flow run does with its browsers.
 
-The update check no longer keeps a request open after the command is complete. This made each command that used the npm registry lookup approximately 250 ms slower.
+The CLI makes a background request to the npm registry to find a new version. It now stops that request when the command is complete.
 
 An interrupt also keeps its exit code. Ctrl+C gave the same crash code when it stopped a command during a reply. The CLI now runs the cleanup, then gives the work in progress 150 ms to complete before it stops. A second interrupt stops the process immediately.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,18 @@ jobs:
             node dist/cli.js --version
             node test/node20/smoke.mjs
           fi
+      # A command whose reply arrives over the network must exit with its own
+      # status code, and must exit at all — see src/shell/exit.ts. The reply is
+      # served locally, so the smoke needs no API key and no network.
+      - name: Smoke — a networked command exits with its own code
+        env:
+          RUNTIME: ${{ matrix.name }}
+        run: |
+          if [ "$RUNTIME" = "bun" ]; then
+            bun test/exit/networkExitSmoke.mjs bun dist/cli.js
+          else
+            node test/exit/networkExitSmoke.mjs
+          fi
 
   # Only a Windows runner reaches CreateProcess, so only this job catches a
   # win32 spawn regression. WIZ-11274 (`spawn npm ENOENT`) shipped through that
@@ -161,6 +173,15 @@ jobs:
       - name: Smoke — cmd.exe argument escaping round-trips
         shell: bash
         run: node test/spawn/cmdEscapeSmoke.mjs
+      # Only win32 aborts when Node tears down a reply still in flight
+      # ("Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\\win\\async.c"),
+      # which replaced the command's exit code with a crash code. Both the npm
+      # build and the released binary are smoked: they ship different I/O stacks.
+      - name: Smoke — a networked command exits with its own code
+        shell: bash
+        run: |
+          node test/exit/networkExitSmoke.mjs
+          node test/exit/networkExitSmoke.mjs ./dist/qawolf.exe
       # Only Node-on-win32 rejects raw absolute paths in import() ("protocol
       # 'c:'"), so only this job catches a regression in the file:// URL
       # conversion. WIZ-11313 shipped through that gap.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,6 +106,7 @@
     "dist/",
     "node_modules/",
     "knip.config.ts",
+    "test/exit/",
     "test/node20/",
     "test/spawn/",
     "test/testkit/"

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -78,7 +78,8 @@ export function buildBaseContext(
     currentVersion: packageJson.version,
     configDir: getConfigDir(),
     fs,
-    fetchLatestVersion: () => fetchLatestVersion(packageJson.name),
+    fetchLatestVersion: (signal) =>
+      fetchLatestVersion(packageJson.name, { signal }),
     renderNotice: (body, title) => ui.note(body, title),
   });
   return {

--- a/src/domains/updateCheck/updateCheck.ts
+++ b/src/domains/updateCheck/updateCheck.ts
@@ -9,7 +9,8 @@ const noticeFile = "last-update-notice";
 export type UpdateNotifier = {
   /**
    * Announces only if the check already settled on a newer, not-yet-announced
-   * version. Never waits on the network; never throws.
+   * version, and gives up on a check that has not. Never waits on the network;
+   * never throws.
    */
   notifyIfOutdated(): Promise<void>;
 };
@@ -28,15 +29,16 @@ export function startUpdateCheck(deps: {
   currentVersion: string;
   configDir: string;
   fs: Fs;
-  fetchLatestVersion: () => Promise<string | undefined>;
+  fetchLatestVersion: (signal: AbortSignal) => Promise<string | undefined>;
   renderNotice: (body: string, title: string) => void;
 }): UpdateNotifier {
   if (deps.env["QAWOLF_NO_UPDATE_CHECK"]) {
     return noopNotifier;
   }
 
+  const controller = new AbortController();
   let latest: string | undefined;
-  void deps.fetchLatestVersion().then(
+  void deps.fetchLatestVersion(controller.signal).then(
     (version) => {
       latest = version;
     },
@@ -45,6 +47,9 @@ export function startUpdateCheck(deps: {
 
   return {
     async notifyIfOutdated() {
+      // The command is over, so a request still in flight has nothing left to
+      // announce — and an open socket would hold the event loop past the exit.
+      controller.abort();
       if (latest === undefined) return;
       if (!isNewerVersion(deps.currentVersion, latest)) return;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,10 @@
 import { createSignalRegistry } from "./shell/signals/createSignalRegistry.js";
 import { createProgram } from "./commands/program.js";
-import { exitWhenIdle } from "./shell/exit.js";
+import { createSignalExit, exitWhenIdle } from "./shell/exit.js";
 
 const signals = createSignalRegistry();
 
-let forced = false;
-const onSignal = (sig: "SIGINT" | "SIGTERM") => () => {
-  const code = sig === "SIGINT" ? 130 : 143;
-  if (forced) process.exit(code);
-  forced = true;
-  void signals.shutdown(sig).finally(() => {
-    process.exit(code);
-  });
-};
+const onSignal = createSignalExit({ shutdown: (sig) => signals.shutdown(sig) });
 process.on("SIGINT", onSignal("SIGINT"));
 process.on("SIGTERM", onSignal("SIGTERM"));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createSignalRegistry } from "./shell/signals/createSignalRegistry.js";
 import { createProgram } from "./commands/program.js";
-import { flushAndExit } from "./shell/exit.js";
+import { exitWhenIdle } from "./shell/exit.js";
 
 const signals = createSignalRegistry();
 
@@ -16,12 +16,13 @@ const onSignal = (sig: "SIGINT" | "SIGTERM") => () => {
 process.on("SIGINT", onSignal("SIGINT"));
 process.on("SIGTERM", onSignal("SIGTERM"));
 
-// Exit deterministically once the command resolves — see flushAndExit for why.
+// Settle the exit status once the command resolves — see exitWhenIdle for why
+// the process is not killed here.
 void createProgram({ signals })
   .parseAsync()
   .catch(() => {
     if (process.exitCode === undefined) process.exitCode = 1;
   })
   .finally(() =>
-    flushAndExit(typeof process.exitCode === "number" ? process.exitCode : 0),
+    exitWhenIdle(typeof process.exitCode === "number" ? process.exitCode : 0),
   );

--- a/src/shell/exit.test.ts
+++ b/src/shell/exit.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 
-import { exitCodes, exit, createSignalExit, exitWhenIdle } from "./exit.js";
+import {
+  exitCodes,
+  exit,
+  createSignalExit,
+  exitWhenIdle,
+  scheduleSignalGrace,
+} from "./exit.js";
 
 function createFakeProcess() {
   const stderr: string[] = [];
@@ -180,5 +186,15 @@ describe("createSignalExit", () => {
     await settle();
     expect(() => onSignal("SIGTERM")()).toThrow("__fake-exit__");
     expect(exitCalls).toEqual([143]);
+  });
+});
+
+describe("scheduleSignalGrace", () => {
+  it("schedules a timer that holds the event loop open", () => {
+    // Unref'd, the loop can drain first and the process exits on whatever the
+    // command last wrote, not on the code the signal chose.
+    const timer = scheduleSignalGrace(() => {});
+    expect(timer.hasRef()).toBe(true);
+    clearTimeout(timer);
   });
 });

--- a/src/shell/exit.test.ts
+++ b/src/shell/exit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { exitCodes, exit, flushAndExit } from "./exit.js";
+import { exitCodes, exit, exitWhenIdle } from "./exit.js";
 
 function createFakeProcess() {
   const stderr: string[] = [];
@@ -64,75 +64,34 @@ describe("exit", () => {
   });
 });
 
-function createFlushFakeProcess() {
+function createIdleFakeProcess() {
   const exitCalls: number[] = [];
-  let stdoutCb: (() => void) | undefined;
-  let stderrCb: (() => void) | undefined;
   const proc = {
-    stdout: {
-      write: (_chunk: string, cb: () => void): boolean => {
-        stdoutCb = cb;
-        return true;
-      },
-    },
-    stderr: {
-      write: (_chunk: string, cb: () => void): boolean => {
-        stderrCb = cb;
-        return true;
-      },
-    },
+    exitCode: undefined as number | string | undefined,
     exit: (code: number): never => {
       exitCalls.push(code);
       throw Error("__fake-exit__");
     },
   };
-  return {
-    proc,
-    exitCalls,
-    flushStdout: () => stdoutCb?.(),
-    flushStderr: () => stderrCb?.(),
-  };
+  return { proc, exitCalls };
 }
 
-describe("flushAndExit", () => {
-  it("exits with the given code once both streams have flushed", () => {
-    const { proc, exitCalls, flushStdout, flushStderr } =
-      createFlushFakeProcess();
-    flushAndExit(exitCodes.testFailure, proc, () => {});
-    flushStdout();
-    expect(exitCalls).toEqual([]);
-    expect(() => flushStderr()).toThrow("__fake-exit__");
-    expect(exitCalls).toEqual([1]);
-  });
-
-  it("does not exit until both streams have flushed", () => {
-    const { proc, exitCalls, flushStdout } = createFlushFakeProcess();
-    flushAndExit(exitCodes.success, proc, () => {});
-    flushStdout();
+describe("exitWhenIdle", () => {
+  it("records the exit code without killing the process", () => {
+    const { proc, exitCalls } = createIdleFakeProcess();
+    exitWhenIdle(exitCodes.testFailure, proc, () => {});
+    expect(proc.exitCode).toBe(1);
     expect(exitCalls).toEqual([]);
   });
 
-  it("forces exit via the backstop when a stream stalls", () => {
-    const { proc, exitCalls } = createFlushFakeProcess();
+  it("forces the exit from the backstop when the loop stays busy", () => {
+    const { proc, exitCalls } = createIdleFakeProcess();
     let backstop: (() => void) | undefined;
-    flushAndExit(exitCodes.testFailure, proc, (fn) => {
+    exitWhenIdle(exitCodes.payment, proc, (fn) => {
       backstop = fn;
     });
     expect(exitCalls).toEqual([]);
     expect(() => backstop?.()).toThrow("__fake-exit__");
-    expect(exitCalls).toEqual([1]);
-  });
-
-  it("exits at most once when flush and backstop both fire", () => {
-    const { proc, exitCalls, flushStdout, flushStderr } =
-      createFlushFakeProcess();
-    let backstop: (() => void) | undefined;
-    flushAndExit(exitCodes.testFailure, proc, (fn) => {
-      backstop = fn;
-    });
-    flushStdout();
-    expect(() => flushStderr()).toThrow("__fake-exit__");
-    backstop?.();
-    expect(exitCalls).toEqual([1]);
+    expect(exitCalls).toEqual([7]);
   });
 });

--- a/src/shell/exit.test.ts
+++ b/src/shell/exit.test.ts
@@ -162,6 +162,18 @@ describe("createSignalExit", () => {
     expect(shutdownReasons).toEqual(["SIGINT"]);
   });
 
+  it("keeps the exit code when shutdown rejects", async () => {
+    const { proc } = createIdleFakeProcess();
+    const onSignal = createSignalExit({
+      proc,
+      scheduleGrace: () => {},
+      shutdown: () => Promise.reject(new Error("cleanup failed")),
+    });
+    onSignal("SIGINT")();
+    await settle();
+    expect(proc.exitCode).toBe(130);
+  });
+
   it("shares the signalled flag across signals", async () => {
     const { onSignal, exitCalls } = createSignalFake();
     onSignal("SIGINT")();

--- a/src/shell/exit.test.ts
+++ b/src/shell/exit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { exitCodes, exit, exitWhenIdle } from "./exit.js";
+import { exitCodes, exit, createSignalExit, exitWhenIdle } from "./exit.js";
 
 function createFakeProcess() {
   const stderr: string[] = [];
@@ -93,5 +93,80 @@ describe("exitWhenIdle", () => {
     expect(exitCalls).toEqual([]);
     expect(() => backstop?.()).toThrow("__fake-exit__");
     expect(exitCalls).toEqual([7]);
+  });
+});
+
+// Let the shutdown promise's .finally chain run before reading the result.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function createSignalFake() {
+  const { proc, exitCalls } = createIdleFakeProcess();
+  const shutdownReasons: string[] = [];
+  let grace: (() => void) | undefined;
+  const onSignal = createSignalExit({
+    proc,
+    scheduleGrace: (fn) => {
+      grace = fn;
+    },
+    shutdown: (reason) => {
+      shutdownReasons.push(reason);
+      return Promise.resolve();
+    },
+  });
+  return {
+    exitCalls,
+    onSignal,
+    proc,
+    shutdownReasons,
+    endGrace: () => grace?.(),
+  };
+}
+
+describe("createSignalExit", () => {
+  it("records the exit code after shutdown without killing the process", async () => {
+    const { onSignal, proc, exitCalls } = createSignalFake();
+    onSignal("SIGINT")();
+    await settle();
+    expect(proc.exitCode).toBe(130);
+    expect(exitCalls).toEqual([]);
+  });
+
+  it("forces the exit when the grace period ends", async () => {
+    const { onSignal, exitCalls, endGrace } = createSignalFake();
+    onSignal("SIGINT")();
+    await settle();
+    expect(() => endGrace()).toThrow("__fake-exit__");
+    expect(exitCalls).toEqual([130]);
+  });
+
+  it("records 143 for SIGTERM", async () => {
+    const { onSignal, proc } = createSignalFake();
+    onSignal("SIGTERM")();
+    await settle();
+    expect(proc.exitCode).toBe(143);
+  });
+
+  it("shuts down with the signal as the reason", async () => {
+    const { onSignal, shutdownReasons } = createSignalFake();
+    onSignal("SIGTERM")();
+    await settle();
+    expect(shutdownReasons).toEqual(["SIGTERM"]);
+  });
+
+  it("exits at once on a second signal, without waiting for shutdown", async () => {
+    const { onSignal, exitCalls, shutdownReasons } = createSignalFake();
+    onSignal("SIGINT")();
+    await settle();
+    expect(() => onSignal("SIGINT")()).toThrow("__fake-exit__");
+    expect(exitCalls).toEqual([130]);
+    expect(shutdownReasons).toEqual(["SIGINT"]);
+  });
+
+  it("shares the signalled flag across signals", async () => {
+    const { onSignal, exitCalls } = createSignalFake();
+    onSignal("SIGINT")();
+    await settle();
+    expect(() => onSignal("SIGTERM")()).toThrow("__fake-exit__");
+    expect(exitCalls).toEqual([143]);
   });
 });

--- a/src/shell/exit.ts
+++ b/src/shell/exit.ts
@@ -110,6 +110,11 @@ export function createSignalExit(deps: {
     signalled = true;
     void deps
       .shutdown(signal)
+      // A shutdown that rejects would reach the process as an unhandled
+      // rejection, and the default handling replaces the signal's code with 1
+      // — the loss this function exists to prevent. The registry settles its
+      // own cleanups, so this guards the type rather than a caller we have.
+      .catch(() => {})
       .finally(() => exitWhenIdle(code, proc, scheduleGrace));
   };
 }

--- a/src/shell/exit.ts
+++ b/src/shell/exit.ts
@@ -27,44 +27,38 @@ export function exit(
   return proc.exit(code);
 }
 
-type FlushExitProcess = {
-  readonly stdout: {
-    readonly write: (chunk: string, cb: () => void) => unknown;
-  };
-  readonly stderr: {
-    readonly write: (chunk: string, cb: () => void) => unknown;
-  };
+type ExitingProcess = {
+  exitCode: number | string | undefined;
   readonly exit: (code: number) => never;
 };
 
 /**
- * Flush stdout and stderr, then exit with `code`. The flow runtime can leave
- * browser processes and CDP sockets the event loop never drains, so the CLI
- * exits deterministically once its command resolves. The empty-`write`
- * callbacks flush buffered output first; the backstop forces exit if a stream
- * stalls (e.g. EPIPE on a closed pipe).
+ * How long a process that cannot drain on its own is left to finish. Long
+ * enough for an outstanding socket teardown or a stdout write to a slow reader
+ * to land, and only ever waited out by a command that holds the loop open.
  */
-export function flushAndExit(
+const backstopMs = 2000;
+
+/**
+ * Records `code` as the exit status and lets the event loop drain, rather than
+ * killing the process where the command finished. Tearing down mid-flight I/O
+ * aborts a Windows build of Node ("Assertion failed:
+ * !(handle->flags & UV_HANDLE_CLOSING), src\\win\\async.c"), which replaces the
+ * command's own exit code with a crash code — so a caller reads a successful
+ * command as a failure.
+ *
+ * The flow runtime still leaves browser processes and CDP sockets the loop
+ * never drains, so the backstop forces the exit those runs need. Its timer is
+ * unref'd: it fires only while something else holds the loop open, and a
+ * command that has nothing left in flight exits before it ever comes due.
+ */
+export function exitWhenIdle(
   code: number,
-  proc: FlushExitProcess = process,
+  proc: ExitingProcess = process,
   scheduleBackstop: (fn: () => void) => void = (fn) => {
-    setTimeout(fn, 2000).unref();
+    setTimeout(fn, backstopMs).unref();
   },
 ): void {
-  let exited = false;
-  const exitOnce = (): void => {
-    if (exited) return;
-    exited = true;
-    proc.exit(code);
-  };
-
-  let pending = 2;
-  const onFlushed = (): void => {
-    pending -= 1;
-    if (pending === 0) exitOnce();
-  };
-  proc.stdout.write("", onFlushed);
-  proc.stderr.write("", onFlushed);
-
-  scheduleBackstop(exitOnce);
+  proc.exitCode = code;
+  scheduleBackstop(() => proc.exit(code));
 }

--- a/src/shell/exit.ts
+++ b/src/shell/exit.ts
@@ -62,3 +62,54 @@ export function exitWhenIdle(
   proc.exitCode = code;
   scheduleBackstop(() => proc.exit(code));
 }
+
+type SignalName = "SIGINT" | "SIGTERM";
+
+const signalExitCodes: Record<SignalName, number> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+/**
+ * How long a signalled process is left to finish. Long enough for the I/O that
+ * was in flight when the signal landed, short enough to read as immediate.
+ */
+const signalGraceMs = 150;
+
+/**
+ * Builds the handler for `signal`, sharing one "already signalled" flag across
+ * every signal it builds.
+ *
+ * The first signal runs `shutdown`, then records the exit status and leaves a
+ * short moment for work in flight — killing the process here reaches the same
+ * win32 abort `exitWhenIdle` describes, and loses the 130 or 143 with it. The
+ * moment is short rather than absent because a signal, unlike a finished
+ * command, arrives while the event loop is still busy: waiting for it to drain
+ * would mean the command runs to completion and prints, which is not what an
+ * interrupt asks for.
+ *
+ * A second signal exits at once. That is the deliberate escape hatch for a
+ * process whose cleanup will not finish, so it keeps its hard exit.
+ */
+export function createSignalExit(deps: {
+  shutdown: (reason: string) => Promise<void>;
+  proc?: ExitingProcess;
+  scheduleGrace?: (fn: () => void) => void;
+}): (signal: SignalName) => () => void {
+  const proc = deps.proc ?? process;
+  const scheduleGrace =
+    deps.scheduleGrace ??
+    ((fn: () => void) => {
+      setTimeout(fn, signalGraceMs).unref();
+    });
+
+  let signalled = false;
+  return (signal) => () => {
+    const code = signalExitCodes[signal];
+    if (signalled) proc.exit(code);
+    signalled = true;
+    void deps
+      .shutdown(signal)
+      .finally(() => exitWhenIdle(code, proc, scheduleGrace));
+  };
+}

--- a/src/shell/exit.ts
+++ b/src/shell/exit.ts
@@ -76,6 +76,17 @@ const signalExitCodes: Record<SignalName, number> = {
  */
 const signalGraceMs = 150;
 
+/** Schedules the grace period between a signal and the exit it forces. */
+export function scheduleSignalGrace(
+  fn: () => void,
+): ReturnType<typeof setTimeout> {
+  // Holds the event loop open, unlike the backstop in `exitWhenIdle`. The exit
+  // status is one mutable value: a command that settles inside the grace
+  // overwrites the signal's code with its own, so only a timer certain to fire
+  // can exit on the code the signal chose.
+  return setTimeout(fn, signalGraceMs);
+}
+
 /**
  * Builds the handler for `signal`, sharing one "already signalled" flag across
  * every signal it builds.
@@ -97,11 +108,7 @@ export function createSignalExit(deps: {
   scheduleGrace?: (fn: () => void) => void;
 }): (signal: SignalName) => () => void {
   const proc = deps.proc ?? process;
-  const scheduleGrace =
-    deps.scheduleGrace ??
-    ((fn: () => void) => {
-      setTimeout(fn, signalGraceMs).unref();
-    });
+  const scheduleGrace = deps.scheduleGrace ?? scheduleSignalGrace;
 
   let signalled = false;
   return (signal) => () => {

--- a/src/shell/npmRegistry.ts
+++ b/src/shell/npmRegistry.ts
@@ -8,17 +8,21 @@ type FetchLike = (
 
 /**
  * Reads the registry's `latest` dist-tag. Returns undefined on any failure
- * (offline, timeout, bad payload), because the update check must never break
- * a command.
+ * (offline, timeout, bad payload, `deps.signal` aborted), because the update
+ * check must never break a command.
  */
 export async function fetchLatestVersion(
   packageName: string,
-  deps: { fetchFn?: FetchLike } = {},
+  deps: { fetchFn?: FetchLike; signal?: AbortSignal } = {},
 ): Promise<string | undefined> {
   const fetchFn = deps.fetchFn ?? globalThis.fetch;
+  const deadline = AbortSignal.timeout(timeoutMs);
+  const signal = deps.signal
+    ? AbortSignal.any([deps.signal, deadline])
+    : deadline;
   try {
     const response = await fetchFn(`${registryUrl}/${packageName}/latest`, {
-      signal: AbortSignal.timeout(timeoutMs),
+      signal,
     });
     if (!response.ok) return undefined;
     const body: unknown = await response.json();

--- a/test/exit/networkExitSmoke.mjs
+++ b/test/exit/networkExitSmoke.mjs
@@ -1,0 +1,107 @@
+// Witness that a command whose reply arrives over the network exits with its
+// own status code. The CLI used to kill the process the moment the command
+// resolved; a reply still being torn down aborted Node on win32 ("Assertion
+// failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c") and the
+// crash code replaced the command's, so a caller could not tell success from
+// an auth or a billing refusal.
+//
+// The reply has to be large enough to arrive compressed: the API compresses
+// replies past about a kilobyte, and only a compressed, chunked body left work
+// in flight at the exit. This server mirrors that shape, so the smoke needs no
+// API key and reaches no network.
+//
+// Usage: node test/exit/networkExitSmoke.mjs [command ...args]
+//        defaults to the shipped bundle, `node dist/cli.js`.
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { gzipSync } from "node:zlib";
+
+const attempts = 5;
+// A command that cannot drain is as broken as one that crashes, and a hung
+// child would otherwise stall the job until the runner's own timeout.
+const attemptTimeoutMs = 30_000;
+const argv = process.argv.slice(2);
+const [command, ...leadingArgs] =
+  argv.length > 0 ? argv : [process.execPath, "dist/cli.js"];
+
+const tags = Array.from({ length: 40 }, (_, index) => ({
+  color: "#4f46e5",
+  name: `smoke-tag-${index}`,
+  url: "http://127.0.0.1/settings/tags",
+}));
+const payload = gzipSync(
+  Buffer.from(JSON.stringify({ result: { data: { json: { tags } } } })),
+);
+
+const server = createServer((_request, response) => {
+  // No content-length: a compressed reply arrives chunked.
+  response.writeHead(200, {
+    "content-encoding": "gzip",
+    "content-type": "application/json",
+  });
+  response.end(payload);
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const { port } = server.address();
+
+function runCli() {
+  return new Promise((resolve) => {
+    const child = spawn(command, [...leadingArgs, "tag", "list", "--json"], {
+      env: {
+        ...process.env,
+        QAWOLF_API_KEY: "smoke-key",
+        QAWOLF_HOST_URL: `http://127.0.0.1:${port}`,
+        QAWOLF_NO_UPDATE_CHECK: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    let timedOut = false;
+    const watchdog = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, attemptTimeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(watchdog);
+      resolve({ launchError: error, stderr, stdout });
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(watchdog);
+      resolve({ signal, status, stderr, stdout, timedOut });
+    });
+  });
+}
+
+const failures = [];
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  const result = await runCli();
+  if (result.launchError) {
+    failures.push(
+      `attempt ${attempt} failed to launch: ${result.launchError.message}`,
+    );
+  } else if (result.timedOut) {
+    failures.push(
+      `attempt ${attempt} never exited within ${attemptTimeoutMs}ms`,
+    );
+  } else if (result.status !== 0) {
+    failures.push(
+      `attempt ${attempt} exited ${result.status} (signal ${result.signal})\n${result.stdout}\n${result.stderr}`,
+    );
+  } else if (!result.stdout.includes("smoke-tag-39")) {
+    failures.push(`attempt ${attempt} printed no tags\n${result.stdout}`);
+  }
+}
+
+server.close();
+
+if (failures.length > 0) {
+  console.error(`network exit smoke FAILED\n${failures.join("\n")}`);
+  process.exit(1);
+}
+
+console.log(
+  `network exit smoke OK on ${process.platform}: ${attempts}/${attempts} exited 0 (${command})`,
+);

--- a/test/exit/networkExitSmoke.mjs
+++ b/test/exit/networkExitSmoke.mjs
@@ -5,10 +5,14 @@
 // crash code replaced the command's, so a caller could not tell success from
 // an auth or a billing refusal.
 //
-// The reply has to be large enough to arrive compressed: the API compresses
-// replies past about a kilobyte, and only a compressed, chunked body left work
-// in flight at the exit. This server mirrors that shape, so the smoke needs no
-// API key and reaches no network.
+// The refusals are checked for their exact documented codes, 3 and 7, because
+// losing those is the damage a caller feels: the reported symptom was an auth
+// failure returning 3, 3, then a crash code.
+//
+// Every reply has to be large enough to arrive compressed, the refusals
+// included: the API compresses replies past about a kilobyte, and only a
+// compressed, chunked body left work in flight at the exit. This server mirrors
+// that shape, so the smoke needs no API key and reaches no network.
 //
 // Usage: node test/exit/networkExitSmoke.mjs [command ...args]
 //        defaults to the shipped bundle, `node dist/cli.js`.
@@ -29,28 +33,36 @@ const tags = Array.from({ length: 40 }, (_, index) => ({
   name: `smoke-tag-${index}`,
   url: "http://127.0.0.1/settings/tags",
 }));
-const payload = gzipSync(
+const okBody = gzipSync(
   Buffer.from(JSON.stringify({ result: { data: { json: { tags } } } })),
 );
+// The failure path reads the body with text() rather than json(), so it needs
+// its own oversized body to reach the same decompression.
+const refusalBody = gzipSync(
+  Buffer.from(
+    JSON.stringify({ error: { json: { message: "refused ".repeat(200) } } }),
+  ),
+);
 
-const server = createServer((_request, response) => {
+const server = createServer((request, response) => {
+  const refusal = /\/refuse-(401|402)\//.exec(request.url);
   // No content-length: a compressed reply arrives chunked.
-  response.writeHead(200, {
+  response.writeHead(refusal ? Number(refusal[1]) : 200, {
     "content-encoding": "gzip",
     "content-type": "application/json",
   });
-  response.end(payload);
+  response.end(refusal ? refusalBody : okBody);
 });
 await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
 const { port } = server.address();
 
-function runCli() {
+function runCli(basePath) {
   return new Promise((resolve) => {
     const child = spawn(command, [...leadingArgs, "tag", "list", "--json"], {
       env: {
         ...process.env,
         QAWOLF_API_KEY: "smoke-key",
-        QAWOLF_HOST_URL: `http://127.0.0.1:${port}`,
+        QAWOLF_HOST_URL: `http://127.0.0.1:${port}${basePath}`,
         QAWOLF_NO_UPDATE_CHECK: "1",
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -75,23 +87,32 @@ function runCli() {
   });
 }
 
+// A refusal body is long by design; a failing job does not need all of it.
+const excerpt = (text) =>
+  text.length > 300 ? `${text.slice(0, 300)}… (${text.length} bytes)` : text;
+
+const cases = [
+  { basePath: "", expected: 0, label: "success", wantsTags: true },
+  { basePath: "/refuse-401", expected: 3, label: "auth refusal" },
+  { basePath: "/refuse-402", expected: 7, label: "payment refusal" },
+];
+
 const failures = [];
-for (let attempt = 1; attempt <= attempts; attempt += 1) {
-  const result = await runCli();
-  if (result.launchError) {
-    failures.push(
-      `attempt ${attempt} failed to launch: ${result.launchError.message}`,
-    );
-  } else if (result.timedOut) {
-    failures.push(
-      `attempt ${attempt} never exited within ${attemptTimeoutMs}ms`,
-    );
-  } else if (result.status !== 0) {
-    failures.push(
-      `attempt ${attempt} exited ${result.status} (signal ${result.signal})\n${result.stdout}\n${result.stderr}`,
-    );
-  } else if (!result.stdout.includes("smoke-tag-39")) {
-    failures.push(`attempt ${attempt} printed no tags\n${result.stdout}`);
+for (const testCase of cases) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await runCli(testCase.basePath);
+    const where = `${testCase.label} attempt ${attempt}`;
+    if (result.launchError) {
+      failures.push(`${where} failed to launch: ${result.launchError.message}`);
+    } else if (result.timedOut) {
+      failures.push(`${where} never exited within ${attemptTimeoutMs}ms`);
+    } else if (result.status !== testCase.expected) {
+      failures.push(
+        `${where} exited ${result.status}, expected ${testCase.expected} (signal ${result.signal})\n${excerpt(result.stdout)}\n${excerpt(result.stderr)}`,
+      );
+    } else if (testCase.wantsTags && !result.stdout.includes("smoke-tag-39")) {
+      failures.push(`${where} printed no tags\n${excerpt(result.stdout)}`);
+    }
   }
 }
 
@@ -103,5 +124,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `network exit smoke OK on ${process.platform}: ${attempts}/${attempts} exited 0 (${command})`,
+  `network exit smoke OK on ${process.platform}: ${cases.length * attempts} runs, exit codes 0/3/7 as documented (${command})`,
 );


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed.

# Overview of Changes

The CLI stopped its process immediately when a command was complete. On Windows, this closed the event loop while the reply was not fully complete, and Node stopped with an error:

`Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94`

The crash code then replaced the exit code of the command. The output was correct, but a script could not see the difference between success, an authentication failure (3) and a payment failure (7). Only replies of more than approximately one kilobyte cause the error, because only those are compressed. macOS and Linux do not have this error.

- **`src/shell/exit.ts`**: `flushAndExit` becomes `exitWhenIdle`. It sets `process.exitCode` and lets the event loop complete its work. A backstop timer forces the exit for flow runs, which leave browser processes in the loop. The timer does not hold the loop open, so other commands stop before it. A new `createSignalExit` gives the signal handlers the same protection. The first signal runs the cleanup, then gives the work in progress 150 ms to complete. A signal arrives while the event loop is busy, so it cannot wait for the loop to become empty. A second signal stops the process immediately, which is the escape hatch for a process that will not stop.
- **`src/main.ts`**: The call sites. The signal handler logic moves to `createSignalExit`.
- **Update check (3 files)**: An `AbortController` stops the background npm registry request when the command is complete. Without this, the open request holds the event loop open.
- **Smoke test and CI (3 files)**: A local server sends a compressed reply. The test examines the exit code of the CLI for a successful reply, an HTTP 401 refusal and an HTTP 402 refusal, five runs of each, and asserts the documented codes 0, 3 and 7. It needs no API key. CI runs it on Windows for the npm build and the binary, and on node 20, 22, 24 and bun. Before this change, the Windows job ran only `--version`.
- **`.changeset/windows-exit-code.md`**: A patch changeset.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- New tests in `exit.test.ts`. The smoke test is correct on node 20.19.0 (the `engines` minimum), 22, 24 and bun.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes

