### PR TITLE
test(auth): spy deletePassword so the suite keeps the real login

### DIFF
--- a/src/domains/auth/store/tokens.test.ts
+++ b/src/domains/auth/store/tokens.test.ts
@@ -29,6 +29,10 @@ describe("saveTokens", () => {
     spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
       throw Error("keychain unavailable");
     });
+    // Not decoration: saveTokens clears the entry it could not overwrite, and
+    // an unmocked deletePassword reaches the real keychain under the real
+    // service and account, deleting the session of whoever ran the tests.
+    spyOn(Entry.prototype, "deletePassword").mockReturnValue(true);
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
 

--- a/src/domains/auth/store/tokens.test.ts
+++ b/src/domains/auth/store/tokens.test.ts
@@ -13,6 +13,22 @@ afterEach(() => {
   mock.restore();
 });
 
+// Both spies, always. saveTokens clears the entry it could not overwrite, so a
+// test that only makes setPassword throw sends the real deletePassword to the
+// real keychain, under the real service and account, and deletes the session
+// of whoever ran the tests. It is slow as well: one such test took seven
+// seconds and was the suite's only intermittent failure.
+function keychainRefusesWrites() {
+  spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
+    throw Error("keychain unavailable");
+  });
+  const deletePassword = spyOn(
+    Entry.prototype,
+    "deletePassword",
+  ).mockReturnValue(true);
+  return { deletePassword };
+}
+
 describe("saveTokens", () => {
   it("stores tokens in the keychain when it is available", async () => {
     spyOn(Entry.prototype, "setPassword").mockReturnValue(undefined);
@@ -26,13 +42,7 @@ describe("saveTokens", () => {
   });
 
   it("falls back to a token file when the keychain throws", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
-    // Not decoration: saveTokens clears the entry it could not overwrite, and
-    // an unmocked deletePassword reaches the real keychain under the real
-    // service and account, deleting the session of whoever ran the tests.
-    spyOn(Entry.prototype, "deletePassword").mockReturnValue(true);
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
 
@@ -44,13 +54,7 @@ describe("saveTokens", () => {
   });
 
   it("clears a keychain entry it could not overwrite", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
-    const deletePassword = spyOn(
-      Entry.prototype,
-      "deletePassword",
-    ).mockReturnValue(true);
+    const { deletePassword } = keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
 
@@ -61,10 +65,7 @@ describe("saveTokens", () => {
   });
 
   it("keeps two saves in one process apart", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
-    spyOn(Entry.prototype, "deletePassword").mockReturnValue(true);
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
     const other = { ...tokens, refreshToken: "refresh_other" };
@@ -85,10 +86,7 @@ describe("saveTokens", () => {
   // The staging file holds both tokens. A rename that fails must not leave it
   // on disk to outlive the session it was written for.
   it("removes the staging file when it cannot be published", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
-    spyOn(Entry.prototype, "deletePassword").mockReturnValue(true);
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
     const refusing: Fs = {
@@ -112,10 +110,7 @@ describe("saveTokens", () => {
   });
 
   it("removes a staging file whose write did not complete", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
-    spyOn(Entry.prototype, "deletePassword").mockReturnValue(true);
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
     const truncating: Fs = {
@@ -139,9 +134,7 @@ describe("saveTokens", () => {
   });
 
   it("leaves no partial file behind, and no temporary one", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
     const written: string[] = [];
@@ -161,9 +154,7 @@ describe("saveTokens", () => {
   });
 
   it("writes the token file so only its owner can read it", async () => {
-    spyOn(Entry.prototype, "setPassword").mockImplementation(() => {
-      throw Error("keychain unavailable");
-    });
+    keychainRefusesWrites();
     const memFs = makeMemoryFs();
     await memFs.mkdir("/config", { recursive: true });
     const modes: (number | undefined)[] = [];


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

Three tests in the token store mock `setPassword` to throw, but they do not mock `deletePassword`. `saveTokens` then calls the real `deletePassword` on the real keychain entry. This deletes the login of the developer who runs the test suite. These tests are also slow because they do real keychain I/O, and one of them was the suite's only intermittent failure.

**`src/domains/auth/store/tokens.test.ts`**: Add one helper, `keychainRefusesWrites`, that installs both spies. Every test that makes the keychain throw now calls this helper. A comment explains why both spies are necessary.

# Testing

```bash
bun run test src/domains/auth/store/tokens.test.ts
bun run test
```

- The test file now runs in less than one second. Before this change, one test ran for up to 20 seconds because it reached the real keychain.
- The full suite passes in about 2.5 seconds. Before this change it took up to 20 seconds.
- `qawolf auth whoami` reports the same login before and after a full test run.

# Checklist

- [x] Code follows the style in AGENTS.md
- [x] Self-review done
- [x] Tests added or updated
- [x] No breaking changes
