### PR TITLE
fix(flows): download team-storage assets in a browser session

### DIFF
--- a/.changeset/team-storage-browser-session.md
+++ b/.changeset/team-storage-browser-session.md
@@ -1,0 +1,9 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf flows pull` now downloads team-storage assets when you sign in through the browser. Before, the pull stopped with "Team storage requires a team API key" after it had already downloaded the flows and the environment variables.
+
+The CLI asked the API who the credential belonged to, and used the team from the answer. A browser session has an organization and a user in that answer, but no team, so the CLI refused it. A browser session does name the workspace you chose, and a workspace is a team, so the CLI now uses that.
+
+An organization API key with no workspace still gets the same message, because such a key reaches many teams and names none.

--- a/src/shell/platform/createPlatformClient.teamStorage.test.ts
+++ b/src/shell/platform/createPlatformClient.teamStorage.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, mock, type Mock } from "bun:test";
+import superjson from "superjson";
+
+import { createPlatformClient } from "./createPlatformClient.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+const baseUrl = "https://test.qawolf.com";
+const apiKey = "qawolf_key";
+const noSleep = async (): Promise<void> => {};
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function trpcWrapped(value: unknown) {
+  return { result: { data: superjson.serialize(value) } };
+}
+
+const emptyFileList = trpcWrapped({ files: [], nextPageToken: undefined });
+
+// The mock records `RequestInfo | URL`; every call here passes a string URL,
+// so narrow once at this boundary rather than at each assertion.
+function requestedUrls(f: typeof fetch): string[] {
+  return (f as unknown as Mock<typeof fetch>).mock.calls.map(
+    ([url]) => url as string,
+  );
+}
+
+// mock() cannot express fetch's overloads; build against a loose signature and
+// cast once, as the sibling platform tests do.
+function conditionalFetch(respond: (url: string) => Response): typeof fetch {
+  return mock((input: unknown) =>
+    Promise.resolve(respond(String(input as string))),
+  ) as unknown as typeof fetch;
+}
+
+describe("listTeamStorageFiles", () => {
+  // A browser session's identity names an organization and no team, so reading
+  // it first refused every such session. The workspace it chose is the team.
+  it("uses the session's workspace as the team, without probing identity", async () => {
+    const fetchMock = mock<typeof fetch>().mockResolvedValue(
+      json(emptyFileList),
+    ) as unknown as typeof fetch;
+    const client = createPlatformClient(apiKey, {
+      fetch: fetchMock,
+      baseUrl,
+      sleep: noSleep,
+      workspaceId: "goer6sm4opv6to8ys1jc6ojaotea",
+    });
+
+    const result = await client.listTeamStorageFiles();
+
+    expect(result.ok).toBe(true);
+    const urls = requestedUrls(fetchMock);
+    expect(urls[0]).toContain("team.listStorageFiles");
+    expect(decodeURIComponent(urls[0] ?? "")).toContain(
+      "goer6sm4opv6to8ys1jc6ojaotea",
+    );
+    // The identity endpoint must not be reached at all.
+    expect(urls.some((u) => u.includes("/api/v0/identity"))).toBe(false);
+  });
+
+  it("falls back to a team API key's own identity", async () => {
+    const fetchMock = conditionalFetch((url) =>
+      url.includes("/api/v0/identity")
+        ? json({
+            team: { createdAt: "2026-01-01", id: "team-from-key", name: "T" },
+          })
+        : json(emptyFileList),
+    );
+    const client = createPlatformClient(apiKey, {
+      fetch: fetchMock,
+      baseUrl,
+      sleep: noSleep,
+    });
+
+    const result = await client.listTeamStorageFiles();
+
+    expect(result.ok).toBe(true);
+    const storageUrl = requestedUrls(fetchMock).find((u) =>
+      u.includes("team.listStorageFiles"),
+    );
+    expect(decodeURIComponent(storageUrl ?? "")).toContain("team-from-key");
+  });
+
+  // An organization key reaches many teams and names none, so there is nothing
+  // to fall back on.
+  it("refuses an organization key with no workspace chosen", async () => {
+    const fetchMock = mock<typeof fetch>().mockResolvedValue(
+      json({ organization: { id: "org-1", name: "Org" } }),
+    ) as unknown as typeof fetch;
+    const client = createPlatformClient(apiKey, {
+      fetch: fetchMock,
+      baseUrl,
+      sleep: noSleep,
+    });
+
+    const result = await client.listTeamStorageFiles();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a refusal");
+    expect(result.error).toContain("team API key");
+  });
+});

--- a/src/shell/platform/createPlatformClient.ts
+++ b/src/shell/platform/createPlatformClient.ts
@@ -1,4 +1,3 @@
-import { flowsMessages } from "~/core/messages/index.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import type { Logger } from "~/shell/logger.js";
 import {
@@ -12,11 +11,8 @@ import { createIdentityMethods } from "./identityMethods.js";
 import type { IdentityResponse } from "./getIdentity.js";
 import type { Organization } from "./organizations.js";
 import { type PlatformResult, requestWithRetry } from "./requestWithRetry.js";
-import { listTeamStorageFiles } from "./teamStorage.js";
-import {
-  downloadTeamStorageAssets,
-  type SyncTeamStorageAssetsResult,
-} from "./teamStorageAssets.js";
+import type { SyncTeamStorageAssetsResult } from "./teamStorageAssets.js";
+import { createTeamStorageMethods } from "./teamStorageMethods.js";
 import type { TeamStorageAssetProgress } from "./writeAssetSnapshot.js";
 import {
   environmentWithVariablesResponseSchema,
@@ -85,8 +81,11 @@ export function createPlatformClient(
     return { ok: true, value: { signedUrl: result.value.url } };
   }
 
+  const identityMethods = createIdentityMethods(apiKey, deps, requestBackoffMs);
+
   return {
-    ...createIdentityMethods(apiKey, deps, requestBackoffMs),
+    ...identityMethods,
+    ...createTeamStorageMethods(trpc, deps, fs, identityMethods.getIdentity),
 
     getFlowsBundleUrl: getFlowsBundleUrlImpl,
 
@@ -106,31 +105,6 @@ export function createPlatformClient(
       });
       if (!result.ok) return result;
       return { ok: true, value: result.value.environmentVariables };
-    },
-
-    async listTeamStorageFiles() {
-      const identity = await this.getIdentity();
-      if (!identity.ok) return identity;
-      if (!("team" in identity.value)) {
-        return {
-          ok: false,
-          error: flowsMessages.pull.teamStorageRequiresTeamKey,
-        };
-      }
-      return listTeamStorageFiles(
-        trpc,
-        { teamId: identity.value.team.id },
-        deps,
-      );
-    },
-
-    async syncTeamStorageAssets(assetsAbs, opts) {
-      const files = await this.listTeamStorageFiles();
-      if (!files.ok) return files;
-      return downloadTeamStorageAssets(
-        { assetsAbs, files: files.value },
-        { fetch: deps.fetch, fs, onProgress: opts?.onProgress },
-      );
     },
 
     async downloadBundle(envId) {

--- a/src/shell/platform/teamStorageMethods.ts
+++ b/src/shell/platform/teamStorageMethods.ts
@@ -1,0 +1,78 @@
+import { flowsMessages } from "~/core/messages/index.js";
+import type { Fs } from "~/shell/fs.js";
+
+import type { TrpcClient } from "./createTrpcClient.js";
+import type { IdentityResponse } from "./getIdentity.js";
+import type { PlatformResult } from "./requestWithRetry.js";
+import { listTeamStorageFiles } from "./teamStorage.js";
+import {
+  downloadTeamStorageAssets,
+  type SyncTeamStorageAssetsResult,
+} from "./teamStorageAssets.js";
+import type { TeamStorageFile } from "./types.js";
+import type { TeamStorageAssetProgress } from "./writeAssetSnapshot.js";
+
+type Deps = {
+  fetch: typeof globalThis.fetch;
+  baseUrl: string;
+  sleep?: (ms: number) => Promise<void>;
+  /** Workspace the session chose; a workspace is a team. */
+  workspaceId?: string | undefined;
+};
+
+export type TeamStorageMethods = {
+  listTeamStorageFiles: () => Promise<PlatformResult<TeamStorageFile[]>>;
+  syncTeamStorageAssets: (
+    assetsAbs: string,
+    opts?: { onProgress?: (progress: TeamStorageAssetProgress) => void },
+  ) => Promise<PlatformResult<SyncTeamStorageAssetsResult>>;
+};
+
+/**
+ * Reading the team's shared files, and mirroring them into the local assets
+ * directory.
+ *
+ * Both need a team id, which reaches this in one of two ways: a browser session
+ * chose a workspace, or the credential is itself team-scoped.
+ */
+export function createTeamStorageMethods(
+  trpc: TrpcClient,
+  deps: Deps,
+  fs: Fs,
+  getIdentity: () => Promise<PlatformResult<IdentityResponse>>,
+): TeamStorageMethods {
+  async function list(): Promise<PlatformResult<TeamStorageFile[]>> {
+    // A workspace is a team, so a browser session that chose one already names
+    // the team this route wants. Preferred over the identity probe because a
+    // browser session's identity carries an organization and no team at all —
+    // reading it first refused every such session before it reached the API.
+    if (deps.workspaceId !== undefined) {
+      return listTeamStorageFiles(trpc, { teamId: deps.workspaceId }, deps);
+    }
+
+    const identity = await getIdentity();
+    if (!identity.ok) return identity;
+    // No workspace to fall back on: an organization-scoped API key reaches many
+    // teams and names none, so team storage is genuinely out of reach.
+    if (!("team" in identity.value)) {
+      return {
+        ok: false,
+        error: flowsMessages.pull.teamStorageRequiresTeamKey,
+      };
+    }
+    return listTeamStorageFiles(trpc, { teamId: identity.value.team.id }, deps);
+  }
+
+  return {
+    listTeamStorageFiles: list,
+
+    async syncTeamStorageAssets(assetsAbs, opts) {
+      const files = await list();
+      if (!files.ok) return files;
+      return downloadTeamStorageAssets(
+        { assetsAbs, files: files.value },
+        { fetch: deps.fetch, fs, onProgress: opts?.onProgress },
+      );
+    },
+  };
+}


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

`qawolf flows pull` failed for anyone signed in through the browser. It downloaded the flows bundle and the environment variables, then stopped at the last step with `Team storage requires a team API key; organization keys are not supported here.` The pull exited non-zero and no assets landed, so any flow reading `process.env.TEAM_STORAGE_DIR` could not run locally.

The cause was the question the client asked, not the credential it held. `listTeamStorageFiles` called `/api/v0/identity` and looked for a `team` in the reply. That identity has two shapes: `{ team }` for a team API key, and `{ organization, organizations, user }` for a browser session. A browser session has no `team`, so the client refused before sending a single request — while already holding a usable team id in `deps.workspaceId`, the workspace chosen at sign-in. A workspace is a team; the id was right there.

- **`src/shell/platform/teamStorageMethods.ts`** (new): `createTeamStorageMethods`, holding `listTeamStorageFiles` and `syncTeamStorageAssets`. The list prefers `deps.workspaceId` and only falls back to the identity probe when there is no chosen workspace. The refusal survives for the case that genuinely cannot work: an organization API key reaches many teams and names none, so there is nothing to scope by. Mirrors the existing `createIdentityMethods` factory.
- **`src/shell/platform/createPlatformClient.ts`**: the two team-storage methods move into that factory, and `createIdentityMethods` is bound to a local so its `getIdentity` can be passed in as the fallback.
- **`src/shell/platform/createPlatformClient.teamStorage.test.ts`** (new): three cases — the workspace path (asserting the identity endpoint is never reached), the team-key fallback, and the organization-key refusal.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

Verified live with a browser session: the pull now runs to completion and writes the team-storage assets. The same environment and the same session against a build without this change still fails at `[2/2] Downloading team-storage assets`, which isolates the cause to the identity check.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
