### PR TITLE
docs(cli): say which context wrapper a command action needs

### DIFF
--- a/.claude/rules/domain-structure.md
+++ b/.claude/rules/domain-structure.md
@@ -18,7 +18,7 @@ There are two registration patterns. Commands that expose a platform public-API 
 
 1. Create the handler directory under `src/commands/<domain>/`
 2. Export a registration function (`registerXCommand`) that takes a Commander `program` instance
-3. In the registration function, use `withContext` from `~/commands/context.js` to wrap each action
+3. In the registration function, wrap each action in a context wrapper from `~/commands/context.js`: `withAuthContext` when the command calls the QA Wolf API, since it resolves the API key and builds the platform client, and `withContext` when it does not. A handler that takes an `AuthCommandContext` needs `withAuthContext`; `withContext` supplies a `CommandContext`, which has no `platformClient`.
 4. Extract pure business logic to `src/domains/<domain>/`; keep commands/ files as thin wiring
 5. Import I/O utilities (spawn, playwright, UI) from `src/shell/`
 6. Import pure helpers and types from `src/core/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ src/
 │   ├── runner/          # the LOCAL execution engine: flowsRun, runWebFlow, runAndroidFlow, worker dispatch + pool
 │   └── updateCheck/     # startUpdateCheck: new-version notice after commands
 ├── commands/            # Thin CLI glue — Commander registration + composite root
-    ├── context.ts       # withContext() Commander action wrapper
+    ├── context.ts       # withContext() / withAuthContext() action wrappers
     ├── program.ts       # createProgram() factory
     ├── auth/            # login, logout, whoami handlers
     ├── doctor/          # doctor handler


### PR DESCRIPTION
The rule for adding a command named only `withContext`, so every command that talks to the QA Wolf API looked like it was breaking the rule. A review of #1579 asked for `withContext` in the runner `exec` registration, where `withAuthContext` is required; making that change fails typecheck, because `withContext` supplies a `CommandContext` with no `platformClient`.

# Overview of Changes

The rule now says which wrapper to use and why: `withAuthContext` when the command calls the QA Wolf API, `withContext` when it does not, and that a handler taking an `AuthCommandContext` needs the authenticated one. The directory listing in AGENTS.md names both wrappers instead of one.

Docs only, no code change. Ten runner registrations and 14 command files already use `withAuthContext`, so this describes what the codebase does rather than changing it.

# Testing

```bash
bun run format:check
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
